### PR TITLE
feat: テキスト事前整形ボタンを追加（実験的）

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -46,6 +46,7 @@
                 OnTerminalHeightPercentChanged="HandleTerminalHeightPercentChanged"
                 OnSidebarWidthPercentChanged="HandleSidebarWidthPercentChanged"
                 OnVoiceInputEnabledChanged="HandleVoiceInputEnabledChanged"
+                OnTextRefineEnabledChanged="HandleTextRefineEnabledChanged"
                 OnThemeChanged="HandleThemeChanged" />
 <SubSessionDialog IsVisible="showSubSessionDialog" 
                          ParentSessionName="@subSessionParentSessionName"
@@ -145,6 +146,7 @@
                                  CurrentSessionId="@bottomPanelSession.SessionId"
                                  ClaudeModeSwitchKey="@claudeModeSwitchKey"
                                  VoiceInputEnabled="@voiceInputEnabled"
+                                 TextRefineEnabled="@textRefineEnabled"
                                  PlaceholderText="@GetPlaceholderText(bottomPanelSession.TerminalType)"
                                  WorkingDirectory="@bottomPanelSession.FolderPath"
                                  DotNetRef="@dotNetRef"
@@ -379,6 +381,7 @@
                 var appSettings = AppSettingsService.GetSettings();
                 claudeModeSwitchKey = appSettings.Special.ClaudeModeSwitchKey;
                 voiceInputEnabled = appSettings.Special.VoiceInputEnabled;
+                textRefineEnabled = appSettings.Special.TextRefineEnabled;
                 sessionSortMode = appSettings.Sessions.SortMode;
                 showTerminalType = appSettings.Sessions.ShowTerminalType;
                 showGitInfo = appSettings.Sessions.ShowGitInfo;
@@ -607,6 +610,12 @@
     private void HandleVoiceInputEnabledChanged(bool enabled)
     {
         voiceInputEnabled = enabled;
+        StateHasChanged();
+    }
+
+    private void HandleTextRefineEnabledChanged(bool enabled)
+    {
+        textRefineEnabled = enabled;
         StateHasChanged();
     }
 
@@ -1645,6 +1654,7 @@
 
     private string claudeModeSwitchKey = "altM";
     private bool voiceInputEnabled = false;
+    private bool textRefineEnabled = false;
 
     private async Task SendCustomKey(string keyName)
     {

--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -82,6 +82,7 @@
                             TerminalType="@TerminalType"
                             ClaudeModeSwitchKey="@ClaudeModeSwitchKey"
                             VoiceInputEnabled="@VoiceInputEnabled"
+                            TextRefineEnabled="@TextRefineEnabled"
                             PlaceholderText="@PlaceholderText"
                             Text="@GetTextInputPanelText(tab.Id)"
                             TextChanged="@(text => SetTextInputPanelText(tab.Id, text))"
@@ -114,6 +115,7 @@
     [Parameter] public TerminalType TerminalType { get; set; }
     [Parameter] public string ClaudeModeSwitchKey { get; set; } = "";
     [Parameter] public bool VoiceInputEnabled { get; set; }
+    [Parameter] public bool TextRefineEnabled { get; set; }
     [Parameter] public string PlaceholderText { get; set; } = "";
     [Parameter] public string WorkingDirectory { get; set; } = "";
     [Parameter] public object? DotNetRef { get; set; }

--- a/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
@@ -1,6 +1,8 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
 @inject IInputHistoryService InputHistoryService
+@inject ITextRefineService TextRefine
+@inject ILogger<TextInputPanel> Logger
 @inject IJSRuntime JS
 @implements IAsyncDisposable
 
@@ -66,6 +68,23 @@
                         <i class="bi bi-mic"></i>
                     </button>
                 }
