### PR TITLE
feat: メモの論理削除と復元UI を追加 (Phase 1)

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -59,7 +59,8 @@
                        SessionId="@settingsSessionId"
                        OnSettingsSaved="OnSessionSettingsSaved"
                        OnCancel="() => showSessionSettingsDialog = false"
-                       OnCreateSubSession="HandleCreateSubSessionFromSettings" />
+                       OnCreateSubSession="HandleCreateSubSessionFromSettings"
+                       OnMemoRestored="HandleMemoRestoredFromSettings" />
 <ArchivedSessionsDialog IsVisible="showArchivedSessionsDialog"
                         ArchivedSessions="@GetArchivedSessions()"
                         OnRestoreSession="RestoreArchivedSession"
@@ -2096,6 +2097,16 @@
         showSessionSettingsDialog = false;
         // サブセッションダイアログを表示
         ShowWorktreeDialog(sessionId);
+    }
+
+    private async Task HandleMemoRestoredFromSettings()
+    {
+        // メモ管理ダイアログで論理削除済みメモが復元されたときに BottomPanel を再読み込みさせる。
+        // これで復元メモが新タブとして現れる。
+        if (bottomPanel != null)
+        {
+            await bottomPanel.ReloadMemosForCurrentSessionAsync();
+        }
     }
 
     private async Task OnSessionSettingsSaved()

--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -220,6 +220,18 @@
         }
     }
 
