### PR TITLE
fix: Codex CLIのresume選択式対応とデフォルト値調整

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -78,7 +78,8 @@
                                       SelectedTypeChanged="OnTerminalTypeChanged"
                                       @bind-StartupCommand="startupCommand"
                                       ClaudeOptions="claudeCodeOptions"
-                                      GeminiOptions="geminiOptions" />
+                                      GeminiOptions="geminiOptions"
+                                      CodexOptions="codexOptions" />
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" @onclick="Cancel">キャンセル</button>
@@ -132,6 +133,7 @@
 
     private SessionOptionsSelector.ClaudeCodeOptions claudeCodeOptions = new();
     private SessionOptionsSelector.GeminiOptionsData geminiOptions = new();
+    private SessionOptionsSelector.CodexOptionsData codexOptions = new();
     private List<string> favoriteFolders = new();
     private const string LAST_TERMINAL_TYPE_KEY = "lastSelectedTerminalType";
     private bool showCreateFolderDialog = false;
@@ -345,6 +347,7 @@
         startupCommand = "";
         claudeCodeOptions = new();
         geminiOptions = new();
+        codexOptions = new();
         showCreateFolderDialog = false;
         pendingSessionCreation = false;
     }

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -261,9 +261,9 @@
             }
 
             <div class="form-check mt-3">
-                <input class="form-check-input" type="checkbox" @bind="CodexOptions.ResumeLast" id="@($"codexResumeLast{UniqueId}")">
-                <label class="form-check-label" for="@($"codexResumeLast{UniqueId}")">
-                    前回セッションを再開 (resume --last --all)
+                <input class="form-check-input" type="checkbox" @bind="CodexOptions.ResumePicker" id="@($"codexResumePicker{UniqueId}")">
+                <label class="form-check-label" for="@($"codexResumePicker{UniqueId}")">
+                    再開するセッションを選択 (resume)
                 </label>
             </div>
 
@@ -272,7 +272,7 @@
                 <div class="btn-group d-flex" role="group">
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxNone{UniqueId}")"
                            checked="@(string.IsNullOrEmpty(CodexOptions.SandboxMode))"
-                           @onchange="() => SetCodexSandboxMode(CodexSandbox.None)" autocomplete="off">
+                           @onchange="() => SetCodexSandboxMode(CodexSandbox.Default)" autocomplete="off">
                     <label class="btn btn-outline-secondary btn-sm" for="@($"codexSandboxNone{UniqueId}")" title="--sandbox を付けず、Codex CLI の既定値に任せます。">
                         CLI既定
                     </label>
@@ -474,7 +474,7 @@
     }
 
     private enum CodexMode { Auto, Standard, Yolo }
