### PR TITLE
feat: BottomPanel にセッション紐づきメモタブを追加

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -142,6 +142,7 @@
                 {
                     <BottomPanel @ref="bottomPanel"
                                  TerminalType="@bottomPanelSession.TerminalType"
+                                 CurrentSessionId="@bottomPanelSession.SessionId"
                                  ClaudeModeSwitchKey="@claudeModeSwitchKey"
                                  VoiceInputEnabled="@voiceInputEnabled"
                                  PlaceholderText="@GetPlaceholderText(bottomPanelSession.TerminalType)"
@@ -1303,6 +1304,7 @@
     {
         SessionManager.DeleteSession(sessionId);
         await DeleteSessionFromStorageAsync(sessionId);
+        bottomPanel?.RemoveMemoTabsForSession(sessionId);
 
         sessions = SessionManager.GetAllSessions().ToList();
         StateHasChanged();
@@ -1315,6 +1317,7 @@
         {
             SessionManager.DeleteSession(session.SessionId);
             await DeleteSessionFromStorageAsync(session.SessionId);
+            bottomPanel?.RemoveMemoTabsForSession(session.SessionId);
         }
 
         sessions = SessionManager.GetAllSessions().ToList();

--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -139,6 +139,9 @@
     private string ActiveTabId = "default-text";
     private Dictionary<string, string> textInputPanelTexts = new();
     private Dictionary<Guid, string> memoBodies = new();
+    // 読み込み済みセッションの集合。同セッションへの再切替で DB を再 fetch しないキャッシュ。
+    // 注意: 外部プロセスや直接 SQL からの変更は検知しないため、将来的に同期機能や
+    // 多重編集を入れる場合は無効化 or 再読み込みトリガを検討。
     private HashSet<Guid> loadedMemoSessions = new();
     private Guid? _previousLoadedSessionId;
 
@@ -298,7 +301,8 @@
         }
         else if (tab.Type == BottomPanelTabType.Memo && tab.MemoId is Guid memoId)
         {
-            try { await MemoRepository.DeleteAsync(memoId); } catch { }
+            try { await MemoRepository.DeleteAsync(memoId); }
+            catch (Exception ex) { Logger.LogError(ex, "[BottomPanel] Memo DeleteAsync 失敗: MemoId={MemoId}", memoId); }
             memoBodies.Remove(memoId);
         }
 
@@ -387,8 +391,17 @@
 
         if (tab.MemoId is Guid memoId && newTitle != tab.DisplayName)
         {
+            var oldTitle = tab.DisplayName;
             tab.DisplayName = newTitle;
-            try { await MemoRepository.UpdateTitleAsync(memoId, newTitle); } catch { }
+            try
+            {
+                await MemoRepository.UpdateTitleAsync(memoId, newTitle);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "[BottomPanel] Memo UpdateTitleAsync 失敗: MemoId={MemoId}", memoId);
+                tab.DisplayName = oldTitle;
+            }
         }
         StateHasChanged();
     }

--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -1,17 +1,37 @@
 @using TerminalHub.Models
+@using TerminalHub.Services
 @using TerminalHub.Components.Shared.BottomPanels
+@inject ISessionMemoRepository MemoRepository
+@inject IJSRuntime JSRuntime
+@inject ILogger<BottomPanel> Logger
 @implements IAsyncDisposable
 
 <!-- タブヘッダー -->
 <ul class="nav nav-tabs px-3 pt-2" style="flex-shrink: 0;">
