### PR TITLE
feat: メモ編集履歴と自動スナップショット (Phase 2)

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor
@@ -386,6 +386,9 @@
                         SavedAt = DateTime.Now,
                         Trigger = SessionMemoSnapshot.TriggerAuto
                     });
+                    // 保全 snapshot を挿入した分だけ件数が伸びるので、ここで上限超過を整理する。
+                    // (MemoSnapshotService の Tick を待たずに復元操作で閉じる)
+                    await SnapshotRepository.TrimAutoSnapshotsAsync(memo.MemoId, SessionMemoSnapshot.MaxAutoKeep);
                 }
                 catch (Exception exInner)
                 {
@@ -397,11 +400,9 @@
             // UpdateBodyAsync で現在の本文を上書き。
             await MemoRepository.UpdateBodyAsync(memo.MemoId, snap.Body);
 
-            // 履歴キャッシュをこのメモだけクリア (再展開で最新状態を取得)
-            snapshotCache.Remove(memo.MemoId);
-
+            // ReloadAsync が snapshotCache/expandedMemoIds を全クリアするので、
+            // 戻したメモだけ再展開+最新キャッシュを入れ直しておく (ユーザーが直前に見ていたビューを維持)。
             await ReloadAsync();
-            // 展開状態は ReloadAsync でクリアされるので、戻したメモは再度展開しておくと親切
             expandedMemoIds.Add(memo.MemoId);
             var refreshed = await SnapshotRepository.GetByMemoAsync(memo.MemoId);
             snapshotCache[memo.MemoId] = refreshed;

--- a/TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor
@@ -125,7 +125,7 @@
                                                         @onclick="() => ToggleHistoryAsync(memo.MemoId)"
                                                         disabled="@isBusy">
                                                     <i class="bi @(isExpanded ? "bi-chevron-up" : "bi-clock-history") me-1"></i>
-                                                    履歴@countLabel
+                                                    履歴@(countLabel)
                                                 </button>
                                             </div>
                                         </div>

--- a/TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor
@@ -1,6 +1,7 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
 @inject ISessionMemoRepository MemoRepository
+@inject ISessionMemoSnapshotRepository SnapshotRepository
 @inject ILogger<MemoManagementDialog> Logger
 
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
@@ -67,7 +68,7 @@
                         }
                     </div>
 
-                    <!-- アクティブなメモ (参考情報) -->
+                    <!-- アクティブなメモ (履歴つき) -->
                     <div>
                         <h6 class="text-muted">
                             <i class="bi bi-journal-text me-1"></i>現在のメモ
@@ -82,14 +83,72 @@
                             <div class="list-group">
                                 @foreach (var memo in activeMemos)
                                 {
+                                    var isExpanded = expandedMemoIds.Contains(memo.MemoId);
+                                    var snapshots = snapshotCache.TryGetValue(memo.MemoId, out var list) ? list : null;
                                     <div class="list-group-item">
-                                        <div class="fw-bold text-truncate">@(string.IsNullOrWhiteSpace(memo.Title) ? "(無題)" : memo.Title)</div>
-                                        <small class="text-muted">
-                                            更新日時: @memo.UpdatedAt.ToString("yyyy-MM-dd HH:mm:ss")
-                                        </small>
-                                        <div class="small text-muted mt-1" style="white-space: pre-wrap; word-break: break-all; max-height: 4.5em; overflow: hidden;">
-                                            @(GetPreview(memo.Body))
+                                        <div class="d-flex justify-content-between align-items-start gap-2">
+                                            <div class="flex-grow-1 min-width-0">
+                                                <div class="fw-bold text-truncate">@(string.IsNullOrWhiteSpace(memo.Title) ? "(無題)" : memo.Title)</div>
+                                                <small class="text-muted">
+                                                    更新日時: @memo.UpdatedAt.ToString("yyyy-MM-dd HH:mm:ss")
+                                                </small>
+                                                <div class="small text-muted mt-1" style="white-space: pre-wrap; word-break: break-all; max-height: 4.5em; overflow: hidden;">
+                                                    @(GetPreview(memo.Body))
+                                                </div>
+                                            </div>
+                                            <div class="flex-shrink-0">
+                                                <button type="button" class="btn btn-outline-secondary btn-sm"
+                                                        @onclick="() => ToggleHistoryAsync(memo.MemoId)"
+                                                        disabled="@isBusy">
+                                                    <i class="bi @(isExpanded ? "bi-chevron-up" : "bi-clock-history") me-1"></i>
+                                                    履歴@(snapshots is null ? "" : $" ({snapshots.Count})")
+                                                </button>
+                                            </div>
                                         </div>
+
+                                        @if (isExpanded)
+                                        {
+                                            <div class="mt-2 ps-3 border-start">
+                                                @if (snapshots is null)
+                                                {
+                                                    <div class="small text-muted py-2">
+                                                        <span class="spinner-border spinner-border-sm me-1"></span>読み込み中...
+                                                    </div>
+                                                }
+                                                else if (snapshots.Count == 0)
+                                                {
+                                                    <div class="small text-muted py-2">履歴はまだありません。自動スナップショットは 10 分毎に取得されます。</div>
+                                                }
+                                                else
+                                                {
+                                                    @foreach (var snap in snapshots)
+                                                    {
+                                                        <div class="py-2 border-bottom">
+                                                            <div class="d-flex justify-content-between align-items-start gap-2">
+                                                                <div class="flex-grow-1 min-width-0">
+                                                                    <div class="small">
+                                                                        <span class="text-muted">@snap.SavedAt.ToString("yyyy-MM-dd HH:mm:ss")</span>
+                                                                        <span class="badge @(snap.Trigger == SessionMemoSnapshot.TriggerPreDelete ? "bg-warning text-dark" : "bg-secondary") ms-2">
+                                                                            @(snap.Trigger == SessionMemoSnapshot.TriggerPreDelete ? "削除直前" : "自動")
+                                                                        </span>
+                                                                    </div>
+                                                                    <div class="small text-muted mt-1" style="white-space: pre-wrap; word-break: break-all; max-height: 3.5em; overflow: hidden;">
+                                                                        @(GetPreview(snap.Body))
+                                                                    </div>
+                                                                </div>
+                                                                <div class="flex-shrink-0">
+                                                                    <button type="button" class="btn btn-outline-success btn-sm"
+                                                                            @onclick="() => RequestRestoreVersion(memo, snap)"
+                                                                            disabled="@isBusy">
+                                                                        <i class="bi bi-arrow-counterclockwise me-1"></i>このバージョンに戻す
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    }
+                                                }
+                                            </div>
+                                        }
                                     </div>
                                 }
                             </div>
