### PR TITLE
refactor: KeySequencePresets の順序保証と enum の文字列 JSON 保存

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1646,7 +1646,7 @@
     private async Task SendCustomKey(string keyName)
     {
         if (activeSession == null) return;
-        if (KeySequencePresets.All.TryGetValue(keyName, out var preset))
+        if (KeySequencePresets.TryGet(keyName, out var preset))
         {
             await activeSession.WriteAsync(preset.EscapeSequence);
         }

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -1121,7 +1121,7 @@
                 if (!newCommandTypes.ContainsKey(type))
                     newCommandTypes[type] = CustomCommandType.Text;
                 if (!newCommandKeyNames.ContainsKey(type))
-                    newCommandKeyNames[type] = KeySequencePresets.All.Keys.First();
+                    newCommandKeyNames[type] = KeySequencePresets.DefaultKey;
             }
 
             // リモート起動設定
@@ -1444,7 +1444,7 @@
         if (type == CustomCommandType.KeySequence)
         {
             var keyName = newCommandKeyNames.GetValueOrDefault(terminalType, "");
-            if (string.IsNullOrEmpty(keyName) || !KeySequencePresets.All.ContainsKey(keyName)) return;
+            if (!KeySequencePresets.Contains(keyName)) return;
 
             editingCommands[terminalType].Add(new CustomCommand
             {

--- a/TerminalHub/Models/KeySequencePresets.cs
+++ b/TerminalHub/Models/KeySequencePresets.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace TerminalHub.Models
 {
     /// <summary>
@@ -7,34 +10,55 @@ namespace TerminalHub.Models
     {
         public record Preset(string DisplayName, string EscapeSequence);
 
-        public static readonly System.Collections.Generic.IReadOnlyDictionary<string, Preset> All =
-            new System.Collections.Generic.Dictionary<string, Preset>
+        // 順序を保証するため配列で定義する (UI ドロップダウンの並びに直結)。
+        // Dictionary のイテレーション順は仕様上不定なため、一覧表示用の型は List を使う。
+        public static readonly IReadOnlyList<KeyValuePair<string, Preset>> All = new[]
+        {
+            new KeyValuePair<string, Preset>("CtrlC",      new("Ctrl+C",        "\x03")),
+            new KeyValuePair<string, Preset>("CtrlD",      new("Ctrl+D",        "\x04")),
+            new KeyValuePair<string, Preset>("CtrlL",      new("Ctrl+L (clear)","\x0C")),
+            new KeyValuePair<string, Preset>("CtrlR",      new("Ctrl+R",        "\x12")),
+            new KeyValuePair<string, Preset>("CtrlA",      new("Ctrl+A",        "\x01")),
+            new KeyValuePair<string, Preset>("CtrlE",      new("Ctrl+E",        "\x05")),
+            new KeyValuePair<string, Preset>("CtrlZ",      new("Ctrl+Z",        "\x1A")),
+            new KeyValuePair<string, Preset>("Escape",     new("Esc",           "\x1B")),
+            new KeyValuePair<string, Preset>("Tab",        new("Tab",           "\t")),
+            new KeyValuePair<string, Preset>("ShiftTab",   new("Shift+Tab",     "\x1b[Z")),
+            new KeyValuePair<string, Preset>("Enter",      new("Enter",         "\r")),
+            new KeyValuePair<string, Preset>("ArrowUp",    new("↑",             "\x1b[A")),
+            new KeyValuePair<string, Preset>("ArrowDown",  new("↓",             "\x1b[B")),
+            new KeyValuePair<string, Preset>("ArrowRight", new("→",             "\x1b[C")),
+            new KeyValuePair<string, Preset>("ArrowLeft",  new("←",             "\x1b[D")),
+            new KeyValuePair<string, Preset>("Home",       new("Home",          "\x1b[H")),
+            new KeyValuePair<string, Preset>("End",        new("End",           "\x1b[F")),
+            new KeyValuePair<string, Preset>("AltM",       new("Alt+M",         "\x1Bm")),
+        };
+
+        // O(1) ルックアップ用の内部辞書 (All から自動生成されるので順序依存しない)
+        private static readonly IReadOnlyDictionary<string, Preset> _lookup =
+            All.ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        /// <summary>UI デフォルト選択用の先頭キー</summary>
+        public static string DefaultKey => All[0].Key;
+
+        /// <summary>プリセット取得</summary>
+        public static bool TryGet(string? keyName, out Preset preset)
+        {
+            if (!string.IsNullOrEmpty(keyName) && _lookup.TryGetValue(keyName, out var found))
             {
-                ["CtrlC"]      = new("Ctrl+C",        "\x03"),
-                ["CtrlD"]      = new("Ctrl+D",        "\x04"),
-                ["CtrlL"]      = new("Ctrl+L (clear)","\x0C"),
-                ["CtrlR"]      = new("Ctrl+R",        "\x12"),
-                ["CtrlA"]      = new("Ctrl+A",        "\x01"),
-                ["CtrlE"]      = new("Ctrl+E",        "\x05"),
-                ["CtrlZ"]      = new("Ctrl+Z",        "\x1A"),
-                ["Escape"]     = new("Esc",           "\x1B"),
-                ["Tab"]        = new("Tab",           "\t"),
-                ["ShiftTab"]   = new("Shift+Tab",     "\x1b[Z"),
-                ["Enter"]      = new("Enter",         "\r"),
-                ["ArrowUp"]    = new("↑",             "\x1b[A"),
-                ["ArrowDown"]  = new("↓",             "\x1b[B"),
-                ["ArrowRight"] = new("→",             "\x1b[C"),
-                ["ArrowLeft"]  = new("←",             "\x1b[D"),
-                ["Home"]       = new("Home",          "\x1b[H"),
-                ["End"]        = new("End",           "\x1b[F"),
-                ["AltM"]       = new("Alt+M",         "\x1Bm"),
-            };
+                preset = found;
+                return true;
+            }
+            preset = null!;
+            return false;
+        }
+
+        /// <summary>プリセットの存在確認</summary>
+        public static bool Contains(string? keyName)
+            => !string.IsNullOrEmpty(keyName) && _lookup.ContainsKey(keyName);
 
         /// <summary>キー名から表示名を取得（未定義なら null）</summary>
         public static string? GetDisplayName(string? keyName)
-        {
-            if (string.IsNullOrEmpty(keyName)) return null;
-            return All.TryGetValue(keyName, out var preset) ? preset.DisplayName : null;
-        }
+            => TryGet(keyName, out var preset) ? preset.DisplayName : null;
     }
 }

--- a/TerminalHub/Services/AppSettingsService.cs
+++ b/TerminalHub/Services/AppSettingsService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using TerminalHub.Models;
 
@@ -38,7 +39,10 @@ public class AppSettingsService : IAppSettingsService
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true
+        WriteIndented = true,
+        // enum は文字列で保存する (JSON を直接開いた時の可読性と、enum 値の並び替え耐性のため)。
+        // allowIntegerValues=true で既存の数値表記の JSON も引き続き読める。
+        Converters = { new JsonStringEnumConverter(namingPolicy: JsonNamingPolicy.CamelCase, allowIntegerValues: true) }
     };
 
     public AppSettingsService(


### PR DESCRIPTION
## Summary

PR #11 のレビュー指摘 2 件への対応。

### 1. KeySequencePresets の順序保証
`Dictionary<string, Preset>` のイテレーション順は仕様上不定で、UI ドロップダウンの並びがランタイム実装変更で崩れる可能性があった。

- `All` を `IReadOnlyList<KeyValuePair<string, Preset>>` に変更（順序を明示）
- O(1) ルックアップは内部辞書 `_lookup` で確保
- 公開 API として `TryGet` / `Contains` / `GetDisplayName` / `DefaultKey` を提供
- 呼び出し側を新 API に置換:
  - `KeySequencePresets.All.TryGetValue(...)` → `KeySequencePresets.TryGet(...)`
  - `KeySequencePresets.All.ContainsKey(...)` → `KeySequencePresets.Contains(...)`
  - `KeySequencePresets.All.Keys.First()` → `KeySequencePresets.DefaultKey`
- `SettingsDialog.razor` の `@foreach (var preset in KeySequencePresets.All)` は `KeyValuePair<string, Preset>` を返すため変更不要

### 2. enum の文字列 JSON 保存
`System.Text.Json` のデフォルトで enum は数値（整数）で保存されるため:
- `app-settings.json` を直接開いた時の可読性が低い
- enum の定義順を変えると既存設定の意味がズレる

`AppSettingsService.JsonOptions` に `JsonStringEnumConverter(namingPolicy: CamelCase, allowIntegerValues: true)` を追加。

```json
// Before
{ "type": 1 }
// After
{ "type": "keySequence" }
```

`allowIntegerValues: true` により**既存の数値表記 JSON も引き続き読み込める**（後方互換維持）。

## Test plan

- [ ] 既存の `app-settings.json`（type 数値表記）が読み込める
- [ ] 新規追加した KeySequence カスタムコマンドが `"type": "keySequence"` で保存される
- [ ] 設定 → コマンドタブのキープリセットドロップダウンの並びが定義通り（CtrlC, CtrlD, ...）になる
- [ ] 既存の Text タイプも問題なく動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)