-    @foreach (var tab in Tabs)
+    @foreach (var tab in Tabs.Where(IsTabVisible))
     {
+        var isEditing = editingTabId == tab.Id;
         <li class="nav-item">
             <button class="nav-link @(ActiveTabId == tab.Id ? "active" : "") d-flex align-items-center gap-1"
                type="button"
                @onclick="async () => await SelectTab(tab.Id)">
                 <i class="bi @GetTabIcon(tab.Type)"></i>
-                <span>@tab.DisplayName</span>
+                @if (isEditing && tab.Type == BottomPanelTabType.Memo)
+                {
+                    <input type="text" class="form-control form-control-sm"
+                           style="width: 140px; font-size: 0.85rem;"
+                           @ref="editingInputRef"
+                           @bind="editingTitle"
+                           @bind:event="oninput"
+                           @onkeydown="@(async (e) => await OnTitleEditKeyDown(e, tab))"
+                           @onclick:stopPropagation="true"
+                           @onblur="@(async () => await CommitTitleEdit(tab))" />
+                }
+                else
+                {
+                    <span @ondblclick="@(() => StartTitleEdit(tab))"
+                          @ondblclick:stopPropagation="true">@tab.DisplayName</span>
+                }
                 @if (!tab.IsDefault)
                 {
                     <button type="button" class="btn-close ms-1" style="font-size: 0.6rem; opacity: 0.7;"
@@ -47,12 +67,18 @@
                     <i class="bi bi-terminal-fill me-2"></i>PowerShellを追加
                 </button>
             </li>
+            <li>
+                <button class="dropdown-item" type="button"
+                   @onclick="AddMemoTab">
+                    <i class="bi bi-journal-text me-2"></i>メモを追加
+                </button>
+            </li>
         </ul>
     </li>
 </ul>
 
 <!-- タブコンテンツ（全タブを常時描画、非アクティブはdisplay:noneで隠す） -->
-@foreach (var tab in Tabs)
+@foreach (var tab in Tabs.Where(IsTabVisible))
 {
     var isActive = tab.Id == ActiveTabId;
     <div class="flex-grow-1" style="overflow-y: auto; @(isActive ? "" : "display: none;")">
@@ -81,6 +107,12 @@
                         DotNetRef="@DotNetRef"
                         OnPanelReady="@(panel => ShellPanelRefs[tab.Id] = panel)" />
         }
+        else if (tab.Type == BottomPanelTabType.Memo && tab.MemoId is Guid memoId)
+        {
+            <MemoPanel MemoId="@memoId"
+                       Body="@GetMemoBody(memoId)"
+                       BodyChanged="@(body => OnMemoBodyChanged(memoId, body))" />
+        }
     </div>
 }
 
@@ -92,6 +124,7 @@
     [Parameter] public string WorkingDirectory { get; set; } = "";
     [Parameter] public object? DotNetRef { get; set; }
     [Parameter] public Dictionary<string, ShellPanel> ShellPanelRefs { get; set; } = new();
+    [Parameter] public Guid? CurrentSessionId { get; set; }
 
     // TextInputPanelのイベント
     [Parameter] public EventCallback<string> OnSendInput { get; set; }
@@ -105,6 +138,15 @@
     private List<BottomPanelTabInfo> Tabs = new();
     private string ActiveTabId = "default-text";
     private Dictionary<string, string> textInputPanelTexts = new();
+    private Dictionary<Guid, string> memoBodies = new();
+    private HashSet<Guid> loadedMemoSessions = new();
+    private Guid? _previousLoadedSessionId;
+
+    // タブタイトル編集用の state
+    private string? editingTabId;
+    private string editingTitle = "";
+    private ElementReference editingInputRef;
+    private bool _focusEditingInput;
 
     protected override void OnInitialized()
     {
@@ -113,6 +155,70 @@
             new() { Id = "default-text", Type = BottomPanelTabType.TextInput, DisplayName = "テキスト入力", IsDefault = true }
         };
         ActiveTabId = "default-text";
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (CurrentSessionId.HasValue && _previousLoadedSessionId != CurrentSessionId)
+        {
+            _previousLoadedSessionId = CurrentSessionId;
+            await LoadMemoTabsForSessionAsync(CurrentSessionId.Value);
+
+            // 切替後、アクティブタブが別セッション固有タブ(Memo)で非表示になった場合は
+            // デフォルト(default-text)に戻す。そのままだとコンテンツ領域が空白になる。
+            var activeTab = Tabs.FirstOrDefault(t => t.Id == ActiveTabId);
+            if (activeTab == null || !IsTabVisible(activeTab))
+            {
+                ActiveTabId = "default-text";
+                StateHasChanged();
+            }
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_focusEditingInput)
+        {
+            _focusEditingInput = false;
+            try { await editingInputRef.FocusAsync(); } catch { }
+        }
+    }
+
+    private bool IsTabVisible(BottomPanelTabInfo tab)
+    {
+        if (tab.Type != BottomPanelTabType.Memo) return true;
+        return tab.SessionId.HasValue && tab.SessionId == CurrentSessionId;
+    }
+
+    private async Task LoadMemoTabsForSessionAsync(Guid sessionId)
+    {
+        if (loadedMemoSessions.Contains(sessionId)) return;
+
+        try
+        {
+            var memos = await MemoRepository.GetBySessionAsync(sessionId);
+            foreach (var memo in memos)
+            {
+                if (Tabs.Any(t => t.MemoId == memo.MemoId)) continue;
+
+                Tabs.Add(new BottomPanelTabInfo
+                {
+                    Id = memo.MemoId.ToString(),
+                    Type = BottomPanelTabType.Memo,
+                    DisplayName = memo.Title,
+                    IsDefault = false,
+                    SessionId = memo.SessionId,
+                    MemoId = memo.MemoId
+                });
+                memoBodies[memo.MemoId] = memo.Body;
+            }
+            loadedMemoSessions.Add(sessionId);
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[BottomPanel] LoadMemoTabsForSessionAsync 失敗: SessionId={SessionId}", sessionId);
+        }
     }
 
     private void AddTab(BottomPanelTabType type)