@@ -138,6 +197,37 @@
     </div>
 }
 
+@if (restoreVersionTarget.HasValue)
+{
+    var (targetMemo, targetSnap) = restoreVersionTarget.Value;
+    <div class="modal fade show" tabindex="-1" style="display: block; background-color: var(--th-surface-overlay); z-index: 1060;">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title"><i class="bi bi-arrow-counterclockwise me-2"></i>過去バージョンに戻す</h5>
+                    <button type="button" class="btn-close" @onclick="() => restoreVersionTarget = null"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-2">
+                        メモ「<strong>@(string.IsNullOrWhiteSpace(targetMemo.Title) ? "(無題)" : targetMemo.Title)</strong>」の本文を
+                        <strong>@targetSnap.SavedAt.ToString("yyyy-MM-dd HH:mm:ss")</strong> 時点のバージョンに戻します。
+                    </p>
+                    <p class="small text-muted mb-2">現在の本文は新しい「直前」スナップショット (自動) として残り、いつでも戻せます。</p>
+                    <div class="border rounded p-2 small bg-body-tertiary" style="white-space: pre-wrap; word-break: break-all; max-height: 10em; overflow: auto;">
+                        @(GetPreview(targetSnap.Body, 400))
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="() => restoreVersionTarget = null">キャンセル</button>
+                    <button type="button" class="btn btn-success" @onclick="ConfirmRestoreVersion" disabled="@isBusy">
+                        <i class="bi bi-arrow-counterclockwise me-1"></i>このバージョンに戻す
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
 @code {
     [Parameter] public bool IsVisible { get; set; }
     [Parameter] public Guid? SessionId { get; set; }
@@ -151,6 +241,13 @@
     private string statusMessage = "";
     private bool statusIsError = false;
     private SessionMemo? hardDeleteConfirmTarget;
+
+    // アクティブメモの履歴展開状態とキャッシュ
+    private HashSet<Guid> expandedMemoIds = new();
+    private Dictionary<Guid, List<SessionMemoSnapshot>> snapshotCache = new();
+
+    // 履歴復元の確認対象 (メモ本体 + 戻すスナップショット)
+    private (SessionMemo Memo, SessionMemoSnapshot Snapshot)? restoreVersionTarget;
 
     private Guid? _loadedSessionId;
 
@@ -173,6 +270,9 @@
 
         isLoading = true;
         statusMessage = "";
+        // 再読み込み時は履歴キャッシュ/展開状態もクリア (別セッション切替や確実な最新化のため)
+        expandedMemoIds.Clear();
+        snapshotCache.Clear();
         StateHasChanged();
         try
         {
@@ -188,6 +288,99 @@
         finally
         {
             isLoading = false;
+        }
+    }
+
+    private async Task ToggleHistoryAsync(Guid memoId)
+    {
+        if (expandedMemoIds.Contains(memoId))
+        {
+            expandedMemoIds.Remove(memoId);
+            return;
+        }
+        expandedMemoIds.Add(memoId);
+        StateHasChanged();
+
+        if (!snapshotCache.ContainsKey(memoId))
+        {
+            try
+            {
+                var snapshots = await SnapshotRepository.GetByMemoAsync(memoId);
+                snapshotCache[memoId] = snapshots;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "[MemoManagementDialog] 履歴読み込み失敗: MemoId={MemoId}", memoId);
+                snapshotCache[memoId] = new List<SessionMemoSnapshot>();
+                statusMessage = $"履歴の読み込みに失敗しました: {ex.Message}";
+                statusIsError = true;
+            }
+        }
+    }
+
+    private void RequestRestoreVersion(SessionMemo memo, SessionMemoSnapshot snap)
+    {
+        restoreVersionTarget = (memo, snap);
+    }
+
+    private async Task ConfirmRestoreVersion()
+    {
+        if (restoreVersionTarget is null || isBusy) return;
+        var (memo, snap) = restoreVersionTarget.Value;
+        restoreVersionTarget = null;
+        isBusy = true;
+        statusMessage = "";
+        try
+        {
+            // 先に現在の本文を snapshot に残してから UpdateBodyAsync で巻き戻す。
+            // これで「復元をやり直したい」時も現在の本文が履歴から拾えるように保全される。
+            if (!string.Equals(memo.Body, snap.Body, StringComparison.Ordinal))
+            {
+                try
+                {
+                    await SnapshotRepository.InsertAsync(new SessionMemoSnapshot
+                    {
+                        MemoId = memo.MemoId,
+                        Title = memo.Title,
+                        Body = memo.Body,
+                        SavedAt = DateTime.Now,
+                        Trigger = SessionMemoSnapshot.TriggerAuto
+                    });
+                }
+                catch (Exception exInner)
+                {
+                    // 保全 snapshot が取れなくても復元自体は続行 (ログだけ残す)
+                    Logger.LogWarning(exInner, "[MemoManagementDialog] 復元前 snapshot 保存失敗 (続行): MemoId={MemoId}", memo.MemoId);
+                }
+            }
+
+            // UpdateBodyAsync で現在の本文を上書き。
+            await MemoRepository.UpdateBodyAsync(memo.MemoId, snap.Body);
+
+            // 履歴キャッシュをこのメモだけクリア (再展開で最新状態を取得)
+            snapshotCache.Remove(memo.MemoId);
+
+            await ReloadAsync();
+            // 展開状態は ReloadAsync でクリアされるので、戻したメモは再度展開しておくと親切
+            expandedMemoIds.Add(memo.MemoId);
+            var refreshed = await SnapshotRepository.GetByMemoAsync(memo.MemoId);
+            snapshotCache[memo.MemoId] = refreshed;
+
+            statusMessage = $"メモを {snap.SavedAt:yyyy-MM-dd HH:mm:ss} 時点のバージョンに戻しました。";
+            statusIsError = false;
+
+            // BottomPanel に通知して textarea 側も差し替える
+            await OnMemoRestored.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[MemoManagementDialog] バージョン復元失敗: MemoId={MemoId}, SnapshotId={SnapshotId}", memo.MemoId, snap.SnapshotId);
+            statusMessage = $"復元に失敗しました: {ex.Message}";
+            statusIsError = true;
+        }
+        finally
+        {
+            isBusy = false;
         }
     }
 
@@ -252,10 +445,9 @@
         await OnClose.InvokeAsync();
     }
 
