### PR TITLE
refactor: セッション保存を全件→個別に置換 + LocalStorage自動マイグレーション

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -247,6 +247,17 @@
     }
 
     /// <summary>
+    /// セッションをストレージから削除
+    /// </summary>
+    private async Task DeleteSessionFromStorageAsync(Guid sessionId)
+    {
+        if (_storageService != null)
+        {
+            await _storageService.DeleteSessionAsync(sessionId);
+        }
+    }
+
+    /// <summary>
     /// アクティブセッションIDをストレージに保存
     /// </summary>
     private async Task SaveActiveSessionIdToStorageAsync(Guid? sessionId)
@@ -1095,6 +1106,7 @@
         // ターミナルのクリーンアップはdestroyTerminalで処理される
 
         await SessionManager.RemoveSessionAsync(sessionId);
+        await DeleteSessionFromStorageAsync(sessionId);
         sessions = SessionManager.GetAllSessions().ToList();
 
         if (activeSessionId == sessionId)
@@ -1156,6 +1168,10 @@
 
         // SessionManagerでアーカイブ処理（ConPtySessionの破棄含む）
         SessionManager.ArchiveSession(sessionId);
+        if (_storageService != null)
+        {
+            await _storageService.UpdateArchivedStateAsync(sessionId, true, DateTime.Now);
+        }
 
         sessions = SessionManager.GetAllSessions().ToList();
 
@@ -1203,25 +1219,22 @@
 
     private async Task DeleteArchivedSession(Guid sessionId)
     {
-        // SessionManagerから完全削除
         SessionManager.DeleteSession(sessionId);
+        await DeleteSessionFromStorageAsync(sessionId);
 
-        // SessionManagerから最新のセッションリストを取得
         sessions = SessionManager.GetAllSessions().ToList();
-
         StateHasChanged();
     }
 
     private async Task DeleteAllArchivedSessions()
     {
-        // アーカイブされた全セッションを削除
         var archivedSessions = SessionManager.GetAllSessions().Where(s => s.IsArchived).ToList();
         foreach (var session in archivedSessions)
         {
             SessionManager.DeleteSession(session.SessionId);
+            await DeleteSessionFromStorageAsync(session.SessionId);
         }
 
-        // SessionManagerから最新のセッションリストを取得
         sessions = SessionManager.GetAllSessions().ToList();
         StateHasChanged();
     }
@@ -1978,6 +1991,16 @@
         showSessionSettingsDialog = false;
         // セッション一覧を更新
         sessions = SessionManager.GetAllSessions().ToList();
+
+        // 変更されたセッションをDBに保存
+        if (settingsSessionId.HasValue)
+        {
+            var savedSession = SessionManager.GetSessionInfo(settingsSessionId.Value);
+            if (savedSession != null)
+            {
+                await SaveSessionToStorageAsync(savedSession);
+            }
+        }
 
         // セッションが再起動された場合、ターミナルコンポーネントも再読み込み
         if (settingsSessionId.HasValue && settingsSessionId.Value == activeSessionId)

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -202,18 +202,47 @@
     private IStorageService? _storageService;
 
     /// <summary>
-    /// セッションをストレージに保存（SQLiteの場合は部分更新、LocalStorageの場合は全体更新）
+    /// SQLiteストレージを確保し、LocalStorageにデータがあれば自動マイグレーション
     /// </summary>