@@ -139,6 +245,47 @@
         StateHasChanged();
     }
 
+    private async Task AddMemoTab()
+    {
+        if (!CurrentSessionId.HasValue) return;
+
+        var sessionId = CurrentSessionId.Value;
+        var visibleMemoCount = Tabs.Count(t => t.Type == BottomPanelTabType.Memo && t.SessionId == sessionId);
+        var memo = new SessionMemo
+        {
+            MemoId = Guid.NewGuid(),
+            SessionId = sessionId,
+            Title = $"メモ({visibleMemoCount + 1})",
+            Body = "",
+            CreatedAt = DateTime.Now,
+            UpdatedAt = DateTime.Now,
+            SortOrder = visibleMemoCount
+        };
+
+        try
+        {
+            await MemoRepository.InsertAsync(memo);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[BottomPanel] AddMemoTab で InsertAsync 失敗: MemoId={MemoId}", memo.MemoId);
+            return;
+        }
+
+        Tabs.Add(new BottomPanelTabInfo
+        {
+            Id = memo.MemoId.ToString(),
+            Type = BottomPanelTabType.Memo,
+            DisplayName = memo.Title,
+            IsDefault = false,
+            SessionId = memo.SessionId,
+            MemoId = memo.MemoId
+        });
+        memoBodies[memo.MemoId] = memo.Body;
+        ActiveTabId = memo.MemoId.ToString();
+        StateHasChanged();
+    }
+
     private async Task RemoveTab(string tabId)
     {
         var tab = Tabs.FirstOrDefault(t => t.Id == tabId);
@@ -149,12 +296,18 @@
             await panel.DisposeAsync();
             ShellPanelRefs.Remove(tabId);
         }
+        else if (tab.Type == BottomPanelTabType.Memo && tab.MemoId is Guid memoId)
+        {
+            try { await MemoRepository.DeleteAsync(memoId); } catch { }
+            memoBodies.Remove(memoId);
+        }
 
         Tabs.Remove(tab);
 
         if (ActiveTabId == tabId)
         {
-            ActiveTabId = Tabs.FirstOrDefault()?.Id ?? "default-text";
+            var firstVisible = Tabs.FirstOrDefault(IsTabVisible);
+            ActiveTabId = firstVisible?.Id ?? "default-text";
         }
 
         StateHasChanged();
@@ -178,6 +331,7 @@
         {
             BottomPanelTabType.TextInput => "bi-chat-left-text",
             BottomPanelTabType.PowerShell => "bi-terminal-fill",
+            BottomPanelTabType.Memo => "bi-journal-text",
             _ => "bi-terminal"
         };
     }