-    private static string GetPreview(string body)
+    private static string GetPreview(string body, int maxLen = 200)
     {
         if (string.IsNullOrEmpty(body)) return "(空)";
-        const int maxLen = 200;
         return body.Length <= maxLen ? body : body.Substring(0, maxLen) + "…";
     }
 }

--- a/TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor
@@ -23,12 +23,36 @@
                 }
                 else
                 {
-                    <!-- 削除済みメモ -->
-                    <div class="mb-4">
-                        <h6 class="text-muted">
-                            <i class="bi bi-trash me-1"></i>削除済みメモ
-                            <span class="badge bg-secondary ms-2">@deletedMemos.Count</span>
-                        </h6>
+                    <!-- タブナビゲーション -->
+                    <ul class="nav nav-tabs mb-3" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button type="button"
+                                    class="nav-link @(activeTab == "current" ? "active" : "")"
+                                    @onclick='() => activeTab = "current"'>
+                                <i class="bi bi-journal-text me-1"></i>現在のメモ
+                                <span class="badge bg-secondary ms-1">@activeMemos.Count</span>
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button type="button"
+                                    class="nav-link @(activeTab == "deleted" ? "active" : "")"
+                                    @onclick='() => activeTab = "deleted"'>
+                                <i class="bi bi-trash me-1"></i>削除済みメモ
+                                @if (deletedMemos.Count > 0)
+                                {
+                                    <span class="badge bg-warning text-dark ms-1">@deletedMemos.Count</span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-secondary ms-1">0</span>
+                                }
+                            </button>
+                        </li>
+                    </ul>
+
+                    @if (activeTab == "deleted")
+                    {
+                        <!-- 削除済みメモタブ -->
                         @if (deletedMemos.Count == 0)
                         {
                             <p class="text-muted small mb-0">削除済みのメモはありません。</p>
@@ -66,14 +90,10 @@
                                 }
                             </div>
                         }
-                    </div>
-
-                    <!-- アクティブなメモ (履歴つき) -->
-                    <div>
-                        <h6 class="text-muted">
-                            <i class="bi bi-journal-text me-1"></i>現在のメモ
-                            <span class="badge bg-secondary ms-2">@activeMemos.Count</span>
-                        </h6>
+                    }
+                    else
+                    {
+                        <!-- 現在のメモタブ (履歴つき) -->
                         @if (activeMemos.Count == 0)
                         {
                             <p class="text-muted small mb-0">現在、有効なメモはありません。</p>
@@ -85,6 +105,10 @@
                                 {
                                     var isExpanded = expandedMemoIds.Contains(memo.MemoId);
                                     var snapshots = snapshotCache.TryGetValue(memo.MemoId, out var list) ? list : null;
+                                    // 展開前は事前ロードした snapshotCounts を、展開後はより確実な snapshots.Count を表示
+                                    var countLabel = snapshots is not null
+                                        ? $" ({snapshots.Count})"
+                                        : (snapshotCounts.TryGetValue(memo.MemoId, out var cnt) && cnt > 0 ? $" ({cnt})" : "");
                                     <div class="list-group-item">
                                         <div class="d-flex justify-content-between align-items-start gap-2">
                                             <div class="flex-grow-1 min-width-0">
@@ -101,7 +125,7 @@
                                                         @onclick="() => ToggleHistoryAsync(memo.MemoId)"
                                                         disabled="@isBusy">
                                                     <i class="bi @(isExpanded ? "bi-chevron-up" : "bi-clock-history") me-1"></i>
-                                                    履歴@(snapshots is null ? "" : $" ({snapshots.Count})")
+                                                    履歴@countLabel
                                                 </button>
                                             </div>
                                         </div>
@@ -153,7 +177,7 @@
                                 }
                             </div>
                         }
-                    </div>
+                    }
 
                     @if (!string.IsNullOrEmpty(statusMessage))
                     {
@@ -242,9 +266,14 @@
     private bool statusIsError = false;
     private SessionMemo? hardDeleteConfirmTarget;
 
+    // ダイアログ内のタブ: "current" (現在のメモ+履歴) | "deleted" (削除済み)
+    private string activeTab = "current";
+
     // アクティブメモの履歴展開状態とキャッシュ
     private HashSet<Guid> expandedMemoIds = new();
     private Dictionary<Guid, List<SessionMemoSnapshot>> snapshotCache = new();
+    // メモごとの履歴件数 (展開前に (N) を表示するため、ダイアログ表示時に一括取得)
+    private Dictionary<Guid, int> snapshotCounts = new();
 
     // 履歴復元の確認対象 (メモ本体 + 戻すスナップショット)
     private (SessionMemo Memo, SessionMemoSnapshot Snapshot)? restoreVersionTarget;
@@ -273,11 +302,22 @@
         // 再読み込み時は履歴キャッシュ/展開状態もクリア (別セッション切替や確実な最新化のため)
         expandedMemoIds.Clear();
         snapshotCache.Clear();
+        snapshotCounts.Clear();
         StateHasChanged();
         try
         {
             deletedMemos = await MemoRepository.GetDeletedBySessionAsync(SessionId.Value);
             activeMemos = await MemoRepository.GetBySessionAsync(SessionId.Value);
+            // 履歴件数はメモを開かずとも表示したいので先読み (1 クエリ GROUP BY)
+            try
+            {
+                snapshotCounts = await SnapshotRepository.GetCountsBySessionAsync(SessionId.Value);
+            }
+            catch (Exception exCounts)
+            {
+                Logger.LogWarning(exCounts, "[MemoManagementDialog] 履歴件数取得失敗 (続行): SessionId={SessionId}", SessionId);
+                snapshotCounts = new Dictionary<Guid, int>();
+            }
         }
         catch (Exception ex)
         {

--- a/TerminalHub/Models/SessionMemoSnapshot.cs
+++ b/TerminalHub/Models/SessionMemoSnapshot.cs
@@ -17,5 +17,11 @@ namespace TerminalHub.Models
 
         public const string TriggerAuto = "auto";
         public const string TriggerPreDelete = "pre-delete";
+
+        /// <summary>
+        /// メモ 1 件あたりの auto スナップショット保持上限。超過分は古い順に物理削除される。
+        /// pre-delete は対象外 (復元の最終防衛線として保護)。
+        /// </summary>
+        public const int MaxAutoKeep = 50;
     }
 }

