### PR TITLE
docs: ランディングページ見出しを「主な機能」→「主な特徴」に変更

### DIFF
--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -162,7 +162,7 @@
     <!-- Features Section -->
     <section class="features-section">
         <div class="container">
-            <h2 class="section-title text-center">主な機能</h2>
+            <h2 class="section-title text-center">主な特徴</h2>
             <p class="section-description text-center text-muted">クリックするとスクリーンショットを表示します</p>
             <div class="row g-4 mt-3 justify-content-center">
                 <div class="col-md-4">


### PR DESCRIPTION
## Summary
主な機能セクションに差別化要素 (日本語入力のストレス解消等) が含まれるようになったことを受け、見出しを「主な機能」→「主な特徴」に変更。

## 意図
- 「主な機能」は機能列挙の印象で、他製品にもある一般的なラインナップに読める
- セクション内容が **製品を選ぶ理由・他と違う部分** に寄ったため「特徴」のほうが枠に合う
- Hero で差別化 (AI CLI 特化・切り替えコストゼロ) を前面に押し出した流れと一貫させる

## 変更
\`docs/landing/index.html\` の \`<h2>\` のみ、1文字差。

🤖 Generated with [Claude Code](https://claude.com/claude-code)