### PR TITLE
fix: ログと app-settings.json の保存先を %LOCALAPPDATA% に統一

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -1354,13 +1354,10 @@
     {
         try
         {
-            // Program.cs と同じロジックで dev/prod のフォルダを解決する (Development 環境は "logs-dev")
-            var defaultLogsFolderName = HostEnvironment.IsDevelopment() ? "logs-dev" : "logs";
-            var logsFolderName = Configuration.GetValue<string>("Logging:FolderName") ?? defaultLogsFolderName;
-            var logPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "TerminalHub",
-                logsFolderName);
+            // Program.cs と同じヘルパーで dev/prod のフォルダを解決する (Development 環境は "logs-dev")
+            var logPath = AppDataPaths.GetLogsFolder(
+                HostEnvironment.IsDevelopment(),
+                Configuration.GetValue<string>("Logging:FolderName"));
             if (!Directory.Exists(logPath))
             {
                 Directory.CreateDirectory(logPath);

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -4,6 +4,7 @@
 @using Microsoft.Extensions.Configuration
 @inject INotificationService NotificationService
 @inject IConfiguration Configuration
+@inject IHostEnvironment HostEnvironment
 @inject IJSRuntime JSRuntime
 @inject ILocalStorageService LocalStorageService
 @inject IAppSettingsService AppSettingsService
@@ -1353,7 +1354,13 @@
     {
         try
         {
-            var logPath = Path.Combine(AppContext.BaseDirectory, "logs");
+            // Program.cs と同じロジックで dev/prod のフォルダを解決する (Development 環境は "logs-dev")
+            var defaultLogsFolderName = HostEnvironment.IsDevelopment() ? "logs-dev" : "logs";
+            var logsFolderName = Configuration.GetValue<string>("Logging:FolderName") ?? defaultLogsFolderName;
+            var logPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "TerminalHub",
+                logsFolderName);
             if (!Directory.Exists(logPath))
             {
                 Directory.CreateDirectory(logPath);

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -13,8 +13,21 @@ if (args.Contains("--notify"))
 
 var builder = WebApplication.CreateBuilder(args);
 
+// ユーザーデータ保存先: %LOCALAPPDATA%\TerminalHub\
+// 全ユーザー向けインストール (C:\Program Files 配下) でも書き込み権限の問題が起きないよう、
+// ログ / 設定 / DB すべてユーザーの LocalApplicationData 配下に寄せる。
+var userDataRoot = Path.Combine(
+    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+    "TerminalHub");
+Directory.CreateDirectory(userDataRoot);
+
 // Serilog 設定
-var logPath = Path.Combine(AppContext.BaseDirectory, "logs", "terminalhub-.log");
+// フォルダ名は Development 環境だけ "logs-dev" に切り替えて dev/prod のログを分離する。
+// appsettings.Development.json は gitignore 対象なので、環境変数ベースの既定を採用し、
+// 設定上書き (Logging:FolderName) も引き続き受け付ける。
+var defaultLogsFolderName = builder.Environment.IsDevelopment() ? "logs-dev" : "logs";
+var logsFolderName = builder.Configuration.GetValue<string>("Logging:FolderName") ?? defaultLogsFolderName;
+var logPath = Path.Combine(userDataRoot, logsFolderName, "terminalhub-.log");
 builder.Host.UseSerilog((context, configuration) =>
 {
     configuration
@@ -50,9 +63,8 @@ builder.Services.AddSingleton<ISessionManager, SessionManager>();
 builder.Services.AddScoped<ILocalStorageService, LocalStorageService>();
 
 // SQLiteセッションストレージを登録
-var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 var dbFileName = builder.Configuration.GetValue<string>("Database:FileName") ?? "sessions.db";
-var dbPath = Path.Combine(appDataPath, "TerminalHub", dbFileName);
+var dbPath = Path.Combine(userDataRoot, dbFileName);
 builder.Logging.AddFilter("TerminalHub.Services.SessionDbContext", LogLevel.Debug);
 Console.WriteLine($"[DB][起動時診断] 使用するDB: Environment={builder.Environment.EnvironmentName} / FileName={dbFileName} / FullPath={dbPath}");
 builder.Services.AddSingleton<SessionDbContext>(sp =>

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -13,21 +13,13 @@ if (args.Contains("--notify"))
 
 var builder = WebApplication.CreateBuilder(args);
 
-// ユーザーデータ保存先: %LOCALAPPDATA%\TerminalHub\
-// 全ユーザー向けインストール (C:\Program Files 配下) でも書き込み権限の問題が起きないよう、
-// ログ / 設定 / DB すべてユーザーの LocalApplicationData 配下に寄せる。
-var userDataRoot = Path.Combine(
-    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-    "TerminalHub");
-Directory.CreateDirectory(userDataRoot);
-
 // Serilog 設定
-// フォルダ名は Development 環境だけ "logs-dev" に切り替えて dev/prod のログを分離する。
-// appsettings.Development.json は gitignore 対象なので、環境変数ベースの既定を採用し、
-// 設定上書き (Logging:FolderName) も引き続き受け付ける。
-var defaultLogsFolderName = builder.Environment.IsDevelopment() ? "logs-dev" : "logs";
-var logsFolderName = builder.Configuration.GetValue<string>("Logging:FolderName") ?? defaultLogsFolderName;
-var logPath = Path.Combine(userDataRoot, logsFolderName, "terminalhub-.log");
+// ユーザーデータ配下 (%LOCALAPPDATA%\TerminalHub\) にログを置く。Program Files にインストールした
+// 場合の書き込み権限エラーを回避するため。dev/prod は AppDataPaths 側で切り分け。
+var logsFolder = AppDataPaths.GetLogsFolder(
+    builder.Environment.IsDevelopment(),
+    builder.Configuration.GetValue<string>("Logging:FolderName"));
+var logPath = Path.Combine(logsFolder, "terminalhub-.log");
 builder.Host.UseSerilog((context, configuration) =>
 {
     configuration
@@ -64,7 +56,7 @@ builder.Services.AddScoped<ILocalStorageService, LocalStorageService>();
 
 // SQLiteセッションストレージを登録
 var dbFileName = builder.Configuration.GetValue<string>("Database:FileName") ?? "sessions.db";
-var dbPath = Path.Combine(userDataRoot, dbFileName);
+var dbPath = Path.Combine(AppDataPaths.UserDataRoot, dbFileName);
 builder.Logging.AddFilter("TerminalHub.Services.SessionDbContext", LogLevel.Debug);
 Console.WriteLine($"[DB][起動時診断] 使用するDB: Environment={builder.Environment.EnvironmentName} / FileName={dbFileName} / FullPath={dbPath}");
 builder.Services.AddSingleton<SessionDbContext>(sp =>

--- a/TerminalHub/Services/AppDataPaths.cs
+++ b/TerminalHub/Services/AppDataPaths.cs
@@ -1,0 +1,49 @@
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// アプリのユーザーデータ (DB / ログ / 設定ファイル) の保存先パスを一元解決する。
+    /// 実行ファイル配下ではなく %LOCALAPPDATA%\TerminalHub\ を使うことで、
+    /// 全ユーザー向けインストール (C:\Program Files 配下) でも書き込み権限の問題を避ける。
+    /// dev/prod は IsDevelopment フラグで既定値を切り替え、configuration からの上書きも受け付ける。
+    /// </summary>
+    public static class AppDataPaths
+    {
+        /// <summary>
+        /// %LOCALAPPDATA%\TerminalHub\ を返す。型初期化時にディレクトリ存在を保証する。
+        /// </summary>
+        public static string UserDataRoot { get; } = InitializeUserDataRoot();
+
+        private static string InitializeUserDataRoot()
+        {
+            var path = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "TerminalHub");
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        /// <summary>
+        /// ログ出力先フォルダのフルパス。dev では "logs-dev"、prod では "logs"。
+        /// configOverride が指定されていればそちらを優先する (Logging:FolderName 等)。
+        /// </summary>
+        public static string GetLogsFolder(bool isDevelopment, string? configOverride = null)
+        {
+            var folderName = !string.IsNullOrWhiteSpace(configOverride)
+                ? configOverride
+                : (isDevelopment ? "logs-dev" : "logs");
+            return Path.Combine(UserDataRoot, folderName);
+        }
+
+        /// <summary>
+        /// app-settings.json のフルパス。dev では "app-settings-dev.json"、prod では "app-settings.json"。
+        /// configOverride が指定されていればそちらを優先する (AppSettings:FileName 等)。
+        /// </summary>
+        public static string GetAppSettingsFilePath(bool isDevelopment, string? configOverride = null)
+        {
+            var fileName = !string.IsNullOrWhiteSpace(configOverride)
+                ? configOverride
+                : (isDevelopment ? "app-settings-dev.json" : "app-settings.json");
+            return Path.Combine(UserDataRoot, fileName);
+        }
+    }
+}

--- a/TerminalHub/Services/AppSettingsService.cs
+++ b/TerminalHub/Services/AppSettingsService.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using TerminalHub.Models;
 
@@ -47,14 +49,57 @@ public class AppSettingsService : IAppSettingsService
 
     public AppSettingsService(
         ILogger<AppSettingsService> logger,
-        IHttpClientFactory httpClientFactory)
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        IHostEnvironment hostEnvironment)
     {
         _logger = logger;
         _httpClientFactory = httpClientFactory;
 
-        // 実行ファイルと同じディレクトリに設定ファイルを保存
-        var exeDir = AppContext.BaseDirectory;
-        _settingsFilePath = Path.Combine(exeDir, "app-settings.json");
+        // 設定ファイルはユーザーの LocalApplicationData 配下 (%LOCALAPPDATA%\TerminalHub\) に保存する。
+        // 実行ファイルと同じディレクトリだと C:\Program Files 配下にインストールした場合に書き込み権限が無く、
+        // サイレントに保存失敗する問題があったため。
+        // ファイル名は Development 環境で "app-settings-dev.json" に切り替え、dev/prod の設定を分離する。
+        // appsettings.Development.json は gitignore 対象なので環境変数ベースの既定を採用。
+        var userDataRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TerminalHub");
+        Directory.CreateDirectory(userDataRoot);
+
+        var defaultFileName = hostEnvironment.IsDevelopment() ? "app-settings-dev.json" : "app-settings.json";
+        var fileName = configuration.GetValue<string>("AppSettings:FileName") ?? defaultFileName;
+        _settingsFilePath = Path.Combine(userDataRoot, fileName);
+
+        // 旧バージョン (v1.0.54 以前) の設定ファイルが実行ファイル隣に残っていれば 1 回だけ移行する。
+        // 失敗しても既定値で続行できるよう、例外は握り潰してログのみ残す。
+        TryMigrateLegacySettingsFile();
+    }
+
+    private void TryMigrateLegacySettingsFile()
+    {
+        try
+        {
+            if (File.Exists(_settingsFilePath))
+            {
+                // 既に新しい場所に存在する場合はそちらを優先 (上書きしない)
+                return;
+            }
+
+            var legacyPath = Path.Combine(AppContext.BaseDirectory, "app-settings.json");
+            if (!File.Exists(legacyPath))
+            {
+                return;
+            }
+
+            File.Copy(legacyPath, _settingsFilePath, overwrite: false);
+            _logger.LogInformation(
+                "[AppSettings] 旧設定ファイルを移行しました: {LegacyPath} → {NewPath}",
+                legacyPath, _settingsFilePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[AppSettings] 旧設定ファイルの移行に失敗 (既定値で続行)");
+        }
     }
 
     public AppSettings GetSettings()

--- a/TerminalHub/Services/AppSettingsService.cs
+++ b/TerminalHub/Services/AppSettingsService.cs
@@ -56,19 +56,10 @@ public class AppSettingsService : IAppSettingsService
         _logger = logger;
         _httpClientFactory = httpClientFactory;
 
-        // 設定ファイルはユーザーの LocalApplicationData 配下 (%LOCALAPPDATA%\TerminalHub\) に保存する。
-        // 実行ファイルと同じディレクトリだと C:\Program Files 配下にインストールした場合に書き込み権限が無く、
-        // サイレントに保存失敗する問題があったため。
-        // ファイル名は Development 環境で "app-settings-dev.json" に切り替え、dev/prod の設定を分離する。
-        // appsettings.Development.json は gitignore 対象なので環境変数ベースの既定を採用。
-        var userDataRoot = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "TerminalHub");
-        Directory.CreateDirectory(userDataRoot);
-
-        var defaultFileName = hostEnvironment.IsDevelopment() ? "app-settings-dev.json" : "app-settings.json";
-        var fileName = configuration.GetValue<string>("AppSettings:FileName") ?? defaultFileName;
-        _settingsFilePath = Path.Combine(userDataRoot, fileName);
+        // 設定ファイルは %LOCALAPPDATA%\TerminalHub\ 配下に保存 (書き込み権限と dev/prod 分離は AppDataPaths 参照)。
+        _settingsFilePath = AppDataPaths.GetAppSettingsFilePath(
+            hostEnvironment.IsDevelopment(),
+            configuration.GetValue<string>("AppSettings:FileName"));
 
         // 旧バージョン (v1.0.54 以前) の設定ファイルが実行ファイル隣に残っていれば 1 回だけ移行する。
         // 失敗しても既定値で続行できるよう、例外は握り潰してログのみ残す。


### PR DESCRIPTION
## Summary
全ユーザー向けインストール (`C:\Program Files\TerminalHub\`) の場合、標準ユーザーでは実行ファイル配下 (`AppContext.BaseDirectory`) への書き込み権限が無く、**ログ生成と `app-settings.json` 保存がサイレントに失敗していた** 問題を修正する。

DB は既に `%LOCALAPPDATA%\TerminalHub\` に置かれているので、ログと設定ファイルも同じ親ディレクトリに揃える。

## 変更後のデータ配置

| データ | Development 環境 | Production 環境 |
|---|---|---|
| DB | `%LOCALAPPDATA%\TerminalHub\sessions-dev7.db` | `%LOCALAPPDATA%\TerminalHub\sessions.db` |
| ログ | `%LOCALAPPDATA%\TerminalHub\logs-dev\` | `%LOCALAPPDATA%\TerminalHub\logs\` |
| 設定 | `%LOCALAPPDATA%\TerminalHub\app-settings-dev.json` | `%LOCALAPPDATA%\TerminalHub\app-settings.json` |

## 変更内容

### `Program.cs`
- `userDataRoot` (= `%LOCALAPPDATA%\TerminalHub\`) を先頭で計算し、ログ・DB の共通親として使用
- `IHostEnvironment.IsDevelopment()` を既定に、`Logging:FolderName` で設定上書き可

### `Services/AppSettingsService.cs`
- `app-settings.json` を `userDataRoot` 配下へ移動
- `IConfiguration` + `IHostEnvironment` を注入、`AppSettings:FileName` で上書き可
- **自動マイグレーション**: 旧 (v1.0.54 以前) の `AppContext.BaseDirectory\app-settings.json` が残っていれば、新パスに無い場合のみ 1 回だけコピー。失敗しても既定値で起動継続

### `Components/Shared/Dialogs/SettingsDialog.razor`
- 「ログフォルダを開く」の参照先も新パス + dev/prod 追従

### dev/prod 分離のアプローチ
`appsettings.Development.json` は `.gitignore` 対象のため、設定ファイルに依存せず `IHostEnvironment.IsDevelopment()` で既定値を切り替える方式を採用。他の開発環境にクローンしても自動で `logs-dev` / `app-settings-dev.json` が使われる。

## 検証内容
- [ ] v1.0.54 をインストール済みの環境で v1.0.55 にアップグレード → 旧 `app-settings.json` が自動で `%LOCALAPPDATA%\TerminalHub\` に移行されること (ログの `[AppSettings] 旧設定ファイルを移行しました` 確認)
- [ ] 新規インストール → `%LOCALAPPDATA%\TerminalHub\logs\` にログが出力されること
- [ ] Development 実行時 → `logs-dev\` と `app-settings-dev.json` に分離されること
- [ ] `C:\Program Files\TerminalHub\` への全ユーザーインストールでもログが書かれること (これが本 PR のメインターゲット)

## 後方互換 / リスク
- マイグレーションは新パスに設定が無い場合のみ実行されるので、2 回目以降の起動で上書きされることはない
- ログは旧場所のファイルを移行しない (ログは揮発扱い)
- 旧パス (`<exe>\app-settings.json`) はそのまま残るが、アプリは読みにいかなくなるので実害なし。必要なら将来のバージョンで掃除可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)