### PR TITLE
chore: Pages デプロイを Actions 化して paths フィルタを適用

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy Pages
+
+# docs/ 配下が変更されたときのみ GitHub Pages をデプロイする。
+# これまで legacy モード (リポジトリ設定から /docs を自動配信) で
+# master への push のたびにデプロイが走っていたのを、paths フィルタで制御する。
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
GitHub Pages が legacy モード (branch 設定 /docs から自動配信) で、master への全 push でデプロイが走っていた。paths フィルタ付き Actions workflow に切り替え、docs 配下の変更時のみデプロイする。

## 現状
- Pages Source: \`Deploy from a branch\` (master /docs)
- 毎回 GitHub が \"pages build and deployment\" を dynamic 実行
- 本日 PR #28/#29/#30 マージで 3回走った

## 変更内容
\`.github/workflows/deploy-pages.yml\` 追加:
- trigger: push on master, paths: \`docs/**\`
- \`workflow_dispatch\` で手動実行も可
- 標準の Actions Pages フロー (configure-pages → upload-pages-artifact → deploy-pages)

## マージ後の必須手動作業
**リポジトリ設定変更が必要:**
1. Settings → Pages → Build and deployment
2. Source を \`Deploy from a branch\` から \`GitHub Actions\` に変更

これを行うまでは workflow が deploy-pages@v4 ステップで失敗します (legacy と Actions は排他)。切替後は legacy 自動デプロイが停止し、paths フィルタが有効になります。

## Test plan
- [ ] マージ後、Pages Source を \`GitHub Actions\` に切替
- [ ] workflow_dispatch で初回デプロイを手動実行し成功すること
- [ ] \`zio3.github.io/TerminalHub/landing/\` が従来どおり配信されていること
- [ ] docs 以外のファイル (例: TerminalHub/*.cs) のみ変更した PR をマージ → pages workflow が走らないこと
- [ ] docs/landing/index.html を変更した PR をマージ → pages workflow が走ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)