### PR TITLE
chore: 「テキスト入力を追加」メニューを削除

### DIFF
--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -51,12 +51,6 @@
         <ul class="dropdown-menu">
             <li>
                 <button class="dropdown-item" type="button"
-                   @onclick="() => AddTab(BottomPanelTabType.TextInput)">
-                    <i class="bi bi-chat-left-text me-2"></i>テキスト入力を追加
-                </button>
-            </li>
-            <li>
-                <button class="dropdown-item" type="button"
                    @onclick="() => AddTab(BottomPanelTabType.CommandPrompt)">
                     <i class="bi bi-terminal me-2"></i>コマンドプロンプトを追加
                 </button>

--- a/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
@@ -105,8 +105,6 @@
         }
     }
     private bool shouldPreventDefault = false;
-    private bool isCtrlCPressed = false;
-    private bool isEscapePressed = false;
     private bool isModeSwitchPressed = false;
     private bool isSending = false;
     private bool isVoiceRecording = false;
@@ -223,18 +221,12 @@
 
     private async Task OnCtrlCClick()
     {
-        isCtrlCPressed = true;
         await OnCtrlC.InvokeAsync();
-        await Task.Delay(100);
-        isCtrlCPressed = false;
     }
 
     private async Task OnEscapeClick()
     {
-        isEscapePressed = true;
         await OnEscape.InvokeAsync();
-        await Task.Delay(100);
-        isEscapePressed = false;
     }
 
     private async Task OnAltVClick()


### PR DESCRIPTION
## Summary
BottomPanel のタブ追加ドロップダウンから「テキスト入力を追加」項目を削除する小さな整理。

## 背景
テキスト入力タブを複数作る用途は一時メモ的な意味合いが強かったが、セッション紐づきのメモ機能が追加されてその役割を置き換えたため、メニュー項目としては不要になった。

- デフォルトの「テキスト入力」タブは引き続き存在する
- ドロップダウンからはコマンドプロンプト / PowerShell / メモの3つに絞る

## 同時に入る微調整
\`TextInputPanel\` の未使用フィールド \`isCtrlCPressed\` / \`isEscapePressed\` を削除。前回 Ctrl+C/Esc ボタン削除時にボタン側の参照が消えた残骸で、今回整理。ロジックには影響なし（キーボードショートカット経路は維持）。

## Test plan
- [ ] 起動時、BottomPanel のタブ追加ドロップダウンから「テキスト入力を追加」が消えていること
- [ ] 他の項目（コマンドプロンプト / PowerShell / メモ）は引き続き追加できる
- [ ] デフォルトの「テキスト入力」タブは起動時に表示されている
- [ ] テキストエリアで Ctrl+C / Esc を押してターミナルに送信される

🤖 Generated with [Claude Code](https://claude.com/claude-code)