### PR TITLE
chore: セッション保存・作成関連のデバッグログを削除

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -258,9 +258,7 @@
             // ピン留め状態を更新
             sessionInfo.IsPinned = isPinned;
             sessionInfo.PinPriority = isPinned ? pinPriority : null;
-            Logger.LogInformation("[SessionSettings] SaveSettings: SessionId={SessionId} IsPinned={IsPinned} PinPriority={PinPriority}",
-                sessionInfo.SessionId, sessionInfo.IsPinned, sessionInfo.PinPriority);
-            
+
             // ターミナルタイプを更新
             sessionInfo.TerminalType = selectedType;
             

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -242,8 +242,6 @@ namespace TerminalHub.Services
                 _sessionInfos[sessionInfo.SessionId] = sessionInfo;
                 _initializationLocks[sessionInfo.SessionId] = new SemaphoreSlim(1, 1);
 
-                _logger.LogInformation($"Session info created successfully: {sessionInfo.SessionId} ({terminalType})");
-
                 NotifySessionsChanged();
                 return sessionInfo;
             }
@@ -922,8 +920,6 @@ namespace TerminalHub.Services
             }
 
             _sessionInfos[sessionInfo.SessionId] = sessionInfo;
-            _logger.LogInformation("アーカイブセッションを追加しました: {SessionId}", sessionInfo.SessionId);
-
             NotifySessionsChanged();
         }
 

--- a/TerminalHub/Services/SessionRepository.cs
+++ b/TerminalHub/Services/SessionRepository.cs
@@ -63,15 +63,6 @@ namespace TerminalHub.Services
                 sessions.Add(session);
             }
 
-            // ピン留めセッションをログ出力
-            var pinnedSessions = sessions.Where(s => s.IsPinned).ToList();
-            _logger.LogInformation("[LoadSessions] Total={Total} Pinned={Pinned}", sessions.Count, pinnedSessions.Count);
-            foreach (var p in pinnedSessions)
-            {
-                _logger.LogInformation("[LoadSessions] Pinned: SessionId={SessionId} DisplayName={DisplayName} PinPriority={PinPriority}",
-                    p.SessionId, p.GetDisplayName(), p.PinPriority);
-            }
-
             // オプションを取得
             foreach (var session in sessions)
             {
@@ -128,9 +119,6 @@ namespace TerminalHub.Services
 
         public async Task SaveSessionAsync(SessionInfo session)
         {
-            _logger.LogInformation("[SaveSession] SessionId={SessionId} DisplayName={DisplayName} IsPinned={IsPinned} PinPriority={PinPriority}",
-                session.SessionId, session.GetDisplayName(), session.IsPinned, session.PinPriority);
-
             await using var connection = _dbContext.CreateConnection();
             await connection.OpenAsync();
 


### PR DESCRIPTION
## Summary
- SessionRepository: SaveSession/LoadSessionsのInformationレベルログを削除
- SessionManager: セッション作成成功・アーカイブ追加のログを削除
- SessionSettingsDialog: ピン留め保存時のログを削除

## Test plan
- [ ] アプリ起動時のログが減っていること
- [ ] セッション作成・保存・ピン留め操作が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)