--- a/TerminalHub/Models/SessionMemoSnapshot.cs
+++ b/TerminalHub/Models/SessionMemoSnapshot.cs
@@ -1,0 +1,21 @@
+namespace TerminalHub.Models
+{
+    /// <summary>
+    /// メモ編集の履歴スナップショット (v7 以降)。
+    /// 10 分毎の自動保存 (Trigger="auto") と、論理削除直前の保険 (Trigger="pre-delete") を記録する。
+    /// </summary>
+    public class SessionMemoSnapshot
+    {
+        public Guid SnapshotId { get; set; } = Guid.NewGuid();
+        public Guid MemoId { get; set; }
+        public string Title { get; set; } = "";
+        public string Body { get; set; } = "";
+        public DateTime SavedAt { get; set; } = DateTime.Now;
+
+        /// <summary>スナップショット生成のトリガー ("auto" | "pre-delete")。</summary>
+        public string Trigger { get; set; } = TriggerAuto;
+
+        public const string TriggerAuto = "auto";
+        public const string TriggerPreDelete = "pre-delete";
+    }
+}

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -61,8 +61,13 @@ builder.Services.AddSingleton<SessionDbContext>(sp =>
     return new SessionDbContext(dbPath, logger);
 });
 builder.Services.AddSingleton<ISessionRepository, SessionRepository>();
+builder.Services.AddSingleton<ISessionMemoSnapshotRepository, SessionMemoSnapshotRepository>();
 builder.Services.AddSingleton<ISessionMemoRepository, SessionMemoRepository>();
 builder.Services.AddScoped<IStorageServiceFactory, StorageServiceFactory>();
+
+// メモ編集履歴の自動スナップショットサービス (10分毎)
+builder.Services.AddSingleton<MemoSnapshotService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<MemoSnapshotService>());
 
 // NotificationServiceを登録
 builder.Services.AddScoped<INotificationService, NotificationService>();

--- a/TerminalHub/Services/ISessionMemoSnapshotRepository.cs
+++ b/TerminalHub/Services/ISessionMemoSnapshotRepository.cs
@@ -17,6 +17,13 @@ namespace TerminalHub.Services
         Task<List<SessionMemoSnapshot>> GetByMemoAsync(Guid memoId);
 
         /// <summary>
+        /// 指定セッションに紐づくメモごとの snapshot 件数を一括取得する
+        /// (メモ管理ダイアログで履歴件数を展開前に表示するため)。
+        /// 履歴 0 件のメモは Dictionary に含まれない。
+        /// </summary>
+        Task<Dictionary<Guid, int>> GetCountsBySessionAsync(Guid sessionId);
+
+        /// <summary>
         /// Trigger="auto" のスナップショットが <paramref name="maxAutoKeep"/> 件を超えたら
         /// 古い順に物理削除する。pre-delete は削除対象外 (復元の最終防衛線を保護)。
         /// </summary>

--- a/TerminalHub/Services/ISessionMemoSnapshotRepository.cs
+++ b/TerminalHub/Services/ISessionMemoSnapshotRepository.cs
@@ -1,0 +1,25 @@
+using TerminalHub.Models;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// メモ編集履歴 (スナップショット) の永続化リポジトリ
+    /// </summary>
+    public interface ISessionMemoSnapshotRepository
+    {
+        /// <summary>スナップショットを 1 件挿入</summary>
+        Task InsertAsync(SessionMemoSnapshot snapshot);
+
+        /// <summary>指定メモの最新スナップショット (変更検知用)</summary>
+        Task<SessionMemoSnapshot?> GetLatestAsync(Guid memoId);
+
+        /// <summary>指定メモのスナップショット一覧を SavedAt 降順で取得</summary>
+        Task<List<SessionMemoSnapshot>> GetByMemoAsync(Guid memoId);
+
+        /// <summary>
+        /// Trigger="auto" のスナップショットが <paramref name="maxAutoKeep"/> 件を超えたら
+        /// 古い順に物理削除する。pre-delete は削除対象外 (復元の最終防衛線を保護)。
+        /// </summary>
+        Task TrimAutoSnapshotsAsync(Guid memoId, int maxAutoKeep);
+    }
+}

--- a/TerminalHub/Services/MemoSnapshotService.cs
+++ b/TerminalHub/Services/MemoSnapshotService.cs
@@ -16,11 +16,12 @@ namespace TerminalHub.Services
         // WinForms の Timer と衝突するので System.Threading.Timer を明示
         private System.Threading.Timer? _timer;
 
