### PR TITLE
feat: カスタムコマンドにキーシーケンス送信タイプを追加

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -150,6 +150,7 @@
                                  ShellPanelRefs="@shellPanelRefs"
                                  CustomCommands="@GetCustomCommandsForSession(bottomPanelSession.TerminalType)"
                                  OnSendInput="HandleTextInputSend"
+                                 OnSendCustomKey="SendCustomKey"
                                  OnCtrlC="SendCtrlC"
                                  OnEscape="SendEscape"
                                  OnModeSwitch="SendModeSwitch"
@@ -1641,6 +1642,19 @@
 
     private string claudeModeSwitchKey = "altM";
     private bool voiceInputEnabled = false;
+
+    private async Task SendCustomKey(string keyName)
+    {
+        if (activeSession == null) return;
+        if (KeySequencePresets.All.TryGetValue(keyName, out var preset))
+        {
+            await activeSession.WriteAsync(preset.EscapeSequence);
+        }
+        else
+        {
+            Logger.LogWarning("未定義のキーシーケンスプリセットが指定されました: {KeyName}", keyName);
+        }
+    }
 
     private async Task SendCtrlC()
     {

--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -66,6 +66,7 @@
                             Text="@GetTextInputPanelText(tab.Id)"
                             TextChanged="@(text => SetTextInputPanelText(tab.Id, text))"
                             OnSendInput="OnSendInput"
+                            OnSendCustomKey="OnSendCustomKey"
                             OnCtrlC="OnCtrlC"
                             OnEscape="OnEscape"
                             OnModeSwitch="OnModeSwitch"
@@ -94,6 +95,7 @@
 
     // TextInputPanelのイベント
     [Parameter] public EventCallback<string> OnSendInput { get; set; }
+    [Parameter] public EventCallback<string> OnSendCustomKey { get; set; }
     [Parameter] public EventCallback OnCtrlC { get; set; }
     [Parameter] public EventCallback OnEscape { get; set; }
     [Parameter] public EventCallback OnModeSwitch { get; set; }

--- a/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
@@ -48,11 +48,21 @@
                 @foreach (var (cmd, index) in CustomCommands.Select((c, i) => (c, i)))
                 {
                     var idx = index;
+                    var isKey = cmd.Type == CustomCommandType.KeySequence;
+                    var keyDisplay = isKey ? KeySequencePresets.GetDisplayName(cmd.KeyName) : null;
+                    var label = !string.IsNullOrEmpty(cmd.Title) ? cmd.Title
+                                : isKey ? (keyDisplay ?? cmd.KeyName ?? "?")
+                                : cmd.CommandText;
+                    var tooltip = isKey ? (keyDisplay ?? cmd.KeyName ?? "") : cmd.CommandText;
                     <button class="btn btn-secondary @(pressedCommandIndex == idx ? "active" : "")"
                             @onclick="() => OnCustomCommandClick(idx)"
-                            title="@cmd.CommandText"
+                            title="@tooltip"
                             style="@(pressedCommandIndex == idx ? "transform: scale(0.95);" : "")">
-                        @(string.IsNullOrEmpty(cmd.Title) ? cmd.CommandText : cmd.Title)
+                        @if (isKey)
+                        {
+                            <i class="bi bi-keyboard d-none d-md-inline me-1"></i>
+                        }
+                        @label
                     </button>
                 }
                 @if (VoiceInputEnabled)
@@ -87,6 +97,7 @@
     [Parameter] public EventCallback<string> TextChanged { get; set; }
 
     [Parameter] public EventCallback<string> OnSendInput { get; set; }
+    [Parameter] public EventCallback<string> OnSendCustomKey { get; set; }
     [Parameter] public EventCallback OnCtrlC { get; set; }
     [Parameter] public EventCallback OnEscape { get; set; }
     [Parameter] public EventCallback OnModeSwitch { get; set; }
@@ -208,7 +219,15 @@
     {
         pressedCommandIndex = index;
         StateHasChanged();
-        await OnSendInput.InvokeAsync(CustomCommands[index].CommandText);
+        var cmd = CustomCommands[index];
+        if (cmd.Type == CustomCommandType.KeySequence && !string.IsNullOrEmpty(cmd.KeyName))
+        {
+            await OnSendCustomKey.InvokeAsync(cmd.KeyName);
+        }
+        else
+        {
+            await OnSendInput.InvokeAsync(cmd.CommandText);
+        }
         await Task.Delay(100);
         pressedCommandIndex = null;
         StateHasChanged();

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -575,17 +575,38 @@
                                     <div class="mb-4">
                                         <label class="form-label fw-bold">@displayName</label>
                                         <div class="input-group input-group-sm mb-2">
+                                            <select class="form-select" style="max-width: 110px;"
+                                                    @bind="newCommandTypes[type]">
+                                                <option value="@CustomCommandType.Text">テキスト</option>
+                                                <option value="@CustomCommandType.KeySequence">キー</option>
+                                            </select>
                                             <input type="text" class="form-control"
                                                    @bind="newCommandTitles[type]" @bind:event="oninput"
-                                                   placeholder="タイトル（省略可）" style="max-width: 120px;" />
-                                            <input type="text" class="form-control"
-                                                   @bind="newCommandTexts[type]" @bind:event="oninput"
-                                                   placeholder="コマンド（例: /plan）" />
-                                            <button class="btn btn-outline-primary" type="button"
-                                                    @onclick="() => AddCommand(type)"
-                                                    disabled="@string.IsNullOrWhiteSpace(newCommandTexts.GetValueOrDefault(type))">
-                                                <i class="bi bi-plus-lg"></i>
-                                            </button>
+                                                   placeholder="タイトル（省略可）" style="max-width: 140px;" />
+                                            @if (newCommandTypes.GetValueOrDefault(type, CustomCommandType.Text) == CustomCommandType.KeySequence)
+                                            {
+                                                <select class="form-select" @bind="newCommandKeyNames[type]">
+                                                    @foreach (var preset in KeySequencePresets.All)
+                                                    {
+                                                        <option value="@preset.Key">@preset.Value.DisplayName</option>
+                                                    }
+                                                </select>
+                                                <button class="btn btn-outline-primary" type="button"
+                                                        @onclick="() => AddCommand(type)">
+                                                    <i class="bi bi-plus-lg"></i>
+                                                </button>
+                                            }
+                                            else
+                                            {
+                                                <input type="text" class="form-control"
+                                                       @bind="newCommandTexts[type]" @bind:event="oninput"
+                                                       placeholder="コマンド（例: /plan）" />
+                                                <button class="btn btn-outline-primary" type="button"
+                                                        @onclick="() => AddCommand(type)"
+                                                        disabled="@string.IsNullOrWhiteSpace(newCommandTexts.GetValueOrDefault(type))">
+                                                    <i class="bi bi-plus-lg"></i>
+                                                </button>
+                                            }
                                         </div>
                                         @if (editingCommands.ContainsKey(type) && editingCommands[type].Any())
                                         {
@@ -594,16 +615,24 @@
                                                 {
                                                     var idx = i;
                                                     var cmd = editingCommands[type][i];
+                                                    var isKey = cmd.Type == CustomCommandType.KeySequence;
+                                                    var bodyText = isKey
+                                                        ? (KeySequencePresets.GetDisplayName(cmd.KeyName) ?? cmd.KeyName ?? "?")
+                                                        : cmd.CommandText;
                                                     <li class="list-group-item d-flex justify-content-between align-items-center py-1 px-2">
                                                         <small>
+                                                            @if (isKey)
+                                                            {
+                                                                <i class="bi bi-keyboard me-1 text-muted"></i>
+                                                            }
                                                             @if (!string.IsNullOrEmpty(cmd.Title))
                                                             {
                                                                 <strong>@cmd.Title</strong>
-                                                                <span class="text-muted ms-2">@cmd.CommandText</span>
+                                                                <span class="text-muted ms-2">@bodyText</span>
                                                             }
                                                             else
                                                             {
-                                                                <span>@cmd.CommandText</span>
+                                                                <span>@bodyText</span>
                                                             }
                                                         </small>
                                                         <button class="btn btn-outline-danger btn-sm border-0" type="button"
@@ -961,6 +990,8 @@
     private Dictionary<string, List<CustomCommand>> editingCommands = new();
     private Dictionary<string, string> newCommandTitles = new();
     private Dictionary<string, string> newCommandTexts = new();
+    private Dictionary<string, CustomCommandType> newCommandTypes = new();
+    private Dictionary<string, string> newCommandKeyNames = new();
     private string activeTab = "general";
     private bool remoteLaunchEnabled = false;
     private string remoteLaunchTopicGuid = "";
@@ -1087,6 +1118,10 @@
                     newCommandTitles[type] = "";
                 if (!newCommandTexts.ContainsKey(type))
                     newCommandTexts[type] = "";
+                if (!newCommandTypes.ContainsKey(type))
+                    newCommandTypes[type] = CustomCommandType.Text;
+                if (!newCommandKeyNames.ContainsKey(type))
+                    newCommandKeyNames[type] = KeySequencePresets.All.Keys.First();
             }
 
             // リモート起動設定
@@ -1399,17 +1434,38 @@
 
     private void AddCommand(string terminalType)
     {
-        var text = newCommandTexts.GetValueOrDefault(terminalType, "");
-        if (string.IsNullOrWhiteSpace(text)) return;
-
         if (!editingCommands.ContainsKey(terminalType))
             editingCommands[terminalType] = new();
 
-        editingCommands[terminalType].Add(new CustomCommand
+        var type = newCommandTypes.GetValueOrDefault(terminalType, CustomCommandType.Text);
+        var rawTitle = newCommandTitles.GetValueOrDefault(terminalType, "").Trim();
+        var title = string.IsNullOrWhiteSpace(rawTitle) ? null : rawTitle;
+
+        if (type == CustomCommandType.KeySequence)
         {
-            Title = string.IsNullOrWhiteSpace(newCommandTitles.GetValueOrDefault(terminalType)) ? null : newCommandTitles[terminalType].Trim(),
-            CommandText = text.Trim()
-        });
+            var keyName = newCommandKeyNames.GetValueOrDefault(terminalType, "");
+            if (string.IsNullOrEmpty(keyName) || !KeySequencePresets.All.ContainsKey(keyName)) return;
+
+            editingCommands[terminalType].Add(new CustomCommand
+            {
+                Type = CustomCommandType.KeySequence,
+                Title = title,
+                KeyName = keyName,
+                CommandText = ""
+            });
+        }
+        else
+        {
+            var text = newCommandTexts.GetValueOrDefault(terminalType, "");
+            if (string.IsNullOrWhiteSpace(text)) return;
+
+            editingCommands[terminalType].Add(new CustomCommand
+            {
+                Type = CustomCommandType.Text,
+                Title = title,
+                CommandText = text.Trim()
+            });
+        }
 
         newCommandTitles[terminalType] = "";
         newCommandTexts[terminalType] = "";

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -114,12 +114,26 @@ public class CustomCommandSettings
 }
 
 /// <summary>
+/// カスタムコマンドの種別
+/// </summary>
+public enum CustomCommandType
+{
+    /// <summary>テキスト送信（末尾に Enter を自動付与）</summary>
+    Text = 0,
+    /// <summary>プリセットキーのエスケープシーケンス送信（Enter は付与しない）</summary>
+    KeySequence = 1
+}
+
+/// <summary>
 /// カスタムコマンド
 /// </summary>
 public class CustomCommand
 {
     public string? Title { get; set; }
     public string CommandText { get; set; } = "";
+    public CustomCommandType Type { get; set; } = CustomCommandType.Text;
+    /// <summary>KeySequence 時に参照するプリセットキー名（KeySequencePresets.All のキー）</summary>
+    public string? KeyName { get; set; }
 }
 
 /// <summary>

--- a/TerminalHub/Models/KeySequencePresets.cs
+++ b/TerminalHub/Models/KeySequencePresets.cs
@@ -1,0 +1,40 @@
+namespace TerminalHub.Models
+{
+    /// <summary>
+    /// カスタムコマンド (KeySequence) で送信できるプリセットキーの定義
+    /// </summary>
+    public static class KeySequencePresets
+    {
+        public record Preset(string DisplayName, string EscapeSequence);
+
+        public static readonly System.Collections.Generic.IReadOnlyDictionary<string, Preset> All =
+            new System.Collections.Generic.Dictionary<string, Preset>
+            {
+                ["CtrlC"]      = new("Ctrl+C",        "\x03"),
+                ["CtrlD"]      = new("Ctrl+D",        "\x04"),
+                ["CtrlL"]      = new("Ctrl+L (clear)","\x0C"),
+                ["CtrlR"]      = new("Ctrl+R",        "\x12"),
+                ["CtrlA"]      = new("Ctrl+A",        "\x01"),
+                ["CtrlE"]      = new("Ctrl+E",        "\x05"),
+                ["CtrlZ"]      = new("Ctrl+Z",        "\x1A"),
+                ["Escape"]     = new("Esc",           "\x1B"),
+                ["Tab"]        = new("Tab",           "\t"),
+                ["ShiftTab"]   = new("Shift+Tab",     "\x1b[Z"),
+                ["Enter"]      = new("Enter",         "\r"),
+                ["ArrowUp"]    = new("↑",             "\x1b[A"),
+                ["ArrowDown"]  = new("↓",             "\x1b[B"),
+                ["ArrowRight"] = new("→",             "\x1b[C"),
+                ["ArrowLeft"]  = new("←",             "\x1b[D"),
+                ["Home"]       = new("Home",          "\x1b[H"),
+                ["End"]        = new("End",           "\x1b[F"),
+                ["AltM"]       = new("Alt+M",         "\x1Bm"),
+            };
+
+        /// <summary>キー名から表示名を取得（未定義なら null）</summary>
+        public static string? GetDisplayName(string? keyName)
+        {
+            if (string.IsNullOrEmpty(keyName)) return null;
+            return All.TryGetValue(keyName, out var preset) ? preset.DisplayName : null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

カスタムコマンド（設定 → コマンドタブ）が従来テキスト送信（末尾 Enter 自動付与）のみだったため、Esc / Ctrl+C / Ctrl+L / 矢印キーなどの特殊キーをワンクリックで送れなかった。`CustomCommand` に `Type` フィールドを追加し、プリセットキーから 1 つ選んでエスケープシーケンスのみを送る **KeySequence タイプ** を実装。

## 主な変更

- **データモデル** (`Models/AppSettings.cs`)
  - `CustomCommandType` enum (`Text` / `KeySequence`) を追加
  - `CustomCommand` に `Type` (default: Text) と `KeyName` を追加
  - 既存 `app-settings.json` は `type` フィールド未指定でも `Text` として読める後方互換
- **プリセット定義** (`Models/KeySequencePresets.cs` 新規)
  - Ctrl+C/D/L/R/A/E/Z, Esc, Tab, Shift+Tab, Enter, ↑↓→←, Home, End, Alt+M の 18 種
  - 既存 `Root.razor:1645-1696` の `SendCtrlC` / `SendEscape` 等のエスケープシーケンスを参照
- **設定 UI** (`SettingsDialog.razor`)
  - 種別ドロップダウン（テキスト / キー）を追加
  - キー選択時はプリセット select に切り替え
  - 一覧表示は KeySequence の場合キーボードアイコン + DisplayName
- **ボタンバー** (`TextInputPanel.razor`)
  - KeySequence ボタンには `bi-keyboard` アイコンを表示
  - クリック時は `OnSendCustomKey` 経由で送信（Enter 付与なし）
- **送信ハンドラ** (`Root.razor`)
  - `SendCustomKey(keyName)` で `KeySequencePresets.All` を引いて `WriteAsync`

## Test plan

- [x] 既存の Text タイプコマンドが従来通り動作する（後方互換）
- [x] 設定 → コマンドタブで「キー」を選ぶとプリセットドロップダウンが出る
- [x] キーコマンドを追加すると一覧 / ボタンバーに表示される
- [x] ボタン押下で Enter なしのエスケープシーケンスが ConPTY に送られる
- [x] アプリ再起動後も `app-settings.json` から正しく読み込まれる
- [ ] ターミナル種別ごと（Terminal / ClaudeCode / GeminiCLI / CodexCLI）でそれぞれ追加可能

## 互換性

既存 `app-settings.json` の `customCommand` 配列に `type` フィールドが無い場合、enum default の `Text = 0` で読み込まれます。マイグレーション処理は不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)