@@ -190,6 +344,71 @@
     private void SetTextInputPanelText(string panelId, string text)
     {
         textInputPanelTexts[panelId] = text;
+    }
+
+    private string GetMemoBody(Guid memoId)
+    {
+        return memoBodies.TryGetValue(memoId, out var body) ? body : "";
+    }
+
+    private async Task OnMemoBodyChanged(Guid memoId, string body)
+    {
+        memoBodies[memoId] = body;
+        try { await MemoRepository.UpdateBodyAsync(memoId, body ?? ""); }
+        catch (Exception ex) { Logger.LogError(ex, "[BottomPanel] UpdateBodyAsync 失敗: MemoId={MemoId}", memoId); }
+    }
+
+    private void StartTitleEdit(BottomPanelTabInfo tab)
+    {
+        if (tab.Type != BottomPanelTabType.Memo) return;
+        editingTabId = tab.Id;
+        editingTitle = tab.DisplayName;
+        _focusEditingInput = true;
+    }
+
+    private async Task OnTitleEditKeyDown(KeyboardEventArgs e, BottomPanelTabInfo tab)
+    {
+        if (e.Key == "Enter")
+        {
+            await CommitTitleEdit(tab);
+        }
+        else if (e.Key == "Escape")
+        {
+            editingTabId = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task CommitTitleEdit(BottomPanelTabInfo tab)
+    {
+        if (editingTabId != tab.Id) return;
+        var newTitle = string.IsNullOrWhiteSpace(editingTitle) ? tab.DisplayName : editingTitle.Trim();
+        editingTabId = null;
+
+        if (tab.MemoId is Guid memoId && newTitle != tab.DisplayName)
+        {
+            tab.DisplayName = newTitle;
+            try { await MemoRepository.UpdateTitleAsync(memoId, newTitle); } catch { }
+        }
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// 指定セッションに紐づくメモタブを Tabs リストから除去する (セッション削除時に Root から呼ばれる)。
+    /// DB からは Root 側 (SessionRepository.DeleteSessionAsync 経由) で消えているので追加の DB 操作はしない。
+    /// </summary>
+    public void RemoveMemoTabsForSession(Guid sessionId)
+    {
+        var removed = Tabs.RemoveAll(t => t.Type == BottomPanelTabType.Memo && t.SessionId == sessionId);
+        if (removed > 0)
+        {
+            loadedMemoSessions.Remove(sessionId);
+            if (ActiveTabId != "default-text" && !Tabs.Any(t => t.Id == ActiveTabId && IsTabVisible(t)))
+            {
+                ActiveTabId = "default-text";
+            }
+            StateHasChanged();
+        }
     }
 
     public async ValueTask DisposeAllShellPanels()

--- a/TerminalHub/Components/Shared/BottomPanels/MemoPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/MemoPanel.razor
@@ -1,0 +1,104 @@
+@using TerminalHub.Models
+@implements IAsyncDisposable
+
+<div class="p-3 h-100 d-flex flex-column">
+    <textarea id="@($"memoText-{MemoId}")"
+              class="form-control flex-grow-1"
+              @bind="bodyText"
+              @bind:event="oninput"
+              placeholder="メモ... (Enter で改行、自動保存)"
+              style="resize: none; font-family: 'Consolas', 'Monaco', monospace;">
+    </textarea>
+</div>
+
+@code {
+    [Parameter] public Guid MemoId { get; set; }
+    [Parameter] public string Body { get; set; } = "";
+    [Parameter] public EventCallback<string> BodyChanged { get; set; }
+
+    // デバウンス間隔 (ms)。短すぎると毎入力で I/O が走る、長すぎるとアプリ終了時の消失リスクが増える。
+    private const int DebounceMs = 1000;
+
+    private string bodyText
+    {
+        get => Body;
+        set
+        {
+            if (Body == value) return;
+            Body = value;
+            ScheduleFlush(value);
+        }
+    }
+
+    private CancellationTokenSource? _debounceCts;
+    private string? _pendingBody;
+    private Guid _lastMemoId;
+
+    protected override void OnParametersSet()
+    {
+        // MemoId が切り替わった (= 別タブへ) 場合は、保留中の保存を先にフラッシュしてから差し替える
+        if (_lastMemoId != Guid.Empty && _lastMemoId != MemoId)
+        {
+            _ = FlushNowAsync(_lastMemoId);
+        }
+        _lastMemoId = MemoId;
+    }
+
+    private void ScheduleFlush(string value)
+    {
+        _pendingBody = value;
+        _debounceCts?.Cancel();
+        _debounceCts = new CancellationTokenSource();
+        var token = _debounceCts.Token;
+        var targetMemoId = MemoId;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(DebounceMs, token);
+            }
+            catch (TaskCanceledException)
+            {
+                return;
+            }
+            if (token.IsCancellationRequested) return;
+            await InvokeAsync(async () =>
+            {
+                if (_pendingBody == null || targetMemoId != MemoId) return;
+                var bodyToFlush = _pendingBody;
+                _pendingBody = null;
+                await BodyChanged.InvokeAsync(bodyToFlush);
+            });
+        });
+    }
+
+    private async Task FlushNowAsync(Guid forMemoId)
+    {
+        _debounceCts?.Cancel();
+        if (_pendingBody != null && forMemoId == _lastMemoId)
+        {
+            var bodyToFlush = _pendingBody;
+            _pendingBody = null;
+            await BodyChanged.InvokeAsync(bodyToFlush);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _debounceCts?.Cancel();
+        if (_pendingBody != null)
+        {
+            var bodyToFlush = _pendingBody;
+            _pendingBody = null;
+            try
+            {
+                await BodyChanged.InvokeAsync(bodyToFlush);
+            }
+            catch
+            {
+                // dispose 経由のフラッシュ失敗は黙殺
+            }
+        }
+    }
+}

--- a/TerminalHub/Models/SessionInfo.cs
+++ b/TerminalHub/Models/SessionInfo.cs
@@ -16,7 +16,8 @@ namespace TerminalHub.Models
     {
         TextInput,
         CommandPrompt,
-        PowerShell
+        PowerShell,
+        Memo
     }
 
     public class BottomPanelTabInfo
@@ -25,6 +26,10 @@ namespace TerminalHub.Models
         public BottomPanelTabType Type { get; set; }
         public string DisplayName { get; set; } = "";
         public bool IsDefault { get; set; } = false;
+        /// <summary>Memo タブ用: 属するセッション (null なら全セッション共通タブ)</summary>
+        public Guid? SessionId { get; set; }
+        /// <summary>Memo タブ用: 対応する SessionMemo.MemoId</summary>
+        public Guid? MemoId { get; set; }
     }
 
     public class SessionInfo