-        /// <summary>スナップショット取得間隔</summary>
+        /// <summary>
+        /// スナップショット取得間隔。
+        /// 初回 Tick も同じ遅延を使う (= 起動から 10 分は snapshot を作らない)。
+        /// これは設計上の意図で、「10 分間維持されていないテキストは保護対象外」と割り切っている。
+        /// </summary>
         private static readonly TimeSpan Interval = TimeSpan.FromMinutes(10);
-
-        /// <summary>メモ 1 件あたりの auto スナップショット保持上限 (超過分は古い順に削除)</summary>
-        private const int MaxAutoKeep = 50;
 
         public MemoSnapshotService(IServiceScopeFactory scopeFactory, ILogger<MemoSnapshotService> logger)
         {
@@ -90,7 +91,7 @@ namespace TerminalHub.Services
                                     SavedAt = DateTime.Now,
                                     Trigger = SessionMemoSnapshot.TriggerAuto
                                 });
-                                await snapshotRepo.TrimAutoSnapshotsAsync(memo.MemoId, MaxAutoKeep);
+                                await snapshotRepo.TrimAutoSnapshotsAsync(memo.MemoId, SessionMemoSnapshot.MaxAutoKeep);
                                 inserted++;
                             }
                         }

--- a/TerminalHub/Services/MemoSnapshotService.cs
+++ b/TerminalHub/Services/MemoSnapshotService.cs
@@ -1,0 +1,126 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TerminalHub.Models;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// メモの編集履歴 (スナップショット) を 10 分毎に自動保存するバックグラウンドサービス。
+    /// 変更のあったメモにだけ INSERT するため、idle なメモは履歴が増えない。
+    /// </summary>
+    public class MemoSnapshotService : IHostedService, IDisposable
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<MemoSnapshotService> _logger;
+        // WinForms の Timer と衝突するので System.Threading.Timer を明示
+        private System.Threading.Timer? _timer;
+
+        /// <summary>スナップショット取得間隔</summary>
+        private static readonly TimeSpan Interval = TimeSpan.FromMinutes(10);
+
+        /// <summary>メモ 1 件あたりの auto スナップショット保持上限 (超過分は古い順に削除)</summary>
+        private const int MaxAutoKeep = 50;
+
+        public MemoSnapshotService(IServiceScopeFactory scopeFactory, ILogger<MemoSnapshotService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("[MemoSnapshot] サービス開始 (間隔={Interval})", Interval);
+            _timer = new System.Threading.Timer(OnTimerTick, null, Interval, Interval);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("[MemoSnapshot] サービス停止");
+            _timer?.Change(Timeout.Infinite, 0);
+            return Task.CompletedTask;
+        }
+
+        private void OnTimerTick(object? state)
+        {
+            _ = TickAsync();
+        }
+
+        private async Task TickAsync()
+        {
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var sessionManager = scope.ServiceProvider.GetRequiredService<ISessionManager>();
+                var memoRepo = scope.ServiceProvider.GetRequiredService<ISessionMemoRepository>();
+                var snapshotRepo = scope.ServiceProvider.GetRequiredService<ISessionMemoSnapshotRepository>();
+
+                int inserted = 0;
+                int scanned = 0;
+
+                foreach (var session in sessionManager.GetActiveSessions())
+                {
+                    List<SessionMemo> memos;
+                    try
+                    {
+                        memos = await memoRepo.GetBySessionAsync(session.SessionId);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "[MemoSnapshot] メモ一覧取得失敗 SessionId={SessionId}", session.SessionId);
+                        continue;
+                    }
+
+                    foreach (var memo in memos)
+                    {
+                        scanned++;
+                        try
+                        {
+                            var last = await snapshotRepo.GetLatestAsync(memo.MemoId);
+                            // 初回 or 本文変更ありのみ記録。Title の変更だけでは snapshot を作らない
+                            // (Title は UpdatedAt を進めるが、本文保護の観点で意味は薄い)
+                            if (last is null || !string.Equals(last.Body, memo.Body, StringComparison.Ordinal))
+                            {
+                                await snapshotRepo.InsertAsync(new SessionMemoSnapshot
+                                {
+                                    MemoId = memo.MemoId,
+                                    Title = memo.Title,
+                                    Body = memo.Body,
+                                    SavedAt = DateTime.Now,
+                                    Trigger = SessionMemoSnapshot.TriggerAuto
+                                });
+                                await snapshotRepo.TrimAutoSnapshotsAsync(memo.MemoId, MaxAutoKeep);
+                                inserted++;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "[MemoSnapshot] 個別メモの snapshot 失敗 MemoId={MemoId}", memo.MemoId);
+                        }
+                    }
+                }
+
+                if (inserted > 0)
+                {
+                    _logger.LogInformation("[MemoSnapshot] Tick 完了: スキャン={Scanned}, 新規={Inserted}", scanned, inserted);
+                }
+                else
+                {
+                    _logger.LogDebug("[MemoSnapshot] Tick 完了: スキャン={Scanned}, 変更なし", scanned);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Timer コールバックから例外が漏れるとプロセス終了につながるため、握り潰して継続
+                _logger.LogError(ex, "[MemoSnapshot] Tick で未捕捉の例外");
+            }
+        }
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+            _timer = null;
+        }
+    }
+}

--- a/TerminalHub/Services/SessionDbContext.cs
+++ b/TerminalHub/Services/SessionDbContext.cs
@@ -200,6 +200,15 @@ namespace TerminalHub.Services
                 _logger.LogInformation("[DB][マイグレーション] v6 適用完了");
             }
 
+            if (currentVersion < 7)
+            {
+                // v7: メモ編集履歴 (スナップショット) テーブルを追加
+                _logger.LogInformation("[DB][マイグレーション] v7 適用開始: SessionMemoSnapshots テーブル追加");
+                await CreateSessionMemoSnapshotsTableAsync();
+                await SetSchemaVersionAsync(7);
+                _logger.LogInformation("[DB][マイグレーション] v7 適用完了");
+            }
+
             _logger.LogInformation("[DB][マイグレーション] 完了");
         }
 
