### PR TITLE
fix: 入力テキストを Root に昇格して BottomPanel 再生成時の消失を防止

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -131,6 +131,8 @@
                                      DotNetRef="@dotNetRef"
                                      ShellPanelRefs="@shellPanelRefs"
                                      CustomCommands="@GetCustomCommandsForSession(currentSession.TerminalType)"
+                                     Text="@inputText"
+                                     TextChanged="@((string t) => inputText = t)"
                                      OnSendInput="HandleTextInputSend"
                                      OnCtrlC="SendCtrlC"
                                      OnEscape="SendEscape"

--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -63,8 +63,8 @@
                             ClaudeModeSwitchKey="@ClaudeModeSwitchKey"
                             VoiceInputEnabled="@VoiceInputEnabled"
                             PlaceholderText="@PlaceholderText"
-                            Text="@GetTextInputPanelText(tab.Id)"
-                            TextChanged="@(text => SetTextInputPanelText(tab.Id, text))"
+                            Text="@Text"
+                            TextChanged="TextChanged"
                             OnSendInput="OnSendInput"
                             OnCtrlC="OnCtrlC"
                             OnEscape="OnEscape"
@@ -92,6 +92,10 @@
     [Parameter] public object? DotNetRef { get; set; }
     [Parameter] public Dictionary<string, ShellPanel> ShellPanelRefs { get; set; } = new();
 
+    // TextInputPanelのテキスト（親コンポーネントが保持、破棄・再生成時も入力が失われない）
+    [Parameter] public string Text { get; set; } = "";
+    [Parameter] public EventCallback<string> TextChanged { get; set; }
+
     // TextInputPanelのイベント
     [Parameter] public EventCallback<string> OnSendInput { get; set; }
     [Parameter] public EventCallback OnCtrlC { get; set; }
@@ -102,7 +106,6 @@
 
     private List<BottomPanelTabInfo> Tabs = new();
     private string ActiveTabId = "default-text";
-    private Dictionary<string, string> textInputPanelTexts = new();
 
     protected override void OnInitialized()
     {
@@ -178,16 +181,6 @@
             BottomPanelTabType.PowerShell => "bi-terminal-fill",
             _ => "bi-terminal"
         };
-    }
-
-    private string GetTextInputPanelText(string panelId)
-    {
-        return textInputPanelTexts.TryGetValue(panelId, out var text) ? text : "";
-    }
-
-    private void SetTextInputPanelText(string panelId, string text)
-    {
-        textInputPanelTexts[panelId] = text;
     }
 
     public async ValueTask DisposeAllShellPanels()


### PR DESCRIPTION
## Summary

- 新規セッション作成時などに入力中のテキストが意図せず空になる事象を修正
- 入力テキストの state を `BottomPanel` の private Dictionary から `Root.razor` の `inputText` フィールドに昇格
- `BottomPanel` は `Text`/`TextChanged` を `[Parameter]` として受け取り `TextInputPanel` にプロキシする形に変更

## Root cause

`BottomPanel` は `Root.razor` の以下ネストした `@if` 内に描画されている:

```razor
@if (activeSessionId != null)        // ①
{
    @if (!hideInputPanel)            // ②
    {
        @if (currentSession != null) // ③
        {
            <BottomPanel ... />
        }
    }
}
```

`@key` が付いていないため、①②③のどれかが一瞬でも false に転じると `BottomPanel` インスタンスが破棄され、内部 Dictionary で保持していた入力文字列が失われていた。

**再現経路の例:**
- `SelectSession` の失敗系（フォルダ不在・初期化失敗）で `activeSessionId = null` に戻る
- 新規セッション作成→選択の過渡期で `currentSession` が一瞬 null になる
- 「入力パネル非表示」トグル
- `RestartSessionAsync` 経路

## Fix

- state を Root に昇格。Root は破棄されないので下位の再生成に影響されない
- 保持スコープは「全セッション共有」（既存の挙動と同等）
- `BottomPanel` の `textInputPanelTexts` Dictionary および `GetTextInputPanelText`/`SetTextInputPanelText` ヘルパーを削除

## Test plan

- [ ] セッションAで「abc」入力 → 新規セッションB作成 → B切替後も入力欄に「abc」が残る
- [ ] セッションAで「abc」入力 → 別セッションに切替 → Aに戻って「abc」が残る
- [ ] Worktree/サブセッション作成時にも入力が消えない
- [ ] 「入力パネル非表示」トグルで往復しても入力が残る
- [ ] セッション起動失敗時（フォルダ不在）でも入力が残る
- [ ] 送信後は正しく入力欄がクリアされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)