--- a/TerminalHub/Models/SessionMemo.cs
+++ b/TerminalHub/Models/SessionMemo.cs
@@ -1,0 +1,17 @@
+namespace TerminalHub.Models
+{
+    /// <summary>
+    /// セッションに紐づくメモ (BottomPanel の Memo タブ用)。
+    /// 注釈用の <see cref="SessionInfo.Memo"/> とは別物で、長文・複数件を想定。
+    /// </summary>
+    public class SessionMemo
+    {
+        public Guid MemoId { get; set; } = Guid.NewGuid();
+        public Guid SessionId { get; set; }
+        public string Title { get; set; } = "メモ";
+        public string Body { get; set; } = "";
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+        public DateTime UpdatedAt { get; set; } = DateTime.Now;
+        public int SortOrder { get; set; } = 0;
+    }
+}

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -58,6 +58,7 @@ builder.Services.AddSingleton<SessionDbContext>(sp =>
     return new SessionDbContext(dbPath, logger);
 });
 builder.Services.AddSingleton<ISessionRepository, SessionRepository>();
+builder.Services.AddSingleton<ISessionMemoRepository, SessionMemoRepository>();
 builder.Services.AddScoped<IStorageServiceFactory, StorageServiceFactory>();
 
 // NotificationServiceを登録

