### PR TITLE
fix: MemoPanel の fire-and-forget 例外を握って未観測例外を防ぐ

### DIFF
--- a/TerminalHub/Components/Shared/BottomPanels/MemoPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/MemoPanel.razor
@@ -52,24 +52,34 @@
         var token = _debounceCts.Token;
         var targetMemoId = MemoId;
 
+        // fire-and-forget の Task.Run 内で未観測例外にならないよう全体を try/catch で包む。
+        // Circuit 切断中に InvokeAsync が JSDisconnectedException をスローするケース等を想定。
         _ = Task.Run(async () =>
         {
             try
             {
-                await Task.Delay(DebounceMs, token);
+                try
+                {
+                    await Task.Delay(DebounceMs, token);
+                }
+                catch (TaskCanceledException)
+                {
+                    return;
+                }
+                if (token.IsCancellationRequested) return;
+                await InvokeAsync(async () =>
+                {
+                    if (_pendingBody == null || targetMemoId != MemoId) return;
+                    var bodyToFlush = _pendingBody;
+                    _pendingBody = null;
+                    await BodyChanged.InvokeAsync(bodyToFlush);
+                });
             }
-            catch (TaskCanceledException)
+            catch (Exception)
             {
-                return;
+                // Circuit 切断や BodyChanged 側の未捕捉例外はここで握る。
+                // 呼び出し側 (BottomPanel.OnMemoBodyChanged) が DB 書き込み失敗を LogError する前提。
             }
-            if (token.IsCancellationRequested) return;
-            await InvokeAsync(async () =>
-            {
-                if (_pendingBody == null || targetMemoId != MemoId) return;
-                var bodyToFlush = _pendingBody;
-                _pendingBody = null;
-                await BodyChanged.InvokeAsync(bodyToFlush);
-            });
         });
     }
 
@@ -80,7 +90,15 @@
         {
             var bodyToFlush = _pendingBody;
             _pendingBody = null;
-            await BodyChanged.InvokeAsync(bodyToFlush);
+            try
+            {
+                await BodyChanged.InvokeAsync(bodyToFlush);
+            }
+            catch
+            {
+                // OnParametersSet からの fire-and-forget 経路で未観測例外にならないよう握る。
+                // 書き込み失敗は呼び出し側 (BottomPanel.OnMemoBodyChanged) で LogError 済み。
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- MemoPanel の debounce 経路と `OnParametersSet` 経路のフラッシュ処理を `try/catch` で包み、未観測例外化を防止
- Circuit 切断時の `JSDisconnectedException` 等、`BodyChanged.InvokeAsync` から伝播する例外を想定
- 書き込み失敗は呼び出し側 (`BottomPanel.OnMemoBodyChanged`) で `LogError` 済みのため、ここでは握るのみ

## 背景
PR #14 でメモ機能を追加したが、`Task.Run` による fire-and-forget 経路は未観測例外になるとプロセス全体に影響する可能性がある。Circuit 切断中の書き込みで `JSDisconnectedException` が伝播するケース等に備え、防御的に例外を握る。

## Test plan
- [ ] メモ編集時に debounce 経由でDBに書き込まれること
- [ ] セッション切替直後のメモ編集でクラッシュしないこと
- [ ] Circuit 切断中（タブを閉じる等）に編集→保存が試行されても未観測例外にならないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)