### PR TITLE
テーマSSR化 + インストーラーの起動モード選択

### DIFF
--- a/TerminalHub/Components/App.razor
+++ b/TerminalHub/Components/App.razor
@@ -1,5 +1,13 @@
-﻿<!DOCTYPE html>
-<html lang="en">
+﻿@inject TerminalHub.Services.IAppSettingsService AppSettingsService
+@{
+    // テーマをサーバーレンダー時点で決定して <html data-bs-theme> に埋め込む。
+    // JS interop 経由で後から当てると、初期レンダリング時に一瞬ライトテーマが
+    // 見えてしまう（フラッシュ）問題を防ぐため。
+    var initialTheme = AppSettingsService.GetSettings().General.Theme;
+    if (string.IsNullOrWhiteSpace(initialTheme)) initialTheme = "dark";
+}
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="@initialTheme">
 
 <head>
     <meta charset="utf-8" />

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -391,12 +391,8 @@
                 terminalHeightPercent = appSettings.General.TerminalHeightPercent;
                 sidebarWidthPercent = appSettings.General.SidebarWidthPercent;
 
-                // テーマを適用
-                var theme = appSettings.General.Theme;
-                if (!string.IsNullOrEmpty(theme))
-                {
-                    await JSRuntime.InvokeVoidAsync("terminalHubHelpers.setTheme", theme);
-                }
+                // テーマは App.razor でサーバーレンダー時に <html data-bs-theme> に
+                // 埋め込み済みのため、ここでは JS での再適用は行わない（フラッシュ防止）。
             }
             catch
             {

--- a/installer/TerminalHub.iss
+++ b/installer/TerminalHub.iss
@@ -69,10 +69,88 @@ Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"; 
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\TerminalHub.bat"; IconFilename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
-; インストール後に起動するオプション
-Filename: "{app}\TerminalHub.bat"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+; Finish ページでの起動は [Code] 内のラジオボタン選択に応じて CurStepChanged(ssDone) で実行する。
+; [Run] の postinstall を使うと標準のチェックボックスUIが出てしまうため、ここには登録しない。
 
 [Code]
+var
+  LaunchLabel: TNewStaticText;
+  LaunchModeNormal: TNewRadioButton;
+  LaunchModeApp: TNewRadioButton;
+  LaunchModeNone: TNewRadioButton;
+
+// Finish ページにラジオボタンを動的に追加する
+procedure CurPageChanged(CurPageID: Integer);
+var
+  BaseLeft, ControlWidth, CurrentTop: Integer;
+begin
+  if CurPageID = wpFinished then
+  begin
+    // 二重生成防止（戻る→進むした場合）
+    if LaunchLabel <> nil then Exit;
+
+    BaseLeft := WizardForm.RunList.Left;
+    ControlWidth := WizardForm.FinishedPage.ClientWidth - BaseLeft;
+    CurrentTop := WizardForm.RunList.Top;
+
+    LaunchLabel := TNewStaticText.Create(WizardForm);
+    LaunchLabel.Parent := WizardForm.FinishedPage;
+    LaunchLabel.Left := BaseLeft;
+    LaunchLabel.Top := CurrentTop;
+    LaunchLabel.Width := ControlWidth;
+    LaunchLabel.Caption := '起動モード:';
+    CurrentTop := CurrentTop + LaunchLabel.Height + ScaleY(6);
+
+    LaunchModeApp := TNewRadioButton.Create(WizardForm);
+    LaunchModeApp.Parent := WizardForm.FinishedPage;
+    LaunchModeApp.Left := BaseLeft + ScaleX(8);
+    LaunchModeApp.Top := CurrentTop;
+    LaunchModeApp.Width := ControlWidth - ScaleX(8);
+    LaunchModeApp.Caption := 'アプリモード（Chrome アプリウィンドウで起動）';
+    LaunchModeApp.Checked := True;
+    CurrentTop := CurrentTop + LaunchModeApp.Height + ScaleY(4);
+
+    LaunchModeNormal := TNewRadioButton.Create(WizardForm);
+    LaunchModeNormal.Parent := WizardForm.FinishedPage;
+    LaunchModeNormal.Left := LaunchModeApp.Left;
+    LaunchModeNormal.Top := CurrentTop;
+    LaunchModeNormal.Width := LaunchModeApp.Width;
+    LaunchModeNormal.Caption := '通常モード（デフォルトブラウザで起動）';
+    CurrentTop := CurrentTop + LaunchModeNormal.Height + ScaleY(4);
+
+    LaunchModeNone := TNewRadioButton.Create(WizardForm);
+    LaunchModeNone.Parent := WizardForm.FinishedPage;
+    LaunchModeNone.Left := LaunchModeApp.Left;
+    LaunchModeNone.Top := CurrentTop;
+    LaunchModeNone.Width := LaunchModeApp.Width;
+    LaunchModeNone.Caption := '起動しない';
+  end;
+end;
+
+// インストール完了時、選択したモードで起動する
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  ResultCode: Integer;
+begin
+  if CurStep = ssDone then
+  begin
+    // ラジオボタン未生成（サイレントインストール等）の場合はスキップ
+    if LaunchModeApp = nil then Exit;
+
+    if LaunchModeApp.Checked then
+    begin
+      Exec(ExpandConstant('{app}\TerminalHub-App.bat'), '', ExpandConstant('{app}'),
+           SW_SHOWNORMAL, ewNoWait, ResultCode);
+    end
+    else if LaunchModeNormal.Checked then
+    begin
+      Exec(ExpandConstant('{app}\TerminalHub.bat'), '', ExpandConstant('{app}'),
+           SW_SHOWNORMAL, ewNoWait, ResultCode);
+    end;
+    // LaunchModeNone: 起動しない（何もしない）
+  end;
+end;
+
 // アンインストール時にプロセスが実行中かチェック
 function InitializeUninstall(): Boolean;
 var


### PR DESCRIPTION
## Summary
2つの独立した改善を1つのPRに。

### 1. テーマの初期レンダリングフラッシュを解消
これまで \`app-settings.json\` のテーマは JS interop で後付けしていたため、初期表示〜interop 完了の間に一瞬ライトテーマが見えるフラッシュが発生していた。

\`App.razor\` でサーバーレンダー時に \`IAppSettingsService\` からテーマを読み、\`<html data-bs-theme=\"@initialTheme\">\` として埋め込む形に変更。ブラウザが HTML を受信した瞬間から正しいテーマが当たり、**フラッシュが発生しなくなる**。

- 設定変更時の \`HandleThemeChanged\` は JS interop のまま（\`<html>\` 要素はランタイムで書き換える必要があるため）
- デフォルトが dark に変わった時に顕在化していた UX 問題の解消

### 2. インストーラー Finish ページに起動モード選択を追加
インストール完了画面で起動モードをラジオボタンで選択可能に。

\`\`\`
起動モード:
 (•) アプリモード（Chrome アプリウィンドウで起動） ← デフォルト
 ( ) 通常モード（デフォルトブラウザで起動）
 ( ) 起動しない
\`\`\`

\`[Code]\` セクションで \`CurPageChanged(wpFinished)\` 時に \`TNewStaticText\` + \`TNewRadioButton\` を動的生成。\`CurStepChanged(ssDone)\` で選択に応じて \`TerminalHub.bat\` または \`TerminalHub-App.bat\` を実行。

スタートメニューには従来通り両方のショートカットが作られるので、後から別モードで起動することも可能。

## Test plan
- [ ] ブラウザで起動して、フラッシュなく最初からダークテーマで表示される
- [ ] 設定画面でテーマを切り替えると即座に反映される（従来通り）
- [ ] インストーラーの Finish ページに3つのラジオボタンが表示される
- [ ] 各モードを選んで「完了」押下で期待通り起動する（or 起動しない）
- [ ] サイレントインストールで ssDone がクラッシュしない

🤖 Generated with [Claude Code](https://claude.com/claude-code)