--- a/TerminalHub/Services/ISessionMemoRepository.cs
+++ b/TerminalHub/Services/ISessionMemoRepository.cs
@@ -1,0 +1,25 @@
+using TerminalHub.Models;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// セッション紐づきメモ (BottomPanel の Memo タブ用) の永続化リポジトリ
+    /// </summary>
+    public interface ISessionMemoRepository
+    {
+        /// <summary>指定セッションのメモ一覧を SortOrder, CreatedAt 昇順で取得</summary>
+        Task<List<SessionMemo>> GetBySessionAsync(Guid sessionId);
+
+        /// <summary>新規メモを挿入</summary>
+        Task InsertAsync(SessionMemo memo);
+
+        /// <summary>タイトルのみ更新 (UpdatedAt も更新)</summary>
+        Task UpdateTitleAsync(Guid memoId, string title);
+
+        /// <summary>本文のみ更新 (UpdatedAt も更新)</summary>
+        Task UpdateBodyAsync(Guid memoId, string body);
+
+        /// <summary>個別メモを削除</summary>
+        Task DeleteAsync(Guid memoId);
+    }
+}

--- a/TerminalHub/Services/SessionDbContext.cs
+++ b/TerminalHub/Services/SessionDbContext.cs
@@ -10,7 +10,7 @@ namespace TerminalHub.Services
     {
         private readonly string _connectionString;
         private readonly ILogger<SessionDbContext> _logger;
-        private const int CurrentSchemaVersion = 3;
+        private const int CurrentSchemaVersion = 4;
 
         public SessionDbContext(string dbPath, ILogger<SessionDbContext> logger)
         {
@@ -70,6 +70,14 @@ namespace TerminalHub.Services
                 await connection.ExecuteNonQueryAsync("ALTER TABLE Sessions ADD COLUMN PinPriority INTEGER");
                 await SetSchemaVersionAsync(3);
                 _logger.LogInformation("スキーマ v3 を作成（IsPinned, PinPriority カラム追加）");
+            }
+
+            if (currentVersion < 4)
+            {
+                // v4: セッション紐づきメモテーブルを追加
+                await CreateSessionMemosTableAsync();
+                await SetSchemaVersionAsync(4);
+                _logger.LogInformation("スキーマ v4 を作成（SessionMemos テーブル追加）");
             }
         }
 