-    private enum CodexSandbox { None, ReadOnly, WorkspaceWrite, FullAccess }
+    private enum CodexSandbox { Default, ReadOnly, WorkspaceWrite, FullAccess }
 
     private void SetCodexMode(CodexMode mode)
     {
@@ -491,7 +491,7 @@
     {
         CodexOptions.SandboxMode = mode switch
         {
-            CodexSandbox.None => "",
+            CodexSandbox.Default => "",
             CodexSandbox.ReadOnly => "read-only",
             CodexSandbox.WorkspaceWrite => "workspace-write",
             CodexSandbox.FullAccess => "danger-full-access",
@@ -556,7 +556,7 @@
 
             case TerminalType.CodexCLI:
                 options["mode"] = CodexOptions.Mode;
-                if (CodexOptions.ResumeLast)
+                if (CodexOptions.ResumePicker)
                 {
                     options["resume-picker"] = "true";
                 }
@@ -619,7 +619,7 @@
     public class CodexOptionsData
     {
         public string Mode { get; set; } = "auto"; // auto, standard, yolo
-        public bool ResumeLast { get; set; } = false;
+        public bool ResumePicker { get; set; } = false;
         public string SandboxMode { get; set; } = ""; // "", read-only, workspace-write, danger-full-access
         public string ApprovalPolicy { get; set; } = "";
         public string NetworkAccess { get; set; } = "";

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -491,11 +491,11 @@
     {
         CodexOptions.SandboxMode = mode switch
         {
-            CodexSandbox.None => "none",
+            CodexSandbox.None => "",
             CodexSandbox.ReadOnly => "read-only",
             CodexSandbox.WorkspaceWrite => "workspace-write",
             CodexSandbox.FullAccess => "danger-full-access",
-            _ => "workspace-write"
+            _ => ""
         };
     }
 
@@ -558,7 +558,7 @@
                 options["mode"] = CodexOptions.Mode;
                 if (CodexOptions.ResumeLast)
                 {
-                    options["resume-last"] = "true";
+                    options["resume-picker"] = "true";
                 }
                 if (!string.IsNullOrWhiteSpace(CodexOptions.SandboxMode))
                 {
@@ -620,9 +620,9 @@
     {
         public string Mode { get; set; } = "auto"; // auto, standard, yolo
         public bool ResumeLast { get; set; } = false;
-        public string SandboxMode { get; set; } = "workspace-write"; // "", read-only, workspace-write, danger-full-access
+        public string SandboxMode { get; set; } = ""; // "", read-only, workspace-write, danger-full-access
         public string ApprovalPolicy { get; set; } = "";
-        public string NetworkAccess { get; set; } = "enabled";
+        public string NetworkAccess { get; set; } = "";
         public string Profile { get; set; } = "";
         public string Model { get; set; } = "";
         public bool SearchEnabled { get; set; }

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -228,10 +228,11 @@
                 codexOptions = new SessionOptionsSelector.CodexOptionsData
                 {
                     Mode = options.ContainsKey("mode") ? options["mode"] : "auto",
-                    ResumeLast = options.ContainsKey("resume-last") && options["resume-last"] == "true",
-                    SandboxMode = options.ContainsKey("sandbox-mode") ? options["sandbox-mode"] : "workspace-write",
+                    ResumeLast = (options.ContainsKey("resume-picker") && options["resume-picker"] == "true")
+                        || (options.ContainsKey("resume-last") && options["resume-last"] == "true"),
+                    SandboxMode = options.ContainsKey("sandbox-mode") ? options["sandbox-mode"] : "",
                     ApprovalPolicy = options.ContainsKey("ask-for-approval") ? options["ask-for-approval"] : "",
-                    NetworkAccess = options.ContainsKey("network-access") ? options["network-access"] : "enabled",
+                    NetworkAccess = options.ContainsKey("network-access") ? options["network-access"] : "",
                     Profile = options.ContainsKey("profile") ? options["profile"] : "",
                     Model = options.ContainsKey("model") ? options["model"] : "",
                     SearchEnabled = options.ContainsKey("search") && options["search"] == "true",

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -228,7 +228,7 @@
                 codexOptions = new SessionOptionsSelector.CodexOptionsData
                 {
                     Mode = options.ContainsKey("mode") ? options["mode"] : "auto",
-                    ResumeLast = (options.ContainsKey("resume-picker") && options["resume-picker"] == "true")
+                    ResumePicker = (options.ContainsKey("resume-picker") && options["resume-picker"] == "true")
                         || (options.ContainsKey("resume-last") && options["resume-last"] == "true"),
                     SandboxMode = options.ContainsKey("sandbox-mode") ? options["sandbox-mode"] : "",
                     ApprovalPolicy = options.ContainsKey("ask-for-approval") ? options["ask-for-approval"] : "",

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -144,6 +144,7 @@
                                                   @bind-StartupCommand="startupCommand"
                                                   ClaudeOptions="claudeOptions"
                                                   GeminiOptions="geminiOptions"
+                                                  CodexOptions="codexOptions"
                                                   DisableContinueOption="false" />
                             }
                         </div>
@@ -207,7 +208,8 @@
                                                           SelectedTypeChanged="OnTerminalTypeChanged"
                                                           @bind-StartupCommand="startupCommand"
                                                           ClaudeOptions="claudeOptions"
-                                                          GeminiOptions="geminiOptions" />
+                                                          GeminiOptions="geminiOptions"
+                                                          CodexOptions="codexOptions" />
                                 </div>
                             }
                             }
@@ -223,7 +225,8 @@
                                                   SelectedTypeChanged="OnTerminalTypeChanged"
                                                   @bind-StartupCommand="startupCommand"
                                                   ClaudeOptions="claudeOptions"
-                                                  GeminiOptions="geminiOptions" />
+                                                  GeminiOptions="geminiOptions"
+                                                  CodexOptions="codexOptions" />
                             
                             @if (ParentSessionName != null)
                             {
@@ -265,7 +268,8 @@
                                                           SelectedTypeChanged="OnTerminalTypeChanged"
                                                           @bind-StartupCommand="startupCommand"
                                                           ClaudeOptions="claudeOptions"
-                                                          GeminiOptions="geminiOptions" />
+                                                          GeminiOptions="geminiOptions"
+                                                          CodexOptions="codexOptions" />
                                 </div>
                                 
                                 <div class="alert alert-info mt-3">
@@ -332,6 +336,7 @@
     private string startupCommand = "";
     private SessionOptionsSelector.ClaudeCodeOptions claudeOptions = new();
     private SessionOptionsSelector.GeminiOptionsData geminiOptions = new();
+    private SessionOptionsSelector.CodexOptionsData codexOptions = new();
 
     private bool CanProcess
     {
@@ -377,6 +382,7 @@
             startupCommand = "";
             claudeOptions = new();
             geminiOptions = new();
+            codexOptions = new();
             newFolderPath = "";
             
             // 親セッションのパスがあり、Gitリポジトリの場合はブランチ一覧とworktree一覧を取得

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -154,7 +154,7 @@ namespace TerminalHub.Constants
             if ((options.ContainsKey("resume-picker") && options["resume-picker"] == "true")
                 || (options.ContainsKey("resume-last") && options["resume-last"] == "true"))
             {
-                args.Add("resume --last --all");
+                args.Add("resume");
             }
 
             if (options.ContainsKey("search") && options["search"] == "true")

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -151,7 +151,8 @@ namespace TerminalHub.Constants
                 args.Add($"--model {model.Trim()}");
             }
 
-            if (options.ContainsKey("resume-last") && options["resume-last"] == "true")
+            if ((options.ContainsKey("resume-picker") && options["resume-picker"] == "true")
+                || (options.ContainsKey("resume-last") && options["resume-last"] == "true"))
             {
                 args.Add("resume --last --all");
             }


### PR DESCRIPTION
## Summary
- Codex CLIのresumeオプションを「前回セッション自動再開」から「セッション選択式」に変更
- SandboxMode/NetworkAccessのデフォルト値を空文字に変更し、Codex側のデフォルトに委ねる
- SessionCreateDialog/SubSessionDialogでCodexOptionsが正しく渡されていなかったバグを修正
- 既存の\`resume-last\`指定とも後方互換を維持

## 変更の背景
- 従来の\`resume --last --all\`は直近セッションを自動的に再開する動作だったが、実際の利用では「過去のどのセッションを再開するか選びたい」ケースが多いため、resume picker方式に変更
- SandboxMode/NetworkAccessを明示的に\`workspace-write\`/\`enabled\`で固定していたのを、Codex側のデフォルトに任せることでユーザーの\`config.toml\`設定が効くように

## Test plan
- [ ] セッション作成ダイアログで「再開するセッションを選択」をONにして起動 → Codex resume pickerが表示される
- [ ] 既存セッションの設定からCodexオプションを編集 → 保存後に設定が正しく反映される
- [ ] SubSessionダイアログ（Create/Existing/SamePath/NewFolder）でCodexオプションが渡されることを確認
- [ ] SandboxMode未指定時にCodexデフォルトで起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)