+                @if (TextRefineEnabled)
+                {
+                    <button class="btn btn-secondary @(isRefining ? "active" : "")"
+                            @onclick="OnRefineClick"
+                            disabled="@(isRefining || string.IsNullOrWhiteSpace(inputText))"
+                            title="Claude Code で誤字脱字・表現を整える">
+                        @if (isRefining)
+                        {
+                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                        }
+                        else
+                        {
+                            <i class="bi bi-stars"></i>
+                        }
+                        <span class="d-none d-md-inline ms-1">事前整形</span>
+                    </button>
+                }
                 <button class="btn btn-primary" @onclick="OnSendClick">
                     <i class="bi bi-send d-none d-md-inline"></i> 送信
                 </button>
@@ -80,6 +99,7 @@
     [Parameter] public string ClaudeModeSwitchKey { get; set; } = "altM";
     [Parameter] public string PlaceholderText { get; set; } = "コマンドを入力...";
     [Parameter] public bool VoiceInputEnabled { get; set; } = false;
+    [Parameter] public bool TextRefineEnabled { get; set; } = false;
 
     [Parameter] public string Text { get; set; } = "";
     [Parameter] public EventCallback<string> TextChanged { get; set; }
@@ -108,6 +128,7 @@
     private bool isModeSwitchPressed = false;
     private bool isSending = false;
     private bool isVoiceRecording = false;
+    private bool isRefining = false;
     private DotNetObjectReference<TextInputPanel>? dotNetRef;
     private bool voiceInitialized = false;
 