@@ -188,6 +196,31 @@ namespace TerminalHub.Services
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_inputhistory_createdat ON InputHistory(CreatedAt DESC);
+            ";
+
+            await connection.ExecuteNonQueryAsync(sql);
+        }
+
+        private async Task CreateSessionMemosTableAsync()
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            // 既存の SessionOptions / CheckedScripts と同様、ON DELETE CASCADE を宣言しつつ
+            // PRAGMA foreign_keys の状態に依存しないよう DeleteSessionAsync 側で明示削除する方針。
+            var sql = @"
+                CREATE TABLE IF NOT EXISTS SessionMemos (
+                    MemoId TEXT PRIMARY KEY,
+                    SessionId TEXT NOT NULL,
+                    Title TEXT NOT NULL DEFAULT '',
+                    Body TEXT NOT NULL DEFAULT '',
+                    CreatedAt TEXT NOT NULL,
+                    UpdatedAt TEXT NOT NULL,
+                    SortOrder INTEGER NOT NULL DEFAULT 0,
+                    FOREIGN KEY(SessionId) REFERENCES Sessions(SessionId) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_session_memos_session ON SessionMemos(SessionId, SortOrder, CreatedAt);
             ";
 
             await connection.ExecuteNonQueryAsync(sql);

--- a/TerminalHub/Services/SessionMemoRepository.cs
+++ b/TerminalHub/Services/SessionMemoRepository.cs
@@ -1,0 +1,117 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using TerminalHub.Models;
+
+namespace TerminalHub.Services
+{
+    public class SessionMemoRepository : ISessionMemoRepository
+    {
+        private readonly SessionDbContext _dbContext;
+        private readonly ILogger<SessionMemoRepository> _logger;
+
+        public SessionMemoRepository(SessionDbContext dbContext, ILogger<SessionMemoRepository> logger)
+        {
+            _dbContext = dbContext;
+            _logger = logger;
+        }
+
+        public async Task<List<SessionMemo>> GetBySessionAsync(Guid sessionId)
+        {
+            var result = new List<SessionMemo>();
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            await using var reader = await connection.ExecuteReaderAsync(@"
+                SELECT MemoId, SessionId, Title, Body, CreatedAt, UpdatedAt, SortOrder
+                FROM SessionMemos
+                WHERE SessionId = @sessionId
+                ORDER BY SortOrder ASC, CreatedAt ASC",
+                ("@sessionId", sessionId.ToString()));
+
+            while (await reader.ReadAsync())
+            {
+                result.Add(new SessionMemo
+                {
+                    MemoId = Guid.Parse(reader.GetString(0)),
+                    SessionId = Guid.Parse(reader.GetString(1)),
+                    Title = reader.GetString(2),
+                    Body = reader.GetString(3),
+                    CreatedAt = DateTime.Parse(reader.GetString(4)),
+                    UpdatedAt = DateTime.Parse(reader.GetString(5)),
+                    SortOrder = reader.GetInt32(6)
+                });
+            }
+            return result;
+        }
+
+        public async Task InsertAsync(SessionMemo memo)
+        {
+            try
+            {
+                await using var connection = _dbContext.CreateConnection();
+                await connection.OpenAsync();
+
+                await connection.ExecuteNonQueryAsync(@"
+                    INSERT INTO SessionMemos (MemoId, SessionId, Title, Body, CreatedAt, UpdatedAt, SortOrder)
+                    VALUES (@memoId, @sessionId, @title, @body, @createdAt, @updatedAt, @sortOrder)",
+                    ("@memoId", memo.MemoId.ToString()),
+                    ("@sessionId", memo.SessionId.ToString()),
+                    ("@title", memo.Title),
+                    ("@body", memo.Body),
+                    ("@createdAt", memo.CreatedAt.ToString("o")),
+                    ("@updatedAt", memo.UpdatedAt.ToString("o")),
+                    ("@sortOrder", memo.SortOrder));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[Memo] InsertAsync 失敗: MemoId={MemoId}, SessionId={SessionId}",
+                    memo.MemoId, memo.SessionId);
+                throw;
+            }
+        }
+
+        public async Task UpdateTitleAsync(Guid memoId, string title)
+        {
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            await connection.ExecuteNonQueryAsync(@"
+                UPDATE SessionMemos SET Title = @title, UpdatedAt = @updatedAt
+                WHERE MemoId = @memoId",
+                ("@memoId", memoId.ToString()),
+                ("@title", title),
+                ("@updatedAt", DateTime.Now.ToString("o")));
+        }
+
+        public async Task UpdateBodyAsync(Guid memoId, string body)
+        {
+            try
+            {
+                await using var connection = _dbContext.CreateConnection();
+                await connection.OpenAsync();
+
+                await connection.ExecuteNonQueryAsync(@"
+                    UPDATE SessionMemos SET Body = @body, UpdatedAt = @updatedAt
+                    WHERE MemoId = @memoId",
+                    ("@memoId", memoId.ToString()),
+                    ("@body", body),
+                    ("@updatedAt", DateTime.Now.ToString("o")));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[Memo] UpdateBodyAsync 失敗: MemoId={MemoId}", memoId);
+                throw;
+            }
+        }
+
+        public async Task DeleteAsync(Guid memoId)
+        {
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            await connection.ExecuteNonQueryAsync(
+                "DELETE FROM SessionMemos WHERE MemoId = @memoId",
+                ("@memoId", memoId.ToString()));
+        }
+    }
+}

