### PR TITLE
fix: 各種改善（セキュリティ・安定性・UI）

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1774,6 +1774,12 @@
                 return null;
             }
 
+            // 相対パスの場合は親セッションのフォルダを基準に解決
+            if (!Path.IsPathRooted(folderPath) && !string.IsNullOrEmpty(parentSession.FolderPath))
+            {
+                folderPath = Path.GetFullPath(Path.Combine(parentSession.FolderPath, folderPath));
+            }
+
             // フォルダが存在しない場合は作成
             if (!Directory.Exists(folderPath))
             {

--- a/TerminalHub/Components/Shared/BottomPanels/ShellPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/ShellPanel.razor
@@ -89,6 +89,23 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "シェルパネルの初期化エラー: {PanelId}", PanelId);
+
+            // JS初期化失敗時に起動済みConPTYを片付ける
+            if (shellSession != null)
+            {
+                try
+                {
+                    shellSession.DataReceived -= OnDataReceived;
+                    shellSession.ProcessExited -= OnProcessExited;
+                    shellSession.Dispose();
+                    Logger.LogInformation("初期化失敗のため起動済みConPTYを破棄: {PanelId}", PanelId);
+                }
+                catch (Exception disposeEx)
+                {
+                    Logger.LogWarning(disposeEx, "ConPTY破棄エラー: {PanelId}", PanelId);
+                }
+                shellSession = null;
+            }
         }
     }
 

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -263,7 +263,7 @@
             <div class="form-check mt-3">
                 <input class="form-check-input" type="checkbox" @bind="CodexOptions.ResumeLast" id="@($"codexResumeLast{UniqueId}")">
                 <label class="form-check-label" for="@($"codexResumeLast{UniqueId}")">
-                    前回セッションを再開 (resume --last)
+                    前回セッションを再開 (resume --last --all)
                 </label>
             </div>
 

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -135,6 +135,12 @@
                                     }
                                 </span>
                             }
+                            @if (!string.IsNullOrEmpty(session.RemoteControlUrl))
+                            {
+                                <span class="badge bg-info ms-1" title="リモートコントロール接続中">
+                                    <i class="bi bi-phone-fill"></i>
+                                </span>
+                            }
                             @if (!session.ParentSessionId.HasValue && HasChildren(session) && !session.IsExpanded)
                             {
                                 <span class="badge bg-secondary ms-1" style="font-size: 0.7rem;">

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -153,7 +153,7 @@ namespace TerminalHub.Constants
 
             if (options.ContainsKey("resume-last") && options["resume-last"] == "true")
             {
-                args.Add("resume --last");
+                args.Add("resume --last --all");
             }
 
             if (options.ContainsKey("search") && options["search"] == "true")

--- a/TerminalHub/Services/MqttService.cs
+++ b/TerminalHub/Services/MqttService.cs
@@ -409,8 +409,7 @@ public class MqttService : IHostedService, IDisposable
         }
 
         var match = string.Equals(settings.PasswordHash, requestPasswordHash, StringComparison.OrdinalIgnoreCase);
-        _logger.LogDebug("[MQTT] パスワード検証: サーバー={ServerHash}, リクエスト={RequestHash}, 一致={Match}",
-            settings.PasswordHash, requestPasswordHash, match);
+        _logger.LogDebug("[MQTT] パスワード検証: 一致={Match}", match);
         return match;
     }
 

--- a/TerminalHub/Services/RemoteLaunchService.cs
+++ b/TerminalHub/Services/RemoteLaunchService.cs
@@ -140,12 +140,13 @@ public class RemoteLaunchService : IRemoteLaunchService
                 return;
             }
 
-            var match = RemoteControlUrlPattern.Match(cleanBuffer);
-            if (match.Success)
+            // 最後にマッチしたURLを採用（過去の会話ログにURLが含まれる場合の誤検知防止）
+            var matches = RemoteControlUrlPattern.Matches(cleanBuffer);
+            if (matches.Count > 0)
             {
                 urlDetected = true;
-                var url = match.Value.TrimEnd(')', ']', '}', '>');
-                _logger.LogInformation("[RemoteLaunch] [状態: URL_DETECTED] URL検知: {Url}", url);
+                var url = matches[^1].Value.TrimEnd(')', ']', '}', '>');
+                _logger.LogInformation("[RemoteLaunch] [状態: URL_DETECTED] URL検知: {Url}（マッチ{Count}件中最後）", url, matches.Count);
                 sessionInfo.RemoteControlUrl = url;
 
                 // URL検知後はイベントハンドラーを即座に解除


### PR DESCRIPTION
## Summary
- MQTTパスワードハッシュをDebugログから除去（ハッシュ自体がトークンとして再利用されるリスク）
- ShellPanel初期化失敗時に起動済みConPTYを破棄するよう修正（見えないシェルが残る問題）
- サブセッション作成の相対パスを親セッションのフォルダ基準で解決（実行ファイル位置基準だった）
- セッションリストにリモートコントロール接続中バッジを追加
- Codex CLI resume に --all オプションを追加（--continue相当の動作に対応）

## Test plan
- [ ] パスワード設定済みのMQTT通信でDebugログにハッシュ値が出ないことを確認
- [ ] ShellPanelでJS初期化失敗時にConPTYプロセスが残らないことを確認
- [ ] サブセッション作成で相対パス（例: ../other）が親セッションのフォルダ基準で解決されることを確認
- [ ] リモート起動後にセッションリストにphone バッジが表示されることを確認
- [ ] Codex CLIのresume --lastが--all付きで実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)