@@ -370,6 +379,31 @@ namespace TerminalHub.Services
                 "ALTER TABLE SessionMemos ADD COLUMN DeletedAt TEXT");
             await connection.ExecuteNonQueryAsync(
                 "CREATE INDEX IF NOT EXISTS idx_session_memos_deleted ON SessionMemos(SessionId, IsDeleted, DeletedAt)");
+        }
+
+        private async Task CreateSessionMemoSnapshotsTableAsync()
+        {
+            // v7 マイグレーション: メモの編集履歴 (スナップショット) テーブルを追加。
+            // 10 分毎の自動スナップショット (Trigger="auto") と、論理削除直前の
+            // 保険スナップショット (Trigger="pre-delete") を保存する。
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            var sql = @"
+                CREATE TABLE IF NOT EXISTS SessionMemoSnapshots (
+                    SnapshotId TEXT PRIMARY KEY,
+                    MemoId TEXT NOT NULL,
+                    Title TEXT NOT NULL DEFAULT '',
+                    Body TEXT NOT NULL DEFAULT '',
+                    SavedAt TEXT NOT NULL,
+                    Trigger TEXT NOT NULL,
+                    FOREIGN KEY(MemoId) REFERENCES SessionMemos(MemoId) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_memo_snapshots_memo ON SessionMemoSnapshots(MemoId, SavedAt DESC);
+            ";
+
+            await connection.ExecuteNonQueryAsync(sql);
         }
 
         /// <summary>

--- a/TerminalHub/Services/SessionMemoRepository.cs
+++ b/TerminalHub/Services/SessionMemoRepository.cs
@@ -8,11 +8,16 @@ namespace TerminalHub.Services
     {
         private readonly SessionDbContext _dbContext;
         private readonly ILogger<SessionMemoRepository> _logger;
+        private readonly ISessionMemoSnapshotRepository _snapshotRepository;
 
-        public SessionMemoRepository(SessionDbContext dbContext, ILogger<SessionMemoRepository> logger)
+        public SessionMemoRepository(
+            SessionDbContext dbContext,
+            ILogger<SessionMemoRepository> logger,
+            ISessionMemoSnapshotRepository snapshotRepository)
         {
             _dbContext = dbContext;
             _logger = logger;
+            _snapshotRepository = snapshotRepository;
         }
 
         public async Task<List<SessionMemo>> GetBySessionAsync(Guid sessionId)
@@ -151,6 +156,10 @@ namespace TerminalHub.Services
         {
             // うっかり × ボタンで消されても後から復元できるよう、論理削除に移行。
             // シグネチャは変えていないので、既存呼び出し側 (BottomPanel.RemoveTab 等) は無変更で動く。
+            // さらに、論理削除の直前に pre-delete スナップショットを 1 件作成しておき、
+            // 復元時に直前状態を確実に戻せるようにする (Phase 2)。
+            await SavePreDeleteSnapshotAsync(memoId);
+
             await using var connection = _dbContext.CreateConnection();
             await connection.OpenAsync();
 
@@ -160,6 +169,42 @@ namespace TerminalHub.Services
                 WHERE MemoId = @memoId",
                 ("@memoId", memoId.ToString()),
                 ("@deletedAt", DateTime.Now.ToString("o")));
+        }
+
+        private async Task SavePreDeleteSnapshotAsync(Guid memoId)
+        {
+            try
+            {
+                await using var connection = _dbContext.CreateConnection();
+                await connection.OpenAsync();
+
+                await using var reader = await connection.ExecuteReaderAsync(
+                    "SELECT Title, Body FROM SessionMemos WHERE MemoId = @memoId AND IsDeleted = 0",
+                    ("@memoId", memoId.ToString()));
+
+                if (!await reader.ReadAsync())
+                {
+                    // 既に削除済み or 存在しない → 何もしない
+                    return;
+                }
+                var title = reader.GetString(0);
+                var body = reader.GetString(1);
+                await reader.CloseAsync();
+
+                await _snapshotRepository.InsertAsync(new SessionMemoSnapshot
+                {
+                    MemoId = memoId,
+                    Title = title,
+                    Body = body,
+                    SavedAt = DateTime.Now,
+                    Trigger = SessionMemoSnapshot.TriggerPreDelete
+                });
+            }
+            catch (Exception ex)
+            {
+                // スナップショット失敗で論理削除そのものを止めたくないので、ログだけ残して続行
+                _logger.LogError(ex, "[Memo] pre-delete snapshot 失敗: MemoId={MemoId}", memoId);
+            }
         }
 
         public async Task RestoreAsync(Guid memoId)

--- a/TerminalHub/Services/SessionMemoSnapshotRepository.cs
+++ b/TerminalHub/Services/SessionMemoSnapshotRepository.cs
@@ -80,6 +80,30 @@ namespace TerminalHub.Services
             return result;
         }
 
