### PR TITLE
feat: カスタムコマンドのキー送信に Alt+T を追加

### DIFF
--- a/TerminalHub/Models/KeySequencePresets.cs
+++ b/TerminalHub/Models/KeySequencePresets.cs
@@ -32,6 +32,7 @@ namespace TerminalHub.Models
             new KeyValuePair<string, Preset>("Home",       new("Home",          "\x1b[H")),
             new KeyValuePair<string, Preset>("End",        new("End",           "\x1b[F")),
             new KeyValuePair<string, Preset>("AltM",       new("Alt+M",         "\x1Bm")),
+            new KeyValuePair<string, Preset>("AltT",       new("Alt+T",         "\x1Bt")),
         };
 
         // O(1) ルックアップ用の内部辞書 (All から自動生成されるので順序依存しない)


### PR DESCRIPTION
## Summary
KeySequencePresets に **Alt+T** (\`\x1Bt\`) を追加。Alt+M と同じく ESC + 文字 のエスケープシーケンス形式。

Shift+Tab は既にプリセット登録済み (\`\"ShiftTab\"\` = \`\x1b[Z\`) のため追加不要。

## Test plan
- [ ] 設定 → コマンド → キー送信タイプで \"Alt+T\" が選択肢に出る
- [ ] Alt+T を登録したボタンを押すと、ターミナルに \`ESC t\` が送信される

🤖 Generated with [Claude Code](https://claude.com/claude-code)