+    /// <summary>
+    /// メモ管理ダイアログ側で復元操作が行われた場合など、外部から明示的にメモ一覧を
+    /// 再読み込みしたいときに呼ぶ。対象セッションのロード済みフラグを落としてから
+    /// 読み直すので、復元されたメモが新しいタブとして現れる。
+    /// </summary>
+    public async Task ReloadMemosForCurrentSessionAsync()
+    {
+        if (!CurrentSessionId.HasValue) return;
+        loadedMemoSessions.Remove(CurrentSessionId.Value);
+        await LoadMemoTabsForSessionAsync(CurrentSessionId.Value);
+    }
+
     private void AddTab(BottomPanelTabType type)
     {
         var count = Tabs.Count(t => t.Type == type);

--- a/TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor
@@ -1,0 +1,261 @@
+@using TerminalHub.Models
+@using TerminalHub.Services
+@inject ISessionMemoRepository MemoRepository
+@inject ILogger<MemoManagementDialog> Logger
+
+<div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">
+                    <i class="bi bi-journal-text me-2"></i>メモ管理
+                </h5>
+                <button type="button" class="btn-close" @onclick="HandleClose"></button>
+            </div>
+            <div class="modal-body">
+                @if (isLoading)
+                {
+                    <div class="text-center py-4">
+                        <span class="spinner-border spinner-border-sm" role="status"></span>
+                        読み込み中...
+                    </div>
+                }
+                else
+                {
+                    <!-- 削除済みメモ -->
+                    <div class="mb-4">
+                        <h6 class="text-muted">
+                            <i class="bi bi-trash me-1"></i>削除済みメモ
+                            <span class="badge bg-secondary ms-2">@deletedMemos.Count</span>
+                        </h6>
+                        @if (deletedMemos.Count == 0)
+                        {
+                            <p class="text-muted small mb-0">削除済みのメモはありません。</p>
+                        }
+                        else
+                        {
+                            <div class="list-group">
+                                @foreach (var memo in deletedMemos)
+                                {
+                                    <div class="list-group-item">
+                                        <div class="d-flex justify-content-between align-items-start gap-2">
+                                            <div class="flex-grow-1 min-width-0">
+                                                <div class="fw-bold text-truncate">@(string.IsNullOrWhiteSpace(memo.Title) ? "(無題)" : memo.Title)</div>
+                                                <small class="text-muted">
+                                                    削除日時: @(memo.DeletedAt?.ToString("yyyy-MM-dd HH:mm:ss") ?? "-")
+                                                </small>
+                                                <div class="small text-muted mt-1" style="white-space: pre-wrap; word-break: break-all; max-height: 4.5em; overflow: hidden;">
+                                                    @(GetPreview(memo.Body))
+                                                </div>
+                                            </div>
+                                            <div class="d-flex flex-column gap-1 flex-shrink-0">
+                                                <button type="button" class="btn btn-outline-success btn-sm"
+                                                        @onclick="() => HandleRestore(memo.MemoId)"
+                                                        disabled="@isBusy">
+                                                    <i class="bi bi-arrow-counterclockwise me-1"></i>復元
+                                                </button>
+                                                <button type="button" class="btn btn-outline-danger btn-sm"
+                                                        @onclick="() => HandleHardDelete(memo)"
+                                                        disabled="@isBusy">
+                                                    <i class="bi bi-x-lg me-1"></i>完全削除
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </div>
+
+                    <!-- アクティブなメモ (参考情報) -->
+                    <div>
+                        <h6 class="text-muted">
+                            <i class="bi bi-journal-text me-1"></i>現在のメモ
+                            <span class="badge bg-secondary ms-2">@activeMemos.Count</span>
+                        </h6>
+                        @if (activeMemos.Count == 0)
+                        {
+                            <p class="text-muted small mb-0">現在、有効なメモはありません。</p>
+                        }
+                        else
+                        {
+                            <div class="list-group">
+                                @foreach (var memo in activeMemos)
+                                {
+                                    <div class="list-group-item">
+                                        <div class="fw-bold text-truncate">@(string.IsNullOrWhiteSpace(memo.Title) ? "(無題)" : memo.Title)</div>
+                                        <small class="text-muted">
+                                            更新日時: @memo.UpdatedAt.ToString("yyyy-MM-dd HH:mm:ss")
+                                        </small>
+                                        <div class="small text-muted mt-1" style="white-space: pre-wrap; word-break: break-all; max-height: 4.5em; overflow: hidden;">
+                                            @(GetPreview(memo.Body))
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </div>
+
+                    @if (!string.IsNullOrEmpty(statusMessage))
+                    {
+                        <div class="alert @(statusIsError ? "alert-danger" : "alert-success") mt-3 mb-0 py-2">
+                            @statusMessage
+                        </div>
+                    }
+                }
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" @onclick="HandleClose">閉じる</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (hardDeleteConfirmTarget != null)
+{
+    <div class="modal fade show" tabindex="-1" style="display: block; background-color: var(--th-surface-overlay); z-index: 1060;">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title"><i class="bi bi-exclamation-triangle text-warning me-2"></i>完全削除の確認</h5>
+                    <button type="button" class="btn-close" @onclick="() => hardDeleteConfirmTarget = null"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-2">以下のメモを <strong>完全に削除</strong> します。この操作は取り消せません。</p>
+                    <div class="border rounded p-2 small bg-body-tertiary">
+                        <div class="fw-bold">@(string.IsNullOrWhiteSpace(hardDeleteConfirmTarget.Title) ? "(無題)" : hardDeleteConfirmTarget.Title)</div>
+                        <div class="text-muted">削除日時: @(hardDeleteConfirmTarget.DeletedAt?.ToString("yyyy-MM-dd HH:mm:ss") ?? "-")</div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="() => hardDeleteConfirmTarget = null">キャンセル</button>
+                    <button type="button" class="btn btn-danger" @onclick="ConfirmHardDelete" disabled="@isBusy">
+                        <i class="bi bi-x-lg me-1"></i>完全に削除
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public Guid? SessionId { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+    [Parameter] public EventCallback OnMemoRestored { get; set; }
+
+    private List<SessionMemo> deletedMemos = new();
+    private List<SessionMemo> activeMemos = new();
+    private bool isLoading = false;
+    private bool isBusy = false;
+    private string statusMessage = "";
+    private bool statusIsError = false;
+    private SessionMemo? hardDeleteConfirmTarget;
+
+    private Guid? _loadedSessionId;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (IsVisible && SessionId.HasValue && _loadedSessionId != SessionId)
+        {
+            await ReloadAsync();
+            _loadedSessionId = SessionId;
+        }
+        else if (!IsVisible)
+        {
+            _loadedSessionId = null;
+        }
+    }
+
+    private async Task ReloadAsync()
+    {
+        if (!SessionId.HasValue) return;
+
+        isLoading = true;
+        statusMessage = "";
+        StateHasChanged();
+        try
+        {
+            deletedMemos = await MemoRepository.GetDeletedBySessionAsync(SessionId.Value);
+            activeMemos = await MemoRepository.GetBySessionAsync(SessionId.Value);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[MemoManagementDialog] メモ一覧読み込み失敗: SessionId={SessionId}", SessionId);
+            statusMessage = $"読み込みに失敗しました: {ex.Message}";
+            statusIsError = true;
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private async Task HandleRestore(Guid memoId)
+    {
+        if (isBusy) return;
+        isBusy = true;
+        statusMessage = "";
+        try
+        {
+            await MemoRepository.RestoreAsync(memoId);
+            await ReloadAsync();
+            statusMessage = "メモを復元しました。";
+            statusIsError = false;
+            await OnMemoRestored.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[MemoManagementDialog] メモ復元失敗: MemoId={MemoId}", memoId);
+            statusMessage = $"復元に失敗しました: {ex.Message}";
+            statusIsError = true;
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private void HandleHardDelete(SessionMemo memo)
+    {
+        hardDeleteConfirmTarget = memo;
+    }
+
+    private async Task ConfirmHardDelete()
+    {
+        if (hardDeleteConfirmTarget is null || isBusy) return;
+        var target = hardDeleteConfirmTarget;
+        hardDeleteConfirmTarget = null;
+        isBusy = true;
+        statusMessage = "";
+        try
+        {
+            await MemoRepository.HardDeleteAsync(target.MemoId);
+            await ReloadAsync();
+            statusMessage = "メモを完全に削除しました。";
+            statusIsError = false;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[MemoManagementDialog] メモ完全削除失敗: MemoId={MemoId}", target.MemoId);
+            statusMessage = $"完全削除に失敗しました: {ex.Message}";
+            statusIsError = true;
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task HandleClose()
+    {
+        await OnClose.InvokeAsync();
+    }
+
+    private static string GetPreview(string body)
+    {
+        if (string.IsNullOrEmpty(body)) return "(空)";
+        const int maxLen = 200;
+        return body.Length <= maxLen ? body : body.Substring(0, maxLen) + "…";
+    }
+}

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -6,6 +6,7 @@
 @inject ISessionManager SessionManager
 @inject IJSRuntime JSRuntime
 @inject ILogger<SessionSettingsDialog> Logger
+@inject ISessionMemoRepository MemoRepository
 
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
     <div class="modal-dialog modal-dialog-centered modal-lg">
@@ -58,12 +59,21 @@
                         </div>
                     </div>
 
-                    @if (!sessionInfo.ParentSessionId.HasValue)
+                    @if (!sessionInfo.ParentSessionId.HasValue || anyMemoExists)
                     {
-                        <div class="mt-3">
-                            <button type="button" class="btn btn-outline-success btn-sm" @onclick="HandleCreateSubSession">
-                                <i class="bi bi-plus-circle me-1"></i>サブセッションを作成
-                            </button>
+                        <div class="mt-3 d-flex flex-wrap gap-2">
+                            @if (!sessionInfo.ParentSessionId.HasValue)
+                            {
+                                <button type="button" class="btn btn-outline-success btn-sm" @onclick="HandleCreateSubSession">
+                                    <i class="bi bi-plus-circle me-1"></i>サブセッションを作成
+                                </button>
+                            }
+                            @if (anyMemoExists)
+                            {
+                                <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="OpenMemoManagement">
+                                    <i class="bi bi-journal-text me-1"></i>メモ管理
+                                </button>
+                            }
                         </div>
                     }
 
@@ -146,12 +156,21 @@
     </div>
 </div>
 
+<MemoManagementDialog IsVisible="showMemoManagement"
+                      SessionId="SessionId"
+                      OnClose="CloseMemoManagement"
+                      OnMemoRestored="HandleMemoRestored" />
+
 @code {
     [Parameter] public bool IsVisible { get; set; }
     [Parameter] public Guid? SessionId { get; set; }
     [Parameter] public EventCallback OnSettingsSaved { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback<Guid> OnCreateSubSession { get; set; }
+    [Parameter] public EventCallback OnMemoRestored { get; set; }
+
+    private bool showMemoManagement = false;
+    private bool anyMemoExists = false;
 
     private SessionOptionsSelector? optionsSelector;
     private SessionInfo? sessionInfo;
@@ -167,12 +186,50 @@
     private string errorMessage = "";
     private bool restartSession = true;
 
-    protected override void OnParametersSet()
+    protected override async Task OnParametersSetAsync()
     {
         if (IsVisible && SessionId.HasValue)
         {
             LoadSessionInfo();
+            await RefreshMemoExistsAsync();
         }
+    }
+
+    private async Task RefreshMemoExistsAsync()
+    {
+        if (!SessionId.HasValue)
+        {
+            anyMemoExists = false;
+            return;
+        }
+        try
+        {
+            anyMemoExists = await MemoRepository.AnyExistsAsync(SessionId.Value);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[SessionSettingsDialog] メモ存在確認失敗: SessionId={SessionId}", SessionId);
+            anyMemoExists = false;
+        }
+    }
+
+    private void OpenMemoManagement()
+    {
+        showMemoManagement = true;
+    }
+
+    private async Task CloseMemoManagement()
+    {
+        showMemoManagement = false;
+        // 完全削除や復元でメモの存在状況が変わった可能性があるのでボタン表示を更新
+        await RefreshMemoExistsAsync();
+    }
+
+    private async Task HandleMemoRestored()
+    {
+        // 復元は呼び出し元 (Root 等) にも伝播させて BottomPanel のメモタブを再読み込みさせる
+        await OnMemoRestored.InvokeAsync();
+        await RefreshMemoExistsAsync();
     }
 
     private void LoadSessionInfo()

--- a/TerminalHub/Models/SessionMemo.cs
+++ b/TerminalHub/Models/SessionMemo.cs
@@ -13,5 +13,11 @@ namespace TerminalHub.Models
         public DateTime CreatedAt { get; set; } = DateTime.Now;
         public DateTime UpdatedAt { get; set; } = DateTime.Now;
         public int SortOrder { get; set; } = 0;
+
+        /// <summary>論理削除フラグ (v5)</summary>
+        public bool IsDeleted { get; set; }
+
+        /// <summary>論理削除日時 (v5, IsDeleted=false のときは null)</summary>
+        public DateTime? DeletedAt { get; set; }
     }
 }

--- a/TerminalHub/Services/ISessionMemoRepository.cs
+++ b/TerminalHub/Services/ISessionMemoRepository.cs
@@ -7,8 +7,14 @@ namespace TerminalHub.Services
     /// </summary>
     public interface ISessionMemoRepository
     {
-        /// <summary>指定セッションのメモ一覧を SortOrder, CreatedAt 昇順で取得</summary>
+        /// <summary>指定セッションの有効なメモ一覧を SortOrder, CreatedAt 昇順で取得 (論理削除は除外)</summary>
         Task<List<SessionMemo>> GetBySessionAsync(Guid sessionId);
+
+        /// <summary>指定セッションの論理削除済みメモ一覧を DeletedAt 降順で取得</summary>
+        Task<List<SessionMemo>> GetDeletedBySessionAsync(Guid sessionId);
+
+        /// <summary>指定セッションにメモが1件でも存在するか (active/deleted 両方を対象)</summary>
+        Task<bool> AnyExistsAsync(Guid sessionId);
 
         /// <summary>新規メモを挿入</summary>
         Task InsertAsync(SessionMemo memo);
@@ -19,7 +25,13 @@ namespace TerminalHub.Services
         /// <summary>本文のみ更新 (UpdatedAt も更新)</summary>
         Task UpdateBodyAsync(Guid memoId, string body);
 
-        /// <summary>個別メモを削除</summary>
+        /// <summary>メモを論理削除する (IsDeleted=1, DeletedAt=now)。復元可能。</summary>
         Task DeleteAsync(Guid memoId);
+
+        /// <summary>論理削除されたメモを復元する (IsDeleted=0, DeletedAt=null)</summary>
+        Task RestoreAsync(Guid memoId);
+
+        /// <summary>完全削除 (DB 行削除)。復元不可。</summary>
+        Task HardDeleteAsync(Guid memoId);
     }
 }

--- a/TerminalHub/Services/SessionDbContext.cs
+++ b/TerminalHub/Services/SessionDbContext.cs
@@ -186,6 +186,15 @@ namespace TerminalHub.Services
                 _logger.LogInformation("[DB][マイグレーション] v4 適用完了");
             }
 
+            if (currentVersion < 5)
+            {
+                // v5: SessionMemos に論理削除カラム (IsDeleted, DeletedAt) を追加
+                _logger.LogInformation("[DB][マイグレーション] v5 適用開始: SessionMemos に論理削除カラムを追加");
+                await AddMemoSoftDeleteColumnsAsync();
+                await SetSchemaVersionAsync(5);
+                _logger.LogInformation("[DB][マイグレーション] v5 適用完了");
+            }
+
             _logger.LogInformation("[DB][マイグレーション] 完了");
         }
 
@@ -340,6 +349,22 @@ namespace TerminalHub.Services
             ";
 
             await connection.ExecuteNonQueryAsync(sql);
+        }
+
+        private async Task AddMemoSoftDeleteColumnsAsync()
+        {
+            // v5 マイグレーション: メモのうっかり消失対策で論理削除に移行するため、
+            // IsDeleted (フラグ) と DeletedAt (論理削除日時) を追加する。
+            // 既存レコードは IsDeleted=0 で何も変わらない。
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await connection.ExecuteNonQueryAsync(
+                "ALTER TABLE SessionMemos ADD COLUMN IsDeleted INTEGER NOT NULL DEFAULT 0");
+            await connection.ExecuteNonQueryAsync(
+                "ALTER TABLE SessionMemos ADD COLUMN DeletedAt TEXT");
+            await connection.ExecuteNonQueryAsync(
+                "CREATE INDEX IF NOT EXISTS idx_session_memos_deleted ON SessionMemos(SessionId, IsDeleted, DeletedAt)");
         }
 
         /// <summary>

--- a/TerminalHub/Services/SessionDbContext.cs
+++ b/TerminalHub/Services/SessionDbContext.cs
@@ -186,13 +186,18 @@ namespace TerminalHub.Services
                 _logger.LogInformation("[DB][マイグレーション] v4 適用完了");
             }
 
-            if (currentVersion < 5)
+            // v5 は廃止された「ファイル参照」機能 (SessionFiles テーブル) で一度消費された番号。
+            // 開発環境の DB には SchemaVersion=5 と空のままの SessionFiles テーブルが残っている
+            // ケースがあるため、メモの論理削除は v6 として新設する。新規 DB でも害はない
+            // (単に v5 が no-op で通過するだけ)。
+
+            if (currentVersion < 6)
             {
-                // v5: SessionMemos に論理削除カラム (IsDeleted, DeletedAt) を追加
-                _logger.LogInformation("[DB][マイグレーション] v5 適用開始: SessionMemos に論理削除カラムを追加");
+                // v6: SessionMemos に論理削除カラム (IsDeleted, DeletedAt) を追加
+                _logger.LogInformation("[DB][マイグレーション] v6 適用開始: SessionMemos に論理削除カラムを追加");
                 await AddMemoSoftDeleteColumnsAsync();
-                await SetSchemaVersionAsync(5);
-                _logger.LogInformation("[DB][マイグレーション] v5 適用完了");
+                await SetSchemaVersionAsync(6);
+                _logger.LogInformation("[DB][マイグレーション] v6 適用完了");
             }
 
             _logger.LogInformation("[DB][マイグレーション] 完了");

--- a/TerminalHub/Services/SessionMemoRepository.cs
+++ b/TerminalHub/Services/SessionMemoRepository.cs
@@ -24,7 +24,7 @@ namespace TerminalHub.Services
             await using var reader = await connection.ExecuteReaderAsync(@"
                 SELECT MemoId, SessionId, Title, Body, CreatedAt, UpdatedAt, SortOrder
                 FROM SessionMemos
-                WHERE SessionId = @sessionId
+                WHERE SessionId = @sessionId AND IsDeleted = 0
                 ORDER BY SortOrder ASC, CreatedAt ASC",
                 ("@sessionId", sessionId.ToString()));
 
@@ -42,6 +42,49 @@ namespace TerminalHub.Services
                 });
             }
             return result;
+        }
+
+        public async Task<List<SessionMemo>> GetDeletedBySessionAsync(Guid sessionId)
+        {
+            var result = new List<SessionMemo>();
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            await using var reader = await connection.ExecuteReaderAsync(@"
+                SELECT MemoId, SessionId, Title, Body, CreatedAt, UpdatedAt, SortOrder, DeletedAt
+                FROM SessionMemos
+                WHERE SessionId = @sessionId AND IsDeleted = 1
+                ORDER BY DeletedAt DESC",
+                ("@sessionId", sessionId.ToString()));
+
+            while (await reader.ReadAsync())
+            {
+                result.Add(new SessionMemo
+                {
+                    MemoId = Guid.Parse(reader.GetString(0)),
+                    SessionId = Guid.Parse(reader.GetString(1)),
+                    Title = reader.GetString(2),
+                    Body = reader.GetString(3),
+                    CreatedAt = DateTime.Parse(reader.GetString(4)),
+                    UpdatedAt = DateTime.Parse(reader.GetString(5)),
+                    SortOrder = reader.GetInt32(6),
+                    IsDeleted = true,
+                    DeletedAt = reader.IsDBNull(7) ? null : DateTime.Parse(reader.GetString(7))
+                });
+            }
+            return result;
+        }
+
+        public async Task<bool> AnyExistsAsync(Guid sessionId)
+        {
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            var count = await connection.ExecuteScalarAsync<long>(
+                "SELECT COUNT(*) FROM SessionMemos WHERE SessionId = @sessionId",
+                ("@sessionId", sessionId.ToString()));
+
+            return count > 0;
         }
 
         public async Task InsertAsync(SessionMemo memo)
@@ -105,6 +148,34 @@ namespace TerminalHub.Services
         }
 
         public async Task DeleteAsync(Guid memoId)
+        {
+            // うっかり × ボタンで消されても後から復元できるよう、論理削除に移行。
+            // シグネチャは変えていないので、既存呼び出し側 (BottomPanel.RemoveTab 等) は無変更で動く。
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            await connection.ExecuteNonQueryAsync(@"
+                UPDATE SessionMemos
+                SET IsDeleted = 1, DeletedAt = @deletedAt
+                WHERE MemoId = @memoId",
+                ("@memoId", memoId.ToString()),
+                ("@deletedAt", DateTime.Now.ToString("o")));
+        }
+
+        public async Task RestoreAsync(Guid memoId)
+        {
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            await connection.ExecuteNonQueryAsync(@"
+                UPDATE SessionMemos
+                SET IsDeleted = 0, DeletedAt = NULL, UpdatedAt = @updatedAt
+                WHERE MemoId = @memoId",
+                ("@memoId", memoId.ToString()),
+                ("@updatedAt", DateTime.Now.ToString("o")));
+        }
+
+        public async Task HardDeleteAsync(Guid memoId)
         {
             await using var connection = _dbContext.CreateConnection();
             await connection.OpenAsync();


### PR DESCRIPTION
## Summary
タブ × ボタンでメモが即時物理削除されて救えない問題を、論理削除 + 復元 UI で解消する。

ユーザー合意の段階的 2PR のうちの **Phase 1** (論理削除+復元)。Phase 2 (編集履歴+自動スナップショット) は別 PR で続ける。

## データベース変更

### Schema v5
\`\`\`sql
ALTER TABLE SessionMemos ADD COLUMN IsDeleted INTEGER NOT NULL DEFAULT 0;
ALTER TABLE SessionMemos ADD COLUMN DeletedAt TEXT;
CREATE INDEX idx_session_memos_deleted ON SessionMemos(SessionId, IsDeleted, DeletedAt);
\`\`\`
- 既存 v4 DB は \`ALTER TABLE ADD COLUMN\` (安全操作) で無損失に v5 化される
- 既存レコードは \`IsDeleted=0\` で何も挙動が変わらない

### Repository 変更
- \`GetBySessionAsync\`: WHERE に \`IsDeleted = 0\` を追加 (BottomPanel に削除済みは出ない)
- \`DeleteAsync\`: \`DELETE FROM\` → \`UPDATE SET IsDeleted=1, DeletedAt=now\` (シグネチャ据え置き → 呼び出し元 \`BottomPanel.RemoveTab\` は無変更で論理削除に移行)
- 新規メソッド: \`GetDeletedBySessionAsync\`, \`RestoreAsync\`, \`HardDeleteAsync\`, \`AnyExistsAsync\`

## UI

### 新規 \`MemoManagementDialog.razor\`
- 削除済みメモ一覧 (DeletedAt DESC): タイトル / 削除日時 / 本文プレビュー / 「復元」「完全削除」
- 完全削除は確認ダイアログあり (取り消し不可のため)
- アクティブなメモ一覧も表示 (Phase 2 で履歴起点になる)

### \`SessionSettingsDialog.razor\`
- 「メモ管理」ボタンを追加 (既存の「サブセッションを作成」と同じ段)
- **条件付き表示**: セッションにメモレコードが1件でもあれば表示 (未利用セッションでは非表示で UI ノイズを減らす)

### Root / BottomPanel 連携
- 復元時は \`OnMemoRestored\` を親まで伝搬 → \`BottomPanel.ReloadMemosForCurrentSessionAsync\` で現セッションのメモタブを再読み込み
- 復元されたメモが新タブとして自動的に表示される

## Test plan
- [ ] v4 DB で起動 → migration で IsDeleted/DeletedAt カラムが追加されること (SQL で確認)
- [ ] 新規メモ作成 → 通常通り編集・保存できること
- [ ] タブ × ボタンで閉じる → 行は IsDeleted=1 で残っていること
- [ ] セッション設定を開く → メモ管理ボタンが表示されること (メモ未利用セッションでは非表示)
- [ ] ボタン押下 → 削除済みメモが DeletedAt 降順で表示されること
- [ ] 「復元」→ タブに再度出現、IsDeleted=0 に戻っていること
- [ ] 「完全削除」→ 確認ダイアログ → DB から物理削除されること
- [ ] アクティブなメモ一覧に現在使用中のメモが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)