-    private async Task SaveSessionsToStorageAsync()
+    private async Task EnsureSqliteStorageAsync()
+    {
+        _storageService = await StorageServiceFactory.GetCurrentStorageServiceAsync();
+
+        if (_storageService.CurrentStorageType == StorageType.LocalStorage)
+        {
+            Logger.LogInformation("LocalStorageからSQLiteへの自動マイグレーションを開始");
+            try
+            {
+                var localSessions = await _storageService.LoadSessionsAsync();
+                var localActiveId = await _storageService.LoadActiveSessionIdAsync();
+                var localExpanded = await _storageService.LoadSessionExpandedStatesAsync();
+
+                var success = await StorageServiceFactory.MigrateToSqliteAsync(localSessions, localActiveId, localExpanded);
+                if (success)
+                {
+                    _storageService = StorageServiceFactory.GetSqliteStorageService();
+                    Logger.LogInformation("LocalStorageからSQLiteへの自動マイグレーション完了（{Count}件）", localSessions.Count);
+                }
+                else
+                {
+                    Logger.LogWarning("自動マイグレーション失敗、LocalStorageを継続使用");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "自動マイグレーション中にエラー");
+            }
+        }
+    }
+
+    /// <summary>
+    /// 単一セッションをストレージに保存
+    /// </summary>
+    private async Task SaveSessionToStorageAsync(SessionInfo session)
     {
         if (_storageService != null)
         {
-            await _storageService.SaveSessionsAsync(sessions);
-        }
-        else
-        {
-            // フォールバック: LocalStorageServiceを直接使用
-            await LocalStorageService.SaveSessionsAsync(sessions);
+            await _storageService.SaveSessionAsync(session);
         }
     }
 
@@ -226,10 +255,6 @@
         {
             await _storageService.SaveActiveSessionIdAsync(sessionId);
         }
-        else
-        {
-            await LocalStorageService.SaveActiveSessionIdAsync(sessionId);
-        }
     }
 
     /// <summary>
@@ -240,10 +265,6 @@
         if (_storageService != null)
         {
             await _storageService.SaveSessionExpandedStatesAsync(expandedStates);
-        }
-        else
-        {
-            await LocalStorageService.SaveSessionExpandedStatesAsync(expandedStates);
         }
     }
 
@@ -336,10 +357,10 @@
                 // エラー時はデフォルト値を使用
             }
 
-            // ストレージサービスを初期化
-            // SQLiteにセッションがあればSQLite、なければLocalStorageを使用
-            _storageService = await StorageServiceFactory.GetCurrentStorageServiceAsync();
-            Logger.LogInformation("ストレージタイプ: {StorageType}", _storageService.CurrentStorageType);
+            // ストレージサービスを初期化（SQLite強制）
+            // LocalStorageにセッションが残っていれば自動マイグレーション
+            await EnsureSqliteStorageAsync();
+            Logger.LogInformation("ストレージタイプ: {StorageType}", _storageService!.CurrentStorageType);
 
             // SessionManagerにセッションが存在するかチェック
             // 存在する場合は他のブラウザが既に起動しているため、ストレージからの読み込みはスキップ
@@ -603,7 +624,8 @@
                 {
                     Logger.LogInformation("[LastAccessedAt更新] きっかけ: HandleTextInputSend(テキスト送信), セッション: {SessionName}", sessionInfo.GetDisplayName());
                     sessionInfo.LastAccessedAt = DateTime.Now;
-                    StateHasChanged(); // セッションリストのソート順を更新
+                    await SaveSessionToStorageAsync(sessionInfo);
+                    StateHasChanged();
                 }
             }
 
@@ -631,7 +653,7 @@
             sessions = SessionManager.GetAllSessions().ToList();
 
             // ローカルストレージに保存
-            await SaveSessionsToStorageAsync();
+            await SaveSessionToStorageAsync(sessionInfo);
 
             // 新しいセッションをConPtyConnectionServiceに登録
             // 注意: LastConnectionTimeは設定しない（新規セッションにはバッファがないため）
@@ -1019,7 +1041,7 @@
         {
             session.Memo = memo;
             // ローカルストレージを更新
-            await SaveSessionsToStorageAsync();
+            await SaveSessionToStorageAsync(session);
         }
     }
 
@@ -1074,9 +1096,6 @@
 
         await SessionManager.RemoveSessionAsync(sessionId);
         sessions = SessionManager.GetAllSessions().ToList();