+        public async Task<Dictionary<Guid, int>> GetCountsBySessionAsync(Guid sessionId)
+        {
+            var result = new Dictionary<Guid, int>();
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            // セッション配下のメモ (論理削除済みも含む) に紐づく snapshot 件数を一括取得。
+            // アクティブメモだけでなく削除済みも対象にしておくことで、将来「削除済みメモの履歴」
+            // UI を足すときにも再利用できる。履歴 0 件のメモは結果に含まれない。
+            await using var reader = await connection.ExecuteReaderAsync(@"
+                SELECT sn.MemoId, COUNT(*) AS Cnt
+                FROM SessionMemoSnapshots sn
+                INNER JOIN SessionMemos m ON m.MemoId = sn.MemoId
+                WHERE m.SessionId = @sessionId
+                GROUP BY sn.MemoId",
+                ("@sessionId", sessionId.ToString()));
+
+            while (await reader.ReadAsync())
+            {
+                result[Guid.Parse(reader.GetString(0))] = reader.GetInt32(1);
+            }
+            return result;
+        }
+
         public async Task TrimAutoSnapshotsAsync(Guid memoId, int maxAutoKeep)
         {
             if (maxAutoKeep <= 0) return;

--- a/TerminalHub/Services/SessionMemoSnapshotRepository.cs
+++ b/TerminalHub/Services/SessionMemoSnapshotRepository.cs
@@ -45,11 +45,12 @@ namespace TerminalHub.Services
             await using var connection = _dbContext.CreateConnection();
             await connection.OpenAsync();
 
+            // SavedAt 同時刻のタイ時に順序がぶれないよう SnapshotId を第 2 キーに使う
             await using var reader = await connection.ExecuteReaderAsync(@"
                 SELECT SnapshotId, MemoId, Title, Body, SavedAt, Trigger
                 FROM SessionMemoSnapshots
                 WHERE MemoId = @memoId
-                ORDER BY SavedAt DESC
+                ORDER BY SavedAt DESC, SnapshotId DESC
                 LIMIT 1",
                 ("@memoId", memoId.ToString()));
 
@@ -70,7 +71,7 @@ namespace TerminalHub.Services
                 SELECT SnapshotId, MemoId, Title, Body, SavedAt, Trigger
                 FROM SessionMemoSnapshots
                 WHERE MemoId = @memoId
-                ORDER BY SavedAt DESC",
+                ORDER BY SavedAt DESC, SnapshotId DESC",
                 ("@memoId", memoId.ToString()));
 
             while (await reader.ReadAsync())
@@ -113,12 +114,13 @@ namespace TerminalHub.Services
 
             // auto トリガーだけを対象に、古い順に超過分を削除する。
             // pre-delete スナップショットは対象外 (復元の最終防衛線として保護)。
