### PR TITLE
chore: MQTT接続時の診断ログを強化

### DIFF
--- a/TerminalHub/Services/MqttService.cs
+++ b/TerminalHub/Services/MqttService.cs
@@ -88,9 +88,10 @@ public class MqttService : IHostedService, IDisposable
         var mqttUsername = _configuration.GetValue<string>("Mqtt:Username");
         var mqttPassword = _configuration.GetValue<string>("Mqtt:Password");
 
+        var clientId = $"terminalhub-{topicGuid[..8]}";
         var optionsBuilder = new MqttClientOptionsBuilder()
             .WithTcpServer(mqttHost, mqttPort)
-            .WithClientId($"terminalhub-{topicGuid[..8]}")
+            .WithClientId(clientId)
             .WithCleanSession(true);
 
         if (!string.IsNullOrEmpty(mqttUsername))
@@ -103,18 +104,35 @@ public class MqttService : IHostedService, IDisposable
         _mqttClient.ApplicationMessageReceivedAsync += OnMessageReceivedAsync;
         _mqttClient.DisconnectedAsync += OnDisconnectedAsync;
 
+        _logger.LogInformation("[MQTT] 接続試行: {Host}:{Port}, ClientId={ClientId}, HasCredentials={HasCredentials}",
+            mqttHost, mqttPort, clientId, !string.IsNullOrEmpty(mqttUsername));
+
         try
         {
-            await _mqttClient.ConnectAsync(options, cancellationToken);
-            _logger.LogInformation("[MQTT] ブローカーに接続: {Host}:{Port}", mqttHost, mqttPort);
+            var connectResult = await _mqttClient.ConnectAsync(options, cancellationToken);
+            _logger.LogInformation(
+                "[MQTT] ConnectAsync戻り: ResultCode={ResultCode}, ReasonString={ReasonString}, AssignedClientId={AssignedClientId}, IsSessionPresent={IsSessionPresent}, IsConnected={IsConnected}",
+                connectResult?.ResultCode, connectResult?.ReasonString, connectResult?.AssignedClientIdentifier, connectResult?.IsSessionPresent, _mqttClient.IsConnected);
+
+            if (!_mqttClient.IsConnected)
+            {
+                _logger.LogError("[MQTT] Connect直後にIsConnected=false。ClientId重複で別クライアントに蹴られた可能性が高い (ClientId={ClientId})", clientId);
+                return;
+            }
 
             var requestTopic = $"{MqttConstants.TopicPrefix}/{topicGuid}/request";
-            await _mqttClient.SubscribeAsync(requestTopic, MqttQualityOfServiceLevel.AtLeastOnce, cancellationToken);
-            _logger.LogInformation("[MQTT] トピック購読完了");
+            var subResult = await _mqttClient.SubscribeAsync(requestTopic, MqttQualityOfServiceLevel.AtLeastOnce, cancellationToken);
+            foreach (var item in subResult.Items)
+            {
+                _logger.LogInformation("[MQTT] SUBACK: Topic={Topic}, ResultCode={ResultCode}",
+                    item.TopicFilter.Topic, item.ResultCode);
+            }
+            _logger.LogInformation("[MQTT] トピック購読完了: {Topic}", requestTopic);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[MQTT] 接続失敗");
+            _logger.LogError(ex, "[MQTT] 接続失敗 (Host={Host}:{Port}, ClientId={ClientId}, IsConnected={IsConnected})",
+                mqttHost, mqttPort, clientId, _mqttClient?.IsConnected);
         }
     }
 