-
-        // ローカルストレージを更新
-        await SaveSessionsToStorageAsync();
 
         if (activeSessionId == sessionId)
         {
@@ -1138,9 +1157,7 @@
         // SessionManagerでアーカイブ処理（ConPtySessionの破棄含む）
         SessionManager.ArchiveSession(sessionId);
 
-        // ローカルストレージを更新（再起動時の復元用）
         sessions = SessionManager.GetAllSessions().ToList();
-        await SaveSessionsToStorageAsync();
 
         if (activeSessionId == sessionId)
         {
@@ -1175,7 +1192,7 @@
             sessions = SessionManager.GetAllSessions().ToList();
 
             // ローカルストレージを更新
-            await SaveSessionsToStorageAsync();
+            await SaveSessionToStorageAsync(restoredSession);
             StateHasChanged();
         }
         catch (Exception ex)
@@ -1192,7 +1209,6 @@
         // SessionManagerから最新のセッションリストを取得
         sessions = SessionManager.GetAllSessions().ToList();
 
-        await SaveSessionsToStorageAsync();
         StateHasChanged();
     }
 
@@ -1207,8 +1223,6 @@
 
         // SessionManagerから最新のセッションリストを取得
         sessions = SessionManager.GetAllSessions().ToList();
-
-        await SaveSessionsToStorageAsync();
         StateHasChanged();
     }
 
@@ -1453,7 +1467,8 @@
                 {
                     Logger.LogInformation("[LastAccessedAt更新] きっかけ: SendInput(入力送信), セッション: {SessionName}", sessionInfo.GetDisplayName());
                     sessionInfo.LastAccessedAt = DateTime.Now;
-                    StateHasChanged(); // セッションリストのソート順を更新
+                    await SaveSessionToStorageAsync(sessionInfo);
+                    StateHasChanged();
                 }
             }
 
@@ -1655,7 +1670,7 @@
                 sessions = SessionManager.GetAllSessions().ToList();
 
                 // ローカルストレージに保存
-                await SaveSessionsToStorageAsync();
+                await SaveSessionToStorageAsync(newSession);
 
                 // 新しいセッションを選択
                 await SelectSession(newSession.SessionId);
@@ -1963,7 +1978,6 @@
         showSessionSettingsDialog = false;
         // セッション一覧を更新
         sessions = SessionManager.GetAllSessions().ToList();
-        await SaveSessionsToStorageAsync();
 
         // セッションが再起動された場合、ターミナルコンポーネントも再読み込み
         if (settingsSessionId.HasValue && settingsSessionId.Value == activeSessionId)
@@ -2001,7 +2015,7 @@
                 sessionInfo.HasUncommittedChanges = gitInfo.HasUncommittedChanges;
                 sessionInfo.IsWorktree = gitInfo.IsWorktree;
 
-                await SaveSessionsToStorageAsync();
+                await SaveSessionToStorageAsync(sessionInfo);
                 StateHasChanged();
             }
         }
@@ -2039,9 +2053,9 @@
                 
                 // セッション一覧を更新（最新のConPtySession参照を含む）
                 sessions = SessionManager.GetAllSessions().ToList();
-                
+
                 // ローカルストレージに保存
-                await SaveSessionsToStorageAsync();
+                await SaveSessionToStorageAsync(sessionInfo);
                 
                 // 強制的にセッションを再初期化するため、一旦nullにする
                 activeSessionId = null;

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -47,16 +47,6 @@
                                 <i class="bi bi-terminal me-1"></i>セッション
                             </button>
                         </li>
-                        @if (showMigrationTab)
-                        {
-                            <li class="nav-item" role="presentation">
-                                <button class="nav-link @(activeTab == "migration" ? "active" : "")"
-                                        type="button"
-                                        @onclick="@(() => activeTab = "migration")">
-                                    <i class="bi bi-database me-1"></i>データ移行
-                                </button>
-                            </li>
-                        }
                         <li class="nav-item" role="presentation">
                             <button class="nav-link @(activeTab == "export" ? "active" : "")"
                                     type="button"
@@ -468,93 +458,6 @@
                                 </div>
                             </div>
                         }