@@ -338,6 +359,40 @@
     {
         inputText = text;
         StateHasChanged();
+    }
+
+    /// <summary>
+    /// 「事前整形」ボタン: テキストを Claude Code -p で整形し、結果でテキストエリアを置換する。
+    /// </summary>
+    private async Task OnRefineClick()
+    {
+        if (isRefining) return;
+        var source = inputText;
+        if (string.IsNullOrWhiteSpace(source)) return;
+
+        isRefining = true;
+        StateHasChanged();
+        try
+        {
+            var refined = await TextRefine.RefineAsync(source);
+            if (!string.IsNullOrEmpty(refined))
+            {
+                inputText = refined;
+            }
+            else
+            {
+                Logger.LogWarning("[TextInputPanel] 事前整形に失敗（null 返却）");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[TextInputPanel] 事前整形中にエラー");
+        }
+        finally
+        {
+            isRefining = false;
+            StateHasChanged();
+        }
     }
 
     /// <summary>

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -778,6 +778,24 @@
                                 <hr />
 
                                 <div class="mb-4">
+                                    <h6 class="mb-2">テキスト事前整形</h6>
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" @bind="textRefineEnabled" id="textRefineSwitch">
+                                        <label class="form-check-label" for="textRefineSwitch">
+                                            事前整形ボタンを有効にする（実験的）
+                                        </label>
+                                    </div>
+                                    <p class="text-muted small mt-2 mb-0">
+                                        <i class="bi bi-info-circle me-1"></i>
+                                        有効にすると、テキスト入力パネルに「<i class="bi bi-stars"></i> 事前整形」ボタンが表示されます。
+                                        押すと Claude Code CLI（Haiku モデル）で誤字脱字や表現の揺れを修正します。<br/>
+                                        整形指示は <code>%LOCALAPPDATA%\TerminalHub\refine-workdir\CLAUDE.md</code> を編集してカスタマイズ可能。
+                                    </p>
+                                </div>
+
+                                <hr />
+
+                                <div class="mb-4">
                                     <h6 class="mb-2">開発ツール</h6>
                                     <div class="form-check form-switch">
                                         <input class="form-check-input" type="checkbox" @bind="devToolsEnabled" id="devToolsSwitch">
@@ -990,6 +1008,7 @@
     private bool remoteLaunchPasswordCleared = false;
     private string claudeModeSwitchKey = "altM";
     private bool voiceInputEnabled = false;
+    private bool textRefineEnabled = false;
     private string sessionSortMode = "lastAccessed";
     private bool showTerminalType = false;
     private bool showGitInfo = false;
@@ -1030,6 +1049,7 @@
     [Parameter] public EventCallback<int> OnTerminalHeightPercentChanged { get; set; }
     [Parameter] public EventCallback<int> OnSidebarWidthPercentChanged { get; set; }
     [Parameter] public EventCallback<bool> OnVoiceInputEnabledChanged { get; set; }
+    [Parameter] public EventCallback<bool> OnTextRefineEnabledChanged { get; set; }
     [Parameter] public EventCallback<string> OnThemeChanged { get; set; }
 
     // ダイアログが開いている間は設定を再読み込みしないためのフラグ
@@ -1076,6 +1096,7 @@
             // 特殊設定
             claudeModeSwitchKey = settings.Special.ClaudeModeSwitchKey;
             voiceInputEnabled = settings.Special.VoiceInputEnabled;
+            textRefineEnabled = settings.Special.TextRefineEnabled;
 
             // セッション表示設定
             sessionSortMode = settings.Sessions.SortMode;
@@ -1292,7 +1313,8 @@
                 Special = new SpecialSettings
                 {
                     ClaudeModeSwitchKey = claudeModeSwitchKey,
-                    VoiceInputEnabled = voiceInputEnabled
+                    VoiceInputEnabled = voiceInputEnabled,
+                    TextRefineEnabled = textRefineEnabled
                 },
                 Sessions = new SessionDisplaySettings
                 {
@@ -1356,6 +1378,7 @@
 
             // 音声入力設定の変更を通知
             await OnVoiceInputEnabledChanged.InvokeAsync(voiceInputEnabled);
+            await OnTextRefineEnabledChanged.InvokeAsync(textRefineEnabled);
 
             // テーマの変更を通知
             await OnThemeChanged.InvokeAsync(theme);

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -52,6 +52,12 @@ public class SpecialSettings
 {
     public string ClaudeModeSwitchKey { get; set; } = "none";
     public bool VoiceInputEnabled { get; set; } = false;
+    /// <summary>
+    /// テキスト事前整形（実験的）を有効にするかどうか。
+    /// 有効時、テキスト入力パネルに「事前整形」ボタンが表示され、Claude Code CLI の
+    /// -p モードで入力テキストを整形してから置換する。
+    /// </summary>
+    public bool TextRefineEnabled { get; set; } = false;
 }
 
 /// <summary>

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -97,6 +97,9 @@ builder.Services.AddSingleton<IAppSettingsService, AppSettingsService>();
 // FolderPickerServiceを登録
 builder.Services.AddSingleton<IFolderPickerService, FolderPickerService>();
 
+// TextRefineService（テキスト事前整形、実験的）
+builder.Services.AddSingleton<ITextRefineService, TextRefineService>();
+
 // リモート起動サービスを登録
 builder.Services.AddSingleton<IRemoteLaunchService, RemoteLaunchService>();
 builder.Services.AddSingleton<MqttService>();

--- a/TerminalHub/Services/TextRefineService.cs
+++ b/TerminalHub/Services/TextRefineService.cs
@@ -1,0 +1,177 @@
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using TerminalHub.Constants;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// テキスト事前整形（実験的機能）。
+    /// 専用ワークディレクトリ (%LOCALAPPDATA%\TerminalHub\refine-workdir\) を用意し、
+    /// そこに整形指示用の CLAUDE.md を配置した上で Claude Code CLI を -p モードで呼び出す。
+    /// これによりユーザーの入力テキストだけを渡せば、CLAUDE.md が自動で指示として
+    /// 適用されるため、プロンプトエスケープやテンプレート管理が不要になる。
+    /// </summary>
+    public interface ITextRefineService
+    {
+        /// <summary>
+        /// テキストを Claude Code CLI 経由で整形する。
+        /// 失敗時は null を返す（エラーは Logger に出力）。
+        /// </summary>
+        Task<string?> RefineAsync(string text, CancellationToken cancellationToken = default);
+    }
+
+    public class TextRefineService : ITextRefineService
+    {
+        private readonly ILogger<TextRefineService> _logger;
+        private readonly SemaphoreSlim _initLock = new(1, 1);
+        private bool _initialized = false;
+        private string _workdir = "";
+
+        public TextRefineService(ILogger<TextRefineService> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// ワークディレクトリを初期化して CLAUDE.md を配置する。
+        /// 既に CLAUDE.md が存在する場合は上書きしない（ユーザーのカスタマイズを尊重）。
+        /// </summary>
+        private async Task EnsureInitializedAsync()
+        {
+            if (_initialized) return;
+            await _initLock.WaitAsync();
+            try
+            {
+                if (_initialized) return;
+
+                var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                _workdir = Path.Combine(appData, "TerminalHub", "refine-workdir");
+                Directory.CreateDirectory(_workdir);
+
+                var claudeMdPath = Path.Combine(_workdir, "CLAUDE.md");
+                if (!File.Exists(claudeMdPath))
+                {
+                    await File.WriteAllTextAsync(claudeMdPath, DefaultClaudeMd);
+                    _logger.LogInformation("[TextRefine] CLAUDE.md を生成: {Path}", claudeMdPath);
+                }
+
+                _initialized = true;
+            }
+            finally
+            {
+                _initLock.Release();
+            }
+        }
+
+        public async Task<string?> RefineAsync(string text, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return text;
+
+            try
+            {
+                await EnsureInitializedAsync();
+
+                var (installed, exePath, _) = TerminalConstants.GetClaudeCodeInstallInfo();
+                if (!installed)
+                {
+                    _logger.LogWarning("[TextRefine] Claude Code CLI が見つかりません: {Path}", exePath);
+                    return null;
+                }
+
+                var psi = new ProcessStartInfo
+                {
+                    FileName = exePath,
+                    WorkingDirectory = _workdir,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    StandardOutputEncoding = Encoding.UTF8,
+                    StandardErrorEncoding = Encoding.UTF8,
+                };
+                // -p: print mode (非対話、stdout に結果を出して終了)
+                // --model: 軽量モデル指定
+                psi.ArgumentList.Add("-p");
+                psi.ArgumentList.Add(text);
+                psi.ArgumentList.Add("--model");
+                psi.ArgumentList.Add("claude-haiku-4-5");
+
+                using var process = new Process { StartInfo = psi };
+                if (!process.Start())
+                {
+                    _logger.LogWarning("[TextRefine] プロセス起動に失敗");
+                    return null;
+                }
+
+                // stdout / stderr を並行読み取り（デッドロック回避）
+                var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+                var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+                // タイムアウト保険 (30秒)
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(TimeSpan.FromSeconds(30));
+                try
+                {
+                    await process.WaitForExitAsync(timeoutCts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    try { process.Kill(entireProcessTree: true); } catch { }
+                    _logger.LogWarning("[TextRefine] タイムアウトで強制終了");
+                    return null;
+                }
+
+                var stdout = await stdoutTask;
+                var stderr = await stderrTask;
+
+                if (process.ExitCode != 0)
+                {
+                    _logger.LogWarning("[TextRefine] 非 0 終了コード: {Code} / stderr: {Err}",
+                        process.ExitCode, stderr);
+                    return null;
+                }
+
+                var result = stdout?.TrimEnd('\r', '\n');
+                return string.IsNullOrEmpty(result) ? null : result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[TextRefine] 整形中にエラー");
+                return null;
+            }
+        }
+
+        private const string DefaultClaudeMd = @"# テキスト整形アシスタント
+
+あなたは日本語テキストを整える専門家です。TerminalHub というツールから事前整形用途で呼び出されています。
+
+## 動作ルール
+
+- 入力されたテキストの**誤字脱字・表現の揺れ**のみを自然に修正してください。
+- **内容や意図は一切変えない**でください。
+- 解説・挨拶・補足・前置きは付けず、**整形後のテキストのみ**を出力してください。
+- ファイル操作やツール使用はしないでください（純粋なテキスト変換のみ）。
+- 入力がすでに正しい場合はそのまま返してください。
+- 出力の末尾に余計な改行や空行を入れないでください。
+
+## 例
+
+入力:
+```
+これはてすとです、うまく動くかな
+```
+
+出力:
+```
+これはテストです。うまく動くかな？
+```
+
+---
+
+※ このファイルは TerminalHub の初回起動時に自動生成されたものです。
+自由に編集して好みの整形ルールにカスタマイズできます。削除すると次回起動時に再生成されます。
+";
+    }
+}


### PR DESCRIPTION
## Summary
テキスト入力を Claude Code CLI (\`-p\` モード、Haiku モデル) で事前整形する実験的機能。設定の「特殊」タブのトグルで有効化する。**デフォルト OFF** なので通常利用には影響しない。

> このPRは #23（音声PTT）をベースにしています。#23 マージ後に自動的に master 向け PR になります。

## 設計

専用ワークディレクトリ \`%LOCALAPPDATA%\TerminalHub\refine-workdir\\` に **整形指示を書いた CLAUDE.md を自動生成** し、そのフォルダから \`claude -p \"<ユーザーテキスト>\"\` を実行する。CLAUDE.md が Claude Code に自動読み込みされ、システムプロンプト的に振る舞う。

これにより:
- C# 側でプロンプトテンプレート管理・エスケープ不要（ユーザーテキストだけ渡す）
- 整形ルールのカスタマイズは CLAUDE.md をユーザーが直接編集するだけ
- 既に CLAUDE.md がある場合は上書きしない（カスタマイズ尊重）

## 追加/変更したファイル

- \`Services/TextRefineService.cs\` 新規
  - \`TerminalConstants.GetClaudeCodeInstallInfo\` で claude 実行ファイルを検出
  - \`Process.Start\` で \`claude -p <text> --model claude-haiku-4-5\` を呼び出し、stdout をキャプチャ
  - 30 秒タイムアウトで \`Kill(entireProcessTree: true)\` 保険
  - ワークディレクトリ初期化は \`SemaphoreSlim\` で並行安全
- \`Models/AppSettings.cs\`: \`SpecialSettings.TextRefineEnabled\` 追加
- \`Program.cs\`: DI 登録
- \`SettingsDialog.razor\`: 特殊タブにトグル + 説明文
- \`Root.razor\`: \`textRefineEnabled\` 状態 + BottomPanel への伝搬
- \`BottomPanel.razor\`: \`TextRefineEnabled\` 伝搬
- \`TextInputPanel.razor\`: **✨ 事前整形ボタン** 追加
  - ボタン並び: モード切替 → カスタムコマンド → マイク → **事前整形** → 送信
  - 実行中はスピナー表示、入力テキストが空のときは無効化

## 既知の制約

- Haiku でも **数秒** かかるため、連打には向かない
- Claude Code CLI がインストールされていない環境では何も起きない（Logger に警告）
- 整形プロンプトのカスタマイズは \`refine-workdir/CLAUDE.md\` を直接編集

## Test plan
- [ ] 設定 > 特殊 > 「事前整形ボタンを有効にする」 ON → 保存
- [ ] テキスト入力欄に ✨ ボタンが表示される（マイクと送信の間）
- [ ] テキスト入力してボタン押下 → スピナー → 整形後のテキストに置換される
- [ ] %LOCALAPPDATA%\TerminalHub\refine-workdir\ に CLAUDE.md が生成される
- [ ] CLAUDE.md を編集して保存 → 次回以降カスタマイズが反映される
- [ ] Claude Code 未インストール環境ではエラーにならず処理スキップ
- [ ] トグル OFF 時はボタン非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)