--- a/TerminalHub/Services/SessionRepository.cs
+++ b/TerminalHub/Services/SessionRepository.cs
@@ -126,15 +126,32 @@ namespace TerminalHub.Services
 
             try
             {
-                // UPSERT (INSERT OR REPLACE)
+                // INSERT ... ON CONFLICT DO UPDATE (UPSERT):
+                // INSERT OR REPLACE を使うと PK 衝突時に内部 DELETE が走り、FK の
+                // ON DELETE CASCADE が発動して関連する SessionMemos 等が巻き添えで消える。
+                // UPSERT なら物理 UPDATE なので CASCADE は発動しない。
                 await connection.ExecuteNonQueryAsync(@"
-                    INSERT OR REPLACE INTO Sessions
+                    INSERT INTO Sessions
                     (SessionId, DisplayName, FolderPath, FolderName, CreatedAt, LastAccessedAt,
                      IsActive, TerminalType, Memo, IsArchived, ArchivedAt, ParentSessionId,
                      IsPinned, PinPriority)
                     VALUES (@sessionId, @displayName, @folderPath, @folderName, @createdAt, @lastAccessedAt,
                             @isActive, @terminalType, @memo, @isArchived, @archivedAt, @parentSessionId,
-                            @isPinned, @pinPriority)",
+                            @isPinned, @pinPriority)
+                    ON CONFLICT(SessionId) DO UPDATE SET
+                        DisplayName = excluded.DisplayName,
+                        FolderPath = excluded.FolderPath,
+                        FolderName = excluded.FolderName,
+                        CreatedAt = excluded.CreatedAt,
+                        LastAccessedAt = excluded.LastAccessedAt,
+                        IsActive = excluded.IsActive,
+                        TerminalType = excluded.TerminalType,
+                        Memo = excluded.Memo,
+                        IsArchived = excluded.IsArchived,
+                        ArchivedAt = excluded.ArchivedAt,
+                        ParentSessionId = excluded.ParentSessionId,
+                        IsPinned = excluded.IsPinned,
+                        PinPriority = excluded.PinPriority",
                     ("@sessionId", session.SessionId.ToString()),
                     ("@displayName", session.DisplayName),
                     ("@folderPath", session.FolderPath),
@@ -207,10 +224,11 @@ namespace TerminalHub.Services
             await using var connection = _dbContext.CreateConnection();
             await connection.OpenAsync();
 
-            // 外部キー制約でオプションとスクリプトも自動削除
+            // 外部キー PRAGMA に依存せず明示的に関連レコードを削除
             await connection.ExecuteNonQueryAsync(@"
                 DELETE FROM SessionOptions WHERE SessionId = @sessionId;
                 DELETE FROM CheckedScripts WHERE SessionId = @sessionId;
+                DELETE FROM SessionMemos WHERE SessionId = @sessionId;
                 DELETE FROM Sessions WHERE SessionId = @sessionId;",
                 ("@sessionId", sessionId.ToString()));
         }

--- a/TerminalHub/Services/SessionRepository.cs
+++ b/TerminalHub/Services/SessionRepository.cs
@@ -142,7 +142,7 @@ namespace TerminalHub.Services
                         DisplayName = excluded.DisplayName,
                         FolderPath = excluded.FolderPath,
                         FolderName = excluded.FolderName,
-                        CreatedAt = excluded.CreatedAt,
+                        -- CreatedAt は INSERT 時のみ確定する値なので UPDATE 経路では上書きしない
                         LastAccessedAt = excluded.LastAccessedAt,
                         IsActive = excluded.IsActive,
                         TerminalType = excluded.TerminalType,


### PR DESCRIPTION
## Summary

- BottomPanel に**セッションごとに複数作成できるメモタブ**を追加
  - タイトルはダブルクリックで編集 (Enter 確定 / Escape 取消 / blur 保存)
  - 本文は textarea、Enter は改行、1秒デバウンスの自動保存
  - スキーマ v4 で `SessionMemos` テーブルを追加
  - セッション削除時は `DeleteSessionAsync` が明示的に関連メモを削除
- **副次的バグ修正**: `SaveSessionAsync` を UPSERT に変更
  - 問題: `INSERT OR REPLACE INTO Sessions` が内部で DELETE を伴い、`Microsoft.Data.Sqlite` がデフォルト有効化する `foreign_keys` + `ON DELETE CASCADE` により SessionMemos の関連行が巻き添えで消えていた
  - 修正: `INSERT ... ON CONFLICT(SessionId) DO UPDATE SET ...` へ変更。物理 UPDATE になり CASCADE は発動しない
- UX 改善: セッション切替時、非表示になったメモタブがアクティブのままだと空白になる問題を修正 (default-text に戻す)

## Test plan

- [x] メモ 2件作成 → 本文入力 → 永続化 (プロセス再起動後も残る)
- [x] セッション設定保存で CASCADE wipe が起きないこと (バグ再現テストで確認)
- [x] メモタブ X ボタンで個別削除、DB 側からも消える
- [x] セッション削除時、関連メモも `DeleteSessionAsync` で明示削除される
- [x] セッション A のメモにフォーカス中に B へ切替 → default-text に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)