### PR TITLE
fix: カスタムコマンド並び替えでリスト外ドラッグ時のハイライトを即時解消

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -608,6 +608,7 @@
                                                         @ondragend="OnCommandDragEnd"
                                                         @ondragover:preventDefault="true"
                                                         @ondragover="@(() => OnCommandDragOver(type, idx))"
+                                                        @ondragleave="@(() => OnCommandDragLeave(type, idx))"
                                                         @ondrop:preventDefault="true"
                                                         @ondrop="@(() => OnCommandDrop(type, idx))">
                                                         <small class="d-flex align-items-center" style="min-width: 0; flex: 1;">
@@ -1488,6 +1489,18 @@
         }
         _dragOverType = terminalType;
         _dragOverIndex = index;
+    }
+
+    private void OnCommandDragLeave(string terminalType, int index)
+    {
+        // 自身の上から離脱した場合のみハイライト解除。
+        // 別アイテムへの遷移直後は dragenter → 旧要素 dragleave の順に発火するため、
+        // _dragOverIndex が別 index に既に更新されている可能性を考慮して自分の時だけクリア。
+        if (_dragOverType == terminalType && _dragOverIndex == index)
+        {
+            _dragOverType = null;
+            _dragOverIndex = -1;
+        }
     }
 
     private void OnCommandDrop(string terminalType, int targetIndex)


### PR DESCRIPTION
## Summary
PR #21 のレビュー指摘対応。\`ondragleave\` ハンドラを追加して、ドラッグしたままリスト外に出た時にハイライトが残る問題を解消。

## 背景
これまでは \`ondragover\` の上書きに依存していたため、リスト外に出た直後の一瞬ハイライトが残って見える挙動だった。

## 実装
- \`@ondragleave\` ハンドラを li に追加
- \`OnCommandDragLeave(type, index)\` で自身の上から離脱時のみ \`_dragOverType/_dragOverIndex\` をクリア
- 別アイテムへの遷移時は \`dragenter → 旧要素 dragleave\` の順で発火するので、
  index 一致チェックを入れて誤クリアを防止

## Test plan
- [ ] カスタムコマンドを並び替え中にリスト外にカーソルを移すとハイライトが消える
- [ ] 別アイテムに移動する時はハイライトが正しく次のターゲットに移る（消えない）
- [ ] ドロップ時の挙動は変わらず並び替えできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)