-                        else if (activeTab == "migration")
-                        {
-                            <div class="tab-pane fade show active">
-                                <h6 class="mb-3">データ移行</h6>
-
-                                <div class="mb-4">
-                                    <div class="d-flex align-items-center mb-2">
-                                        <span class="me-2">現在のデータ保存先:</span>
-                                        <span class="badge @(currentStorageType == StorageType.SQLite ? "bg-success" : "bg-warning")">
-                                            @(currentStorageType == StorageType.SQLite ? "SQLite" : "LocalStorage")
-                                        </span>
-                                    </div>
-
-                                    @if (currentStorageType == StorageType.SQLite)
-                                    {
-                                        <div class="alert alert-success">
-                                            <i class="bi bi-check-circle me-1"></i>
-                                            現在SQLiteを使用しています
-                                        </div>
-
-                                        <div class="mb-3">
-                                            <p class="mb-1">SQLiteセッション数: <strong>@sqliteSessionCount</strong>件</p>
-                                            <p class="mb-1">データベースパス:</p>
-                                            <code class="small">@sqliteDbPath</code>
-                                        </div>
-                                    }
-
-                                    @if (localStorageSessionCount > 0)
-                                    {
-                                        <div class="@(currentStorageType == StorageType.SQLite ? "mt-4 pt-3 border-top" : "")">
-                                            <h6 class="mb-2">
-                                                <i class="bi bi-hdd me-1"></i>LocalStorageのデータ
-                                            </h6>
-                                            <div class="mb-3">
-                                                <p class="mb-1">セッション数: <strong>@localStorageSessionCount</strong>件</p>
-                                                <p class="mb-1">データサイズ: 約 <strong>@FormatBytes(localStorageDataSize)</strong></p>
-                                            </div>
-
-                                            @if (currentStorageType == StorageType.LocalStorage)
-                                            {
-                                                <div class="alert alert-info">
-                                                    <h6 class="alert-heading"><i class="bi bi-info-circle me-1"></i>SQLiteに移行すると</h6>
-                                                    <ul class="mb-0 small">
-                                                        <li>セッション切り替えが高速化</li>
-                                                        <li>データの部分更新が可能に</li>
-                                                        <li>アプリ再インストール時もデータ保持</li>
-                                                    </ul>
-                                                </div>
-                                            }
-                                            else
-                                            {
-                                                <div class="alert alert-warning">
-                                                    <i class="bi bi-exclamation-triangle me-1"></i>
-                                                    再移行するとSQLiteの現在のデータが上書きされます
-                                                </div>
-                                            }
-
-                                            <button class="btn @(currentStorageType == StorageType.SQLite ? "btn-warning" : "btn-primary")"
-                                                    @onclick="MigrateToSqlite" disabled="@isMigrating">
-                                                @if (isMigrating)
-                                                {
-                                                    <span class="spinner-border spinner-border-sm me-1" role="status"></span>
-                                                    <span>移行中...</span>
-                                                }
-                                                else
-                                                {
-                                                    <i class="bi bi-database-fill-up me-1"></i>
-                                                    <span>@(currentStorageType == StorageType.SQLite ? "LocalStorageから再移行" : "SQLiteに移行する")</span>
-                                                }
-                                            </button>
-
-                                            <p class="text-muted small mt-2">
-                                                <i class="bi bi-info-circle me-1"></i>
-                                                移行後もLocalStorageのデータはバックアップとして残ります
-                                            </p>
-                                        </div>
-                                    }
-                                    else if (currentStorageType == StorageType.LocalStorage)
-                                    {
-                                        <div class="alert alert-secondary">
-                                            <i class="bi bi-info-circle me-1"></i>
-                                            LocalStorageにセッションデータがありません
-                                        </div>
-                                    }
-                                </div>
-                            </div>
-                        }
                         else if (activeTab == "export")
                         {
                             <div class="tab-pane fade show active">
@@ -564,17 +467,17 @@
                                 <div class="mb-4">
                                     <h6 class="mb-2">エクスポート</h6>
                                     <p class="text-muted small">
-                                        現在のストレージ（@(currentStorageType == StorageType.SQLite ? "SQLite" : "LocalStorage")）からセッション情報をJSONファイルとしてダウンロードします。
+                                        現在のストレージ（@("SQLite")）からセッション情報をJSONファイルとしてダウンロードします。
                                     </p>
 
                                     <div class="alert alert-secondary mb-3">
                                         <small>
                                             <i class="bi bi-info-circle me-1"></i>
-                                            エクスポート対象: セッション情報（@currentStorageSessionCount 件）
+                                            エクスポート対象: セッション情報（@SessionManager.GetAllSessions().Count() 件）
                                         </small>
                                     </div>
 
-                                    <button class="btn btn-primary btn-sm" @onclick="ExportSettings" disabled="@(currentStorageSessionCount == 0)">
+                                    <button class="btn btn-primary btn-sm" @onclick="ExportSettings" disabled="@(SessionManager.GetAllSessions().Count() == 0)">
                                         <i class="bi bi-download me-1"></i>エクスポート
                                     </button>
                                 </div>
@@ -586,7 +489,7 @@
                                     <h6 class="mb-2">インポート</h6>
                                     <p class="text-muted small">
                                         JSONファイルを選択してセッション情報をインポートします。
-                                        現在のストレージ（@(currentStorageType == StorageType.SQLite ? "SQLite" : "LocalStorage")）に追加されます。
+                                        現在のストレージ（@("SQLite")）に追加されます。
                                     </p>
 
                                     <div class="mb-3">
@@ -975,15 +878,6 @@
     private int testElapsedSeconds = 10;
     private string notificationTestResult = "テスト結果がここに表示されます";
 
-    // データ移行関連
-    private bool showMigrationTab = false;
-    private StorageType currentStorageType = StorageType.LocalStorage;
-    private int localStorageSessionCount = 0;
-    private int localStorageDataSize = 0;
-    private int sqliteSessionCount = 0;
-    private string sqliteDbPath = "";
-    private bool isMigrating = false;
-
     [Parameter] public EventCallback<string> OnSessionSortModeChanged { get; set; }
     [Parameter] public string SessionSortMode { get; set; } = "lastAccessed";
     [Parameter] public EventCallback<string> OnClaudeModeSwitchKeyChanged { get; set; }
@@ -998,7 +892,6 @@
     private bool _settingsLoaded = false;
 
     // エクスポート/インポート用
-    private int currentStorageSessionCount = 0;
     private int importSessionCount = 0;
     private List<SessionInfo>? importSessions = null;
 
@@ -1022,9 +915,6 @@
     {
         try
         {
-            // データ移行タブの状態を更新
-            await LoadMigrationTabState();
-
             // ファイルから設定を読み込み
             var settings = AppSettingsService.GetSettings();
 
@@ -1486,7 +1376,7 @@
                 {
                     exportedAt = DateTime.Now,
                     version = "2.0",
-                    storageType = currentStorageType.ToString(),
+                    storageType = "SQLite",
                     sessionCount = sessions.Count
                 }
             };
@@ -1584,8 +1474,6 @@
             importSessions = null;
             importSessionCount = 0;
 
-            // 状態を更新
-            await LoadMigrationTabState();
         }
         catch (Exception ex)
         {
@@ -1860,98 +1748,4 @@
         }
     }
 
