### PR TITLE
fix: 新規DB作成時のスキーマ duplicate column エラーを修正

### DIFF
--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -51,7 +51,8 @@ builder.Services.AddScoped<ILocalStorageService, LocalStorageService>();
 
 // SQLiteセッションストレージを登録
 var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-var dbPath = Path.Combine(appDataPath, "TerminalHub", "sessions.db");
+var dbFileName = builder.Configuration.GetValue<string>("Database:FileName") ?? "sessions.db";
+var dbPath = Path.Combine(appDataPath, "TerminalHub", dbFileName);
 builder.Services.AddSingleton<SessionDbContext>(sp =>
 {
     var logger = sp.GetRequiredService<ILogger<SessionDbContext>>();

--- a/TerminalHub/Services/SessionDbContext.cs
+++ b/TerminalHub/Services/SessionDbContext.cs
@@ -37,6 +37,11 @@ namespace TerminalHub.Services
             await MigrateSchemaAsync();
         }
 
+        // CreateInitialSchemaAsync の CREATE TABLE 定義が最新バージョンの構造を
+        // 含んでいるため、新規DBでは個別ALTERマイグレーションをスキップして
+        // 直接このバージョンにジャンプする。
+        private const int LatestSchemaVersion = 4;
+
         /// <summary>
         /// スキーママイグレーションを実行
         /// </summary>
@@ -45,12 +50,15 @@ namespace TerminalHub.Services
             var currentVersion = await GetSchemaVersionAsync();
             _logger.LogInformation("現在のスキーマバージョン: {Version}", currentVersion);
 
-            if (currentVersion < 1)
+            if (currentVersion == 0)
             {
-                // v1: 初期スキーマ作成
+                // 新規DB: 最新スキーマを一括作成して個別マイグレーションをスキップ
                 await CreateInitialSchemaAsync();
-                await SetSchemaVersionAsync(1);
-                _logger.LogInformation("スキーマ v1 を作成");
+                await CreateInputHistoryTableAsync();
+                await CreateSessionMemosTableAsync();
+                await SetSchemaVersionAsync(LatestSchemaVersion);
+                _logger.LogInformation("新規DBを最新スキーマ v{Version} で作成", LatestSchemaVersion);
+                return;
             }
 
             if (currentVersion < 2)


### PR DESCRIPTION
## Summary
新規インストール時の初回起動で、SQLite スキーママイグレーションが "duplicate column name: IsPinned" エラーで失敗していた問題を修正。

## 背景・影響範囲
2026-03-29 のコミット 098087a 以降、\`CreateInitialSchemaAsync\` のテーブル定義に \`IsPinned\` / \`PinPriority\` カラムが含まれるようになったが、マイグレーション処理は依然として v1 → v2 → v3 → v4 と順に全部実行していた。そのため新規DBでは：

1. CreateInitialSchemaAsync 実行 → IsPinned カラムを含む Sessions テーブル作成
2. v3 マイグレーション: \`ALTER TABLE Sessions ADD COLUMN IsPinned\` → **duplicate column エラー**

**影響**: 2026-03-29 以降に TerminalHub を新規インストールしたユーザーは初回起動時に例外発生。既存ユーザー（DBが既に v4 に到達済み）は影響なし。

## 修正内容
- \`LatestSchemaVersion = 4\` 定数を追加
- \`currentVersion == 0\`（新規DB）の場合は \`CreateInitialSchemaAsync\` + \`CreateInputHistoryTableAsync\` + \`CreateSessionMemosTableAsync\` を一括実行して直接 v4 にジャンプ
- 既存DBからの個別マイグレーション（v2/v3/v4）は従来通り

## 併せて入れた変更
DB ファイル名を設定から読めるように対応。開発環境で開発用DBと実運用DBを分けやすくする。
- \`appsettings.json\` の \`Database:FileName\` キー（未指定時フォールバック: \`sessions.db\`）
- ローカルの \`appsettings.Development.json\` で上書き可能（例: \`sessions-dev.db\`）

## Test plan
- [ ] 既存の \`sessions.db\` がある状態で起動し、問題なく動作すること
- [ ] 新しいDB名（例: \`sessions-dev.db\`）を指定して起動し、エラーなくスキーマが作成されること
- [ ] 作成されたDB の SchemaVersion テーブルに \`4\` が記録されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)