@@ -141,6 +159,11 @@ public class MqttService : IHostedService, IDisposable
 
     private async Task OnDisconnectedAsync(MqttClientDisconnectedEventArgs e)
     {
+        _logger.LogWarning(
+            "[MQTT] 切断検知: Reason={Reason}, ReasonString={ReasonString}, ClientWasConnected={ClientWasConnected}, Intentional={Intentional}, ConnectResultCode={ConnectResultCode}, Exception={ExceptionType}/{ExceptionMessage}",
+            e.Reason, e.ReasonString, e.ClientWasConnected, _intentionalDisconnect,
+            e.ConnectResult?.ResultCode, e.Exception?.GetType().Name, e.Exception?.Message);
+
         if (!e.ClientWasConnected || _intentionalDisconnect) return;
 
         _sessionKey = null;
@@ -179,15 +202,25 @@ public class MqttService : IHostedService, IDisposable
 
             try
             {
-                await _mqttClient!.ConnectAsync(options);
+                var connectResult = await _mqttClient!.ConnectAsync(options);
+                _logger.LogInformation(
+                    "[MQTT] リトライConnectAsync戻り: ResultCode={ResultCode}, ReasonString={ReasonString}, IsConnected={IsConnected}",
+                    connectResult?.ResultCode, connectResult?.ReasonString, _mqttClient.IsConnected);
+
+                if (!_mqttClient.IsConnected)
+                {
+                    _logger.LogWarning("[MQTT] リトライ Connect直後に IsConnected=false ({Attempt}/{Max})", i + 1, delays.Length);
+                    continue;
+                }
+
                 await _mqttClient.SubscribeAsync(requestTopic, MqttQualityOfServiceLevel.AtLeastOnce);
                 _logger.LogInformation("[MQTT] 再接続成功 (リトライ {Attempt}回目)", i + 1);
                 return;
             }
             catch (Exception ex)
             {
-                _logger.LogWarning("[MQTT] リトライ失敗 ({Attempt}/{Max}): {Message}",
-                    i + 1, delays.Length, ex.Message);
+                _logger.LogWarning(ex, "[MQTT] リトライ失敗 ({Attempt}/{Max}): {ExceptionType}/{Message}",
+                    i + 1, delays.Length, ex.GetType().Name, ex.Message);
             }
         }
 

--- a/TerminalHub/Services/MqttService.cs
+++ b/TerminalHub/Services/MqttService.cs
@@ -116,7 +116,9 @@ public class MqttService : IHostedService, IDisposable
 
             if (!_mqttClient.IsConnected)
             {
-                _logger.LogError("[MQTT] Connect直後にIsConnected=false。ClientId重複で別クライアントに蹴られた可能性が高い (ClientId={ClientId})", clientId);
+                _logger.LogError(
+                    "[MQTT] Connect直後にIsConnected=false。ResultCode={ResultCode} を確認 (NotAuthorized=認証失敗、ClientId重複で蹴られた場合は NormalDisconnection 等) (ClientId={ClientId})",
+                    connectResult?.ResultCode, clientId);
                 return;
             }
 


### PR DESCRIPTION
## Summary
MQTT接続失敗時の原因特定を容易にするため、診断ログを強化。

## 背景
本日、インストール版TerminalHubでMQTT接続が繰り返し失敗する事象が発生。旧コードのログでは以下のみで原因特定が困難だった:

```
[MQTT] ブローカーに接続: vps3.zio3.net:1883
[MQTT] 接続失敗
MqttClientNotConnectedException: The MQTT client is not connected.
```

ConnectAsync は例外を吐かずに戻るのに、直後の SubscribeAsync で `NotConnected` 例外が発生するパターンで、何が起きているか分からない状態だった。

## 変更内容
- **接続試行時**: Host/Port/ClientId/資格情報の有無をログ出力
- **ConnectAsync戻り値**: ResultCode, ReasonString, AssignedClientId, IsSessionPresent, IsConnected を出力
- **IsConnected=false検出**: Subscribe する前に早期 return + 警告ログ (ClientId衝突可能性を明示)
- **SUBACK**: トピック別の購読結果コードを出力
- **切断検知 (OnDisconnectedAsync)**: Reason, ReasonString, ClientWasConnected, ConnectResultCode, 例外情報を出力
- **リトライ時**: 同様の詳細ログを追加

## 効果
今回、このログ強化により `ResultCode=NotAuthorized` かつ `HasCredentials=False` が即座に見え、「ローカルビルドのインストーラーにはMQTT資格情報が注入されていない」という根本原因を特定できた。

## Test plan
- [ ] MQTT接続に成功するケース: 詳細ログが出力される
- [ ] 認証失敗ケース: ResultCode=NotAuthorized が記録される
- [ ] 切断ケース: Reason や例外情報が記録される

🤖 Generated with [Claude Code](https://claude.com/claude-code)