-    // データ移行関連メソッド
-    private async Task LoadMigrationTabState()
-    {
-        try
-        {
-            // SQLite DBの存在チェック
-            var sqliteExists = StorageServiceFactory.SqliteDatabaseExists;
-
-            // SQLiteのパスを設定
-            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            sqliteDbPath = Path.Combine(appDataPath, "TerminalHub", "sessions.db");
-
-            // 常にLocalStorageのデータを読み込む（再移行用）
-            try
-            {
-                var localSessions = await LocalStorageService.LoadSessionsAsync();
-                localStorageSessionCount = localSessions.Count;
-
-                // データサイズを概算（JSON形式のサイズ）
-                var json = System.Text.Json.JsonSerializer.Serialize(localSessions);
-                localStorageDataSize = System.Text.Encoding.UTF8.GetByteCount(json);
-            }
-            catch
-            {
-                localStorageSessionCount = 0;
-                localStorageDataSize = 0;
-            }
-
-            if (sqliteExists)
-            {
-                // SQLite使用中
-                currentStorageType = StorageType.SQLite;
-                sqliteSessionCount = await StorageServiceFactory.GetSqliteSessionCountAsync();
-                currentStorageSessionCount = sqliteSessionCount;
-                // SQLite使用中でも、LocalStorageにデータがあれば再移行可能なのでタブを表示
-                showMigrationTab = true;
-            }
-            else
-            {
-                // LocalStorage使用中
-                currentStorageType = StorageType.LocalStorage;
-                currentStorageSessionCount = localStorageSessionCount;
-                // LocalStorageにセッションがある場合のみ移行タブを表示
-                showMigrationTab = localStorageSessionCount > 0;
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"データ移行状態の読み込みエラー: {ex.Message}");
-            showMigrationTab = false;
-        }
-    }
-
-    private async Task MigrateToSqlite()
-    {
-        if (isMigrating) return;
-
-        isMigrating = true;
-        StateHasChanged();
-
-        try
-        {
-            // LocalStorageからデータを取得
-            var sessions = await LocalStorageService.LoadSessionsAsync();
-            var activeSessionId = await LocalStorageService.LoadActiveSessionIdAsync();
-            var expandedStates = await LocalStorageService.LoadSessionExpandedStatesAsync();
-
-            // SQLiteに移行
-            var success = await StorageServiceFactory.MigrateToSqliteAsync(sessions, activeSessionId, expandedStates);
-
-            if (success)
-            {
-                saveMessage = "SQLiteへの移行が完了しました。ページを再読み込みしてください。";
-                saveSuccess = true;
-                currentStorageType = StorageType.SQLite;
-                sqliteSessionCount = sessions.Count;
-            }
-            else
-            {
-                saveMessage = "SQLiteへの移行に失敗しました";
-                saveSuccess = false;
-            }
-        }
-        catch (Exception ex)
-        {
-            saveMessage = $"移行エラー: {ex.Message}";
-            saveSuccess = false;
-        }
-        finally
-        {
-            isMigrating = false;
-            StateHasChanged();
-        }
-    }
 }

