### PR TITLE
fix: Codex CLI のresumeオプションをresume --last に戻す

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -261,9 +261,9 @@
             }
 
             <div class="form-check mt-3">
-                <input class="form-check-input" type="checkbox" @bind="CodexOptions.ResumePicker" id="@($"codexResumePicker{UniqueId}")">
-                <label class="form-check-label" for="@($"codexResumePicker{UniqueId}")">
-                    再開するセッションを選択 (resume)
+                <input class="form-check-input" type="checkbox" @bind="CodexOptions.ResumeLast" id="@($"codexResumeLast{UniqueId}")">
+                <label class="form-check-label" for="@($"codexResumeLast{UniqueId}")">
+                    最新セッションを再開 (resume --last)
                 </label>
             </div>
 
@@ -556,9 +556,9 @@
 
             case TerminalType.CodexCLI:
                 options["mode"] = CodexOptions.Mode;
-                if (CodexOptions.ResumePicker)
+                if (CodexOptions.ResumeLast)
                 {
-                    options["resume-picker"] = "true";
+                    options["resume-last"] = "true";
                 }
                 if (!string.IsNullOrWhiteSpace(CodexOptions.SandboxMode))
                 {
@@ -619,7 +619,7 @@
     public class CodexOptionsData
     {
         public string Mode { get; set; } = "auto"; // auto, standard, yolo
-        public bool ResumePicker { get; set; } = false;
+        public bool ResumeLast { get; set; } = false;
         public string SandboxMode { get; set; } = ""; // "", read-only, workspace-write, danger-full-access
         public string ApprovalPolicy { get; set; } = "";
         public string NetworkAccess { get; set; } = "";

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -228,8 +228,8 @@
                 codexOptions = new SessionOptionsSelector.CodexOptionsData
                 {
                     Mode = options.ContainsKey("mode") ? options["mode"] : "auto",
-                    ResumePicker = (options.ContainsKey("resume-picker") && options["resume-picker"] == "true")
-                        || (options.ContainsKey("resume-last") && options["resume-last"] == "true"),
+                    ResumeLast = (options.ContainsKey("resume-last") && options["resume-last"] == "true")
+                        || (options.ContainsKey("resume-picker") && options["resume-picker"] == "true"),
                     SandboxMode = options.ContainsKey("sandbox-mode") ? options["sandbox-mode"] : "",
                     ApprovalPolicy = options.ContainsKey("ask-for-approval") ? options["ask-for-approval"] : "",
                     NetworkAccess = options.ContainsKey("network-access") ? options["network-access"] : "",

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -151,10 +151,9 @@ namespace TerminalHub.Constants
                 args.Add($"--model {model.Trim()}");
             }
 
-            if ((options.ContainsKey("resume-picker") && options["resume-picker"] == "true")
-                || (options.ContainsKey("resume-last") && options["resume-last"] == "true"))
+            if (options.ContainsKey("resume-last") && options["resume-last"] == "true")
             {
-                args.Add("resume");
+                args.Add("resume --last");
             }
 
             if (options.ContainsKey("search") && options["search"] == "true")


### PR DESCRIPTION
## Summary
Codex CLI 本家の resume --last バグが修正されたため、以前fallback として使っていた対話的 resume (picker) を本来意図していた resume --last 動作に戻す。

## 経緯
- 当初 resume --last を使用する予定だったが Codex 本家にバグがあり機能しなかった
- Issue 提出済み、本家で修正された
- その間の一時策として対話的 resume (picker) を使っていた
- 本 PR で本来意図していた動作に戻す

## 変更内容
| 箇所 | 旧 | 新 |
|---|---|---|
| オプションキー | \`resume-picker\` | \`resume-last\` |
| フィールド名 | \`ResumePicker\` | \`ResumeLast\` |
| UI ラベル | 再開するセッションを選択 (resume) | 最新セッションを再開 (resume --last) |
| CLI 引数 | \`resume\` | \`resume --last\` |

## 後方互換
SessionSettingsDialog.razor の読み込み時に旧 \`resume-picker\` キーも受けて新フィールドに移行する。既存のセッション設定を開いて保存し直せば新キーに移行完了。

設定ダイアログを開かずに直接起動する場合のみ、旧キーの session は resume が効かなくなるが、そもそも旧 resume (picker) も workaround だったので意図した動作とは異なる状態。

## Test plan
- [ ] 新規セッションで「最新セッションを再開」を ON → 起動時に \`codex resume --last\` が呼ばれる
- [ ] 旧キー \`resume-picker: true\` で保存済みの session を設定ダイアログで開く → 自動的にチェック ON になる
- [ ] 設定を保存し直すと \`resume-last: true\` に移行される

🤖 Generated with [Claude Code](https://claude.com/claude-code)