+            // SavedAt 同時刻のタイ時に tie-breaker が無いと削除対象が非決定的になるので SnapshotId を第 2 キーに。
             await connection.ExecuteNonQueryAsync(@"
                 DELETE FROM SessionMemoSnapshots
                 WHERE SnapshotId IN (
                     SELECT SnapshotId FROM SessionMemoSnapshots
                     WHERE MemoId = @memoId AND Trigger = @trigger
-                    ORDER BY SavedAt DESC
+                    ORDER BY SavedAt DESC, SnapshotId DESC
                     LIMIT -1 OFFSET @keep
                 )",
                 ("@memoId", memoId.ToString()),

--- a/TerminalHub/Services/SessionMemoSnapshotRepository.cs
+++ b/TerminalHub/Services/SessionMemoSnapshotRepository.cs
@@ -1,0 +1,118 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using TerminalHub.Models;
+
+namespace TerminalHub.Services
+{
+    public class SessionMemoSnapshotRepository : ISessionMemoSnapshotRepository
+    {
+        private readonly SessionDbContext _dbContext;
+        private readonly ILogger<SessionMemoSnapshotRepository> _logger;
+
+        public SessionMemoSnapshotRepository(SessionDbContext dbContext, ILogger<SessionMemoSnapshotRepository> logger)
+        {
+            _dbContext = dbContext;
+            _logger = logger;
+        }
+
+        public async Task InsertAsync(SessionMemoSnapshot snapshot)
+        {
+            try
+            {
+                await using var connection = _dbContext.CreateConnection();
+                await connection.OpenAsync();
+
+                await connection.ExecuteNonQueryAsync(@"
+                    INSERT INTO SessionMemoSnapshots (SnapshotId, MemoId, Title, Body, SavedAt, Trigger)
+                    VALUES (@snapshotId, @memoId, @title, @body, @savedAt, @trigger)",
+                    ("@snapshotId", snapshot.SnapshotId.ToString()),
+                    ("@memoId", snapshot.MemoId.ToString()),
+                    ("@title", snapshot.Title),
+                    ("@body", snapshot.Body),
+                    ("@savedAt", snapshot.SavedAt.ToString("o")),
+                    ("@trigger", snapshot.Trigger));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[MemoSnapshot] InsertAsync 失敗: SnapshotId={SnapshotId}, MemoId={MemoId}, Trigger={Trigger}",
+                    snapshot.SnapshotId, snapshot.MemoId, snapshot.Trigger);
+                throw;
+            }
+        }
+
+        public async Task<SessionMemoSnapshot?> GetLatestAsync(Guid memoId)
+        {
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            await using var reader = await connection.ExecuteReaderAsync(@"
+                SELECT SnapshotId, MemoId, Title, Body, SavedAt, Trigger
+                FROM SessionMemoSnapshots
+                WHERE MemoId = @memoId
+                ORDER BY SavedAt DESC
+                LIMIT 1",
+                ("@memoId", memoId.ToString()));
+
+            if (await reader.ReadAsync())
+            {
+                return Read(reader);
+            }
+            return null;
+        }
+
+        public async Task<List<SessionMemoSnapshot>> GetByMemoAsync(Guid memoId)
+        {
+            var result = new List<SessionMemoSnapshot>();
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            await using var reader = await connection.ExecuteReaderAsync(@"
+                SELECT SnapshotId, MemoId, Title, Body, SavedAt, Trigger
+                FROM SessionMemoSnapshots
+                WHERE MemoId = @memoId
+                ORDER BY SavedAt DESC",
+                ("@memoId", memoId.ToString()));
+
+            while (await reader.ReadAsync())
+            {
+                result.Add(Read(reader));
+            }
+            return result;
+        }
+
+        public async Task TrimAutoSnapshotsAsync(Guid memoId, int maxAutoKeep)
+        {
+            if (maxAutoKeep <= 0) return;
+
+            await using var connection = _dbContext.CreateConnection();
+            await connection.OpenAsync();
+
+            // auto トリガーだけを対象に、古い順に超過分を削除する。
+            // pre-delete スナップショットは対象外 (復元の最終防衛線として保護)。
+            await connection.ExecuteNonQueryAsync(@"
+                DELETE FROM SessionMemoSnapshots
+                WHERE SnapshotId IN (
+                    SELECT SnapshotId FROM SessionMemoSnapshots
+                    WHERE MemoId = @memoId AND Trigger = @trigger
+                    ORDER BY SavedAt DESC
+                    LIMIT -1 OFFSET @keep
+                )",
+                ("@memoId", memoId.ToString()),
+                ("@trigger", SessionMemoSnapshot.TriggerAuto),
+                ("@keep", maxAutoKeep));
+        }
+
+        private static SessionMemoSnapshot Read(SqliteDataReader reader)
+        {
+            return new SessionMemoSnapshot
+            {
+                SnapshotId = Guid.Parse(reader.GetString(0)),
+                MemoId = Guid.Parse(reader.GetString(1)),
+                Title = reader.GetString(2),
+                Body = reader.GetString(3),
+                SavedAt = DateTime.Parse(reader.GetString(4)),
+                Trigger = reader.GetString(5)
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
メモのうっかり消失対策 Phase 2。10 分毎の自動スナップショット + 論理削除直前 (pre-delete) スナップショット + 過去バージョン復元 UI を追加する。

Phase 1 (PR #36) でタブ × からの論理削除+復元は実装済み。本 PR で「本文を誤って消す」系のロストも救えるようになる。

## データベース
### Schema v7
\`\`\`sql
CREATE TABLE SessionMemoSnapshots (
    SnapshotId TEXT PRIMARY KEY,
    MemoId TEXT NOT NULL,
    Title TEXT NOT NULL DEFAULT '',
    Body TEXT NOT NULL DEFAULT '',
    SavedAt TEXT NOT NULL,
    Trigger TEXT NOT NULL,
    FOREIGN KEY(MemoId) REFERENCES SessionMemos(MemoId) ON DELETE CASCADE
);
CREATE INDEX idx_memo_snapshots_memo ON SessionMemoSnapshots(MemoId, SavedAt DESC);
\`\`\`
- 既存 DB は \`CREATE TABLE IF NOT EXISTS\` で安全に v7 化
- 親メモ消滅 (HardDelete) 時は CASCADE で自動クリーン

## バックエンド
### \`MemoSnapshotService\` (新規 IHostedService)
- 10 分毎 Timer でトリガー
- 全 active セッションを走査 → 各メモで前回 snapshot と本文比較 → 異なれば INSERT
- 超過時は **auto 限定で古い順に DELETE** (pre-delete は retention 対象外で保護)
- 上限: メモ 1 件あたり 50 件
- Timer コールバック内の未捕捉例外は log + 握り潰し (プロセス終了回避)
- Scoped 依存は \`IServiceScopeFactory.CreateScope()\` で都度生成

### \`SessionMemoRepository.DeleteAsync\` に pre-delete snapshot
- 論理削除の直前に現在の Title/Body を 1 件 \`Trigger="pre-delete"\` で snapshot 挿入
- 失敗しても論理削除は実行 (snapshot は best-effort)

## UI: MemoManagementDialog
- 「現在のメモ」の各行に **「履歴 (N)」** ボタンを追加
- クリックで展開 → snapshot を SavedAt 降順表示
  - Trigger バッジで種別を可視化 (auto=secondary, 削除直前=warning)
  - プレビュー本文 + 「このバージョンに戻す」ボタン
- 復元フロー:
  1. 確認モーダル (対象メモ名 + snapshot 時刻 + プレビュー表示)
  2. **復元前に現在本文を auto snapshot として保存** (UI 説明どおり、復元やり直しの保険)
  3. \`UpdateBodyAsync\` で本文差し替え
  4. 履歴キャッシュ更新 + 展開状態維持
  5. \`OnMemoRestored\` で BottomPanel を reload し textarea にも反映

## 変更ファイル
| ファイル | 変更 |
|---|---|
| \`TerminalHub/Services/SessionDbContext.cs\` | v7 migration (CREATE TABLE SessionMemoSnapshots) |
| \`TerminalHub/Models/SessionMemoSnapshot.cs\` | **新規** |
| \`TerminalHub/Services/ISessionMemoSnapshotRepository.cs\` | **新規** |
| \`TerminalHub/Services/SessionMemoSnapshotRepository.cs\` | **新規** |
| \`TerminalHub/Services/MemoSnapshotService.cs\` | **新規** IHostedService |
| \`TerminalHub/Services/SessionMemoRepository.cs\` | DI 追加、DeleteAsync に pre-delete snapshot 挿入 |
| \`TerminalHub/Components/Shared/Dialogs/MemoManagementDialog.razor\` | 履歴アコーディオン + 復元確認 UI |
| \`TerminalHub/Program.cs\` | DI 登録 (SnapshotRepository + MemoSnapshotService) |

## Test plan
- [ ] v6 DB で起動 → v7 migration 適用完了ログ + \`SessionMemoSnapshots\` テーブル作成確認
- [ ] メモ作成 → 本文入力後 10 分経過でログに「Tick 完了: 新規=1」
- [ ] idle メモは 10 分後も snapshot 増えない
- [ ] × で削除時、snapshot に \`Trigger="pre-delete"\` が 1 件
- [ ] メモ管理ダイアログで「履歴」展開 → snapshot 一覧降順表示
- [ ] 「このバージョンに戻す」→ 確認モーダル → BottomPanel の textarea も更新
- [ ] 復元時、現在本文が auto snapshot として残っていること (復元やり直し可)
- [ ] 50 件超の auto snapshot 蓄積で最古が自動削除、pre-delete は残ること

## 動作確認時の tips
- 検証スピードを上げたい場合は一時的に \`MemoSnapshotService.cs\` の \`Interval\` を \`TimeSpan.FromMinutes(10)\` → \`TimeSpan.FromSeconds(30)\` 等に下げる
- SQL 直接確認: \`SELECT SnapshotId, MemoId, SavedAt, Trigger, substr(Body, 1, 40) FROM SessionMemoSnapshots ORDER BY SavedAt DESC;\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)