### PR TITLE
fix: 廃止された設定値を読み込み時に正規化

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -379,7 +379,15 @@
             try
             {
                 var appSettings = AppSettingsService.GetSettings();
-                claudeModeSwitchKey = appSettings.Special.ClaudeModeSwitchKey;
+                // 過去バージョンで "plan" 等の廃止値が保存されている可能性があるため、
+                // 現在の UI とランタイムが扱える値に正規化する。
+                // 不明値をそのままにしておくと TextInputPanel が Alt+M ラベルの
+                // ボタンを表示するが実際は押しても何も起きない、という UI 不整合が発生する。
+                claudeModeSwitchKey = appSettings.Special.ClaudeModeSwitchKey switch
+                {
+                    "altM" or "shiftTab" or "none" => appSettings.Special.ClaudeModeSwitchKey,
+                    _ => "none"
+                };
                 voiceInputEnabled = appSettings.Special.VoiceInputEnabled;
                 textRefineEnabled = appSettings.Special.TextRefineEnabled;
                 sessionSortMode = appSettings.Sessions.SortMode;

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -1094,12 +1094,23 @@
             claudeHookEnabled = settings.ClaudeHook.Enabled;
 
             // 特殊設定
-            claudeModeSwitchKey = settings.Special.ClaudeModeSwitchKey;
+            // ClaudeModeSwitchKey は過去バージョンで "plan" 等の廃止された値が
+            // 保存されている可能性があるため、現在の UI が扱える値にフォールバックする。
+            claudeModeSwitchKey = settings.Special.ClaudeModeSwitchKey switch
+            {
+                "altM" or "shiftTab" or "none" => settings.Special.ClaudeModeSwitchKey,
+                _ => "none"
+            };
             voiceInputEnabled = settings.Special.VoiceInputEnabled;
             textRefineEnabled = settings.Special.TextRefineEnabled;
 
             // セッション表示設定
-            sessionSortMode = settings.Sessions.SortMode;
+            // 未知の SortMode 値は lastAccessed にフォールバック（UI ラジオの未選択状態を防ぐ）
+            sessionSortMode = settings.Sessions.SortMode switch
+            {
+                "createdAt" or "lastAccessed" or "name" => settings.Sessions.SortMode,
+                _ => "lastAccessed"
+            };
             showTerminalType = settings.Sessions.ShowTerminalType;
             showGitInfo = settings.Sessions.ShowGitInfo;
             hideInputPanel = settings.Sessions.HideInputPanel;


### PR DESCRIPTION
## Summary
過去バージョンで \`ClaudeModeSwitchKey\` に \"plan\" が選択肢として存在し、それを選んでいたユーザーの \`app-settings.json\` には \"plan\" が保存されたまま残っている。現行 UI では \"plan\" は削除済みで、以下の不整合が発生していた。

## 症状

- **設定ダイアログ**: 「Claude Code モード切替キー」のラジオが**どれも選択されていない状態**になる
- **TextInputPanel**: \`ClaudeModeSwitchKey != \"none\"\` の条件で「Alt+M」ラベルのボタンが表示されるが、\`SendModeSwitch\` は \"plan\" にマッチしないため**押しても何も起きない**

## 対策

読み込み時に不明値を正規化する。

- **\`SettingsDialog.razor\`**: \`ClaudeModeSwitchKey\` が \`altM/shiftTab/none\` 以外なら \`none\` にフォールバック。併せて \`SortMode\` も \`createdAt/lastAccessed/name\` 以外は \`lastAccessed\` にフォールバック（ラジオの未選択防止）
- **\`Root.razor\`**: 初期ロード時にも同じ正規化を適用。設定ダイアログを開かなくても UI が一貫するようにする

保存ファイルは次回設定保存時に自動で正規化された値で上書きされる。

## Test plan
- [ ] \`app-settings.json\` の \`Special.ClaudeModeSwitchKey\` を手動で \"plan\" に書き換えて起動 → 「無し」として扱われる
- [ ] TextInputPanel にモード切替ボタンが表示されない
- [ ] 設定ダイアログを開くと「無し」ラジオが選択されている
- [ ] そのまま保存 → ファイル内の値が \"none\" になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)