--- a/TerminalHub/Services/HookNotificationService.cs
+++ b/TerminalHub/Services/HookNotificationService.cs
@@ -41,6 +41,7 @@ public class HookNotificationService : IHookNotificationService
     private readonly ISessionManager _sessionManager;
     private readonly IAppSettingsService _appSettingsService;
     private readonly ISessionTimerService _sessionTimerService;
+    private readonly ISessionRepository _sessionRepository;
 
     public event EventHandler<HookNotificationEventArgs>? OnHookNotification;
 
@@ -48,12 +49,14 @@ public class HookNotificationService : IHookNotificationService
         ILogger<HookNotificationService> logger,
         ISessionManager sessionManager,
         IAppSettingsService appSettingsService,
-        ISessionTimerService sessionTimerService)
+        ISessionTimerService sessionTimerService,
+        ISessionRepository sessionRepository)
     {
         _logger = logger;
         _sessionManager = sessionManager;
         _appSettingsService = appSettingsService;
         _sessionTimerService = sessionTimerService;
+        _sessionRepository = sessionRepository;
     }
 
     public async Task HandleHookNotificationAsync(HookNotification notification)
@@ -134,6 +137,7 @@ public class HookNotificationService : IHookNotificationService
         // 最終利用時刻を更新（ソート用）
         _logger.LogInformation("[LastAccessedAt更新] きっかけ: HookNotificationService(Stop イベント), セッション: {SessionName}", session.GetDisplayName());
         session.LastAccessedAt = DateTime.Now;
+        try { await _sessionRepository.SaveSessionAsync(session); } catch { }
 
         // 処理状態を完全にリセット（SessionTimeoutと同じ項目をクリア）
         _logger.LogInformation(

--- a/TerminalHub/Services/IStorageService.cs
+++ b/TerminalHub/Services/IStorageService.cs
@@ -53,6 +53,11 @@ namespace TerminalHub.Services
         Task UpdateArchivedStateAsync(Guid sessionId, bool isArchived, DateTime? archivedAt);
 
         /// <summary>
+        /// セッションを削除
+        /// </summary>
+        Task DeleteSessionAsync(Guid sessionId);
+
+        /// <summary>
         /// アクティブセッションIDを保存
         /// </summary>
         Task SaveActiveSessionIdAsync(Guid? sessionId);

--- a/TerminalHub/Services/LocalStorageServiceAdapter.cs
+++ b/TerminalHub/Services/LocalStorageServiceAdapter.cs
@@ -107,6 +107,16 @@ namespace TerminalHub.Services
             }
         }
 
