### PR TITLE
fix: メモ編集中に再描画が連鎖すると入力が戻される問題を修正

### DIFF
--- a/TerminalHub/Components/Shared/BottomPanels/MemoPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/MemoPanel.razor
@@ -19,13 +19,16 @@
     // デバウンス間隔 (ms)。短すぎると毎入力で I/O が走る、長すぎるとアプリ終了時の消失リスクが増える。
     private const int DebounceMs = 1000;
 
+    // 編集中は _pendingBody を優先的に返す。親のステータス更新等で
+    // 再描画が連鎖したときに親の古い Body が textarea に書き戻されて
+    // 入力が消える/荒ぶる現象を防ぐための「local-wins」戦略。
     private string bodyText
     {
-        get => Body;
+        get => _pendingBody ?? Body;
         set
         {
-            if (Body == value) return;
-            Body = value;
+            var current = _pendingBody ?? Body;
+            if (current == value) return;
             ScheduleFlush(value);
         }
     }
@@ -43,6 +46,12 @@
         }
         _lastMemoId = MemoId;
     }
+
+    // 編集中 (debounce 保留あり) は親の再描画に追従しない。
+    // SetParametersAsync は呼ばれるが DOM を書き換えない → textarea の入力値が維持される。
+    // MemoId 切替時は OnParametersSet で _pendingBody がフラッシュ/クリアされるので、
+    // 本メソッドは次回の再描画で true を返し、新しい Body が正しく表示される。
+    protected override bool ShouldRender() => _pendingBody == null;
 
     private void ScheduleFlush(string value)
     {


### PR DESCRIPTION
## Summary
メモを編集中に Claude Code のステータス変更等で親コンポーネントの StateHasChanged が連鎖すると、textarea の入力が親の古い Body 値で上書きされて「入力が戻る/荒ぶる」現象が発生していた。TextInputPanel は過去対策済みだが、MemoPanel は未対策だった。

## 原因
\`MemoPanel.razor\` の textarea は \`@bind="bodyText"\` で Body パラメータに直接紐付いており、\`bodyText\` getter が常に親の \`Body\` を返していた。

### race condition
1. ユーザー入力 (T=0ms) → \`_pendingBody\` に保留、1秒後にデバウンスで保存
2. T=500ms: OutputAnalyzerService がステータス変更を検知
3. Root → BottomPanel → MemoPanel に再描画が連鎖
4. Blazor が \`SetParametersAsync\` で \`Body\` に **親の古い保存済み値** を再設定
5. getter が古い \`Body\` を返し、textarea が上書き → 入力消失

## 対応: local-wins 戦略

\`\`\`csharp
private string bodyText
{
    get => _pendingBody ?? Body;  // 保留中はローカル値優先
    set
    {
        var current = _pendingBody ?? Body;
        if (current == value) return;
        ScheduleFlush(value);
    }
}

protected override bool ShouldRender() => _pendingBody == null;
\`\`\`

- 編集保留中は textarea の表示もローカルの最新値を維持
- \`ShouldRender\` で無駄な DOM 書き換えも抑止
- MemoId 切替時は \`OnParametersSet\` で \`_pendingBody\` がフラッシュ/クリアされ、次回の再描画で新タブの内容が正しく表示される

## 副次効果
- 外部からメモが同時編集された場合はローカル編集が優先 (last-write-wins、合理的)
- ステータス変更が多い環境で textarea の無駄な再描画を抑止

## Test plan
- [ ] メモ編集中に Claude Code が実行中 (ステータス頻繁変更) の状態で、入力が戻らず継続できること
- [ ] 編集中に 1 秒経過後、自動保存されていること
- [ ] メモタブを別のメモに切り替え → 元のメモの未保存変更が flush される (既存挙動維持)
- [ ] メモタブを閉じる/開き直す → 保存済みの内容が正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)