### PR TITLE
fix: フォルダ選択ダイアログが前面に出ない問題を修正

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -324,10 +324,11 @@
         {
             if (Directory.Exists(path))
             {
-                // Windows の explorer.exe はスラッシュをオプションとして解釈するため、
-                // バックスラッシュに正規化してから渡す
-                var normalizedPath = path.Replace('/', '\\');
-                Process.Start("explorer.exe", $"\"{normalizedPath}\"");
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = path.Replace('/', '\\'),
+                    UseShellExecute = true,
+                });
             }
         }
         catch (Exception ex)

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -1208,7 +1208,11 @@
             {
                 Directory.CreateDirectory(logPath);
             }
-            System.Diagnostics.Process.Start("explorer.exe", logPath);
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = logPath,
+                UseShellExecute = true,
+            });
         }
         catch (Exception ex)
         {

--- a/TerminalHub/Services/FolderPickerService.cs
+++ b/TerminalHub/Services/FolderPickerService.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace TerminalHub.Services;
 
 /// <summary>
@@ -14,6 +16,16 @@ public interface IFolderPickerService
 
 public class FolderPickerService : IFolderPickerService
 {
+    [DllImport("user32.dll")]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+    private static readonly IntPtr HWND_NOTOPMOST = new(-2);
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOSIZE = 0x0001;
+    private const uint SWP_NOACTIVATE = 0x0010;
+    private const uint TopMostFlags = SWP_NOMOVE | SWP_NOSIZE;
+
     public Task<string?> PickFolderAsync(string? initialDirectory = null)
     {
         var tcs = new TaskCompletionSource<string?>();
@@ -32,7 +44,11 @@ public class FolderPickerService : IFolderPickerService
                     dialog.InitialDirectory = initialDirectory;
                 }
 
-                var result = dialog.ShowDialog();
+                // ダイアログの親として一瞬TOPMOSTにするオーナーウィンドウを作成。
+                // Blazor Serverはバックグラウンドプロセスのため、
+                // そのままではWindowsがダイアログを前面に出さない。
+                using var owner = new TopmostOwnerWindow();
+                var result = dialog.ShowDialog(owner);
                 tcs.SetResult(result == System.Windows.Forms.DialogResult.OK ? dialog.SelectedPath : null);
             }
             catch (Exception ex)
@@ -45,5 +61,31 @@ public class FolderPickerService : IFolderPickerService
         thread.Start();
 
         return tcs.Task;
+    }
+
+    /// <summary>
+    /// ダイアログ表示時に一瞬TOPMOSTにして前面表示を保証するオーナーウィンドウ。
+    /// ShowDialog(owner) に渡すと、ダイアログもオーナーの Z-order に従って前面に出る。
+    /// </summary>
+    private sealed class TopmostOwnerWindow : System.Windows.Forms.NativeWindow, IDisposable
+    {
+        public TopmostOwnerWindow()
+        {
+            CreateHandle(new System.Windows.Forms.CreateParams
+            {
+                X = 0, Y = 0, Width = 0, Height = 0,
+                Style = 0x00000000, // WS_OVERLAPPED (不可視)
+            });
+            SetWindowPos(Handle, HWND_TOPMOST, 0, 0, 0, 0, TopMostFlags);
+        }
+
+        public void Dispose()
+        {
+            if (Handle != IntPtr.Zero)
+            {
+                SetWindowPos(Handle, HWND_NOTOPMOST, 0, 0, 0, 0, TopMostFlags | SWP_NOACTIVATE);
+                DestroyHandle();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- FolderPickerService に TOPMOST オーナーウィンドウ方式を追加し、フォルダ選択ダイアログを最前面に表示
- SessionSettingsDialog / SettingsDialog のフォルダ表示を `UseShellExecute = true` に変更

## 背景
Blazor Server はバックグラウンドプロセスとして動作するため、Windows のフォアグラウンドロック機構によりダイアログやエクスプローラーが他のウィンドウの裏に隠れることがあった。

## Test plan
- [ ] セッション作成時のフォルダ選択ダイアログが前面に表示されること
- [ ] 設定画面のフォルダ選択（デフォルトフォルダ・お気に入り）が前面に表示されること
- [ ] セッション設定画面の「フォルダを開く」でエクスプローラーが前面に表示されること
- [ ] 設定画面の「ログフォルダを開く」でエクスプローラーが前面に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)