+        public async Task DeleteSessionAsync(Guid sessionId)
+        {
+            if (_cachedSessions == null)
+            {
+                _cachedSessions = await _localStorageService.LoadSessionsAsync();
+            }
+            _cachedSessions.RemoveAll(s => s.SessionId == sessionId);
+            await _localStorageService.SaveSessionsAsync(_cachedSessions);
+        }
+
         public async Task SaveActiveSessionIdAsync(Guid? sessionId)
         {
             await _localStorageService.SaveActiveSessionIdAsync(sessionId);

--- a/TerminalHub/Services/OutputAnalyzerService.cs
+++ b/TerminalHub/Services/OutputAnalyzerService.cs
@@ -13,17 +13,20 @@ namespace TerminalHub.Services
         private readonly INotificationService _notificationService;
         private readonly IOutputAnalyzerFactory _analyzerFactory;
         private readonly ISessionTimerService _sessionTimerService;
+        private readonly ISessionRepository _sessionRepository;
 
         public OutputAnalyzerService(
             ILogger<OutputAnalyzerService> logger,
             INotificationService notificationService,
             IOutputAnalyzerFactory analyzerFactory,
-            ISessionTimerService sessionTimerService)
+            ISessionTimerService sessionTimerService,
+            ISessionRepository sessionRepository)
         {
             _logger = logger;
             _notificationService = notificationService;
             _analyzerFactory = analyzerFactory;
             _sessionTimerService = sessionTimerService;
+            _sessionRepository = sessionRepository;
         }
 
         public void AnalyzeOutput(string data, SessionInfo sessionInfo, Guid activeSessionId, Action<Guid, string?>? updateStatus)
@@ -214,6 +217,7 @@ namespace TerminalHub.Services
                     // 最終利用時刻を更新（ソート用）
                     _logger.LogInformation("[LastAccessedAt更新] きっかけ: OutputAnalyzerService(処理完了検出), セッション: {SessionName}", session.GetDisplayName());
                     session.LastAccessedAt = DateTime.Now;
+                    try { _ = _sessionRepository.SaveSessionAsync(session); } catch { }
 
                     // セッション情報をクリア
                     session.ProcessingStartTime = null;

--- a/TerminalHub/Services/SqliteStorageService.cs
+++ b/TerminalHub/Services/SqliteStorageService.cs
@@ -52,6 +52,11 @@ namespace TerminalHub.Services
             await _repository.UpdateArchivedStateAsync(sessionId, isArchived, archivedAt);
         }
 
+        public async Task DeleteSessionAsync(Guid sessionId)
+        {
+            await _repository.DeleteSessionAsync(sessionId);
+        }
+
         public async Task SaveActiveSessionIdAsync(Guid? sessionId)
         {
             await _repository.SetActiveSessionIdAsync(sessionId);


### PR DESCRIPTION
## Summary
- セッション保存を全件INSERT（148件）から個別保存に置換し、パフォーマンスとデータ整合性を改善
- LastAccessedAt更新時もDB個別保存を追加（Root.razor, HookNotificationService, OutputAnalyzerService）
- 起動時にLocalStorageデータがあれば自動的にSQLiteにマイグレーション
- 設定画面の「データ移行」タブとマイグレーション関連コードを削除（-250行）

## Test plan
- [ ] セッション作成・削除・アーカイブが正常に動作すること
- [ ] セッション設定変更（ピン留め、メモ等）が再起動後も維持されること
- [ ] セッション切替でLastAccessedAtが更新されソート順に反映されること
- [ ] 処理完了時のLastAccessedAt更新がDBに保存されること
- [ ] 設定画面に「データ移行」タブが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)