### PR TITLE
feat: 設定ダイアログ 表示/通知/セッション タブを多言語対応 (Phase 2B-1)

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -248,16 +248,16 @@
                         else if (activeTab == "display")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">表示設定</h6>
+                                <h6 class="mb-3">@L["Settings.Display.Header"]</h6>
 
                                 <div class="mb-4">
-                                    <label class="form-label">テーマ</label>
+                                    <label class="form-label">@L["Settings.Display.Theme.Label"]</label>
                                     <div class="form-check">
                                         <input class="form-check-input" type="radio" name="themeMode"
                                                id="themeLight" value="light" checked="@(theme == "light")"
                                                @onchange="@(() => OnThemePreviewChange("light"))">
                                         <label class="form-check-label" for="themeLight">
-                                            <i class="bi bi-sun me-1"></i>ライト
+                                            <i class="bi bi-sun me-1"></i>@L["Settings.Display.Theme.Light"]
                                         </label>
                                     </div>
                                     <div class="form-check">
@@ -265,13 +265,13 @@
                                                id="themeDark" value="dark" checked="@(theme == "dark")"
                                                @onchange="@(() => OnThemePreviewChange("dark"))">
                                         <label class="form-check-label" for="themeDark">
-                                            <i class="bi bi-moon-stars me-1"></i>ダーク
+                                            <i class="bi bi-moon-stars me-1"></i>@L["Settings.Display.Theme.Dark"]
                                         </label>
                                     </div>
                                 </div>
 
                                 <div class="mb-4">
-                                    <label class="form-label">セッションリスト表示倍率</label>
+                                    <label class="form-label">@L["Settings.Display.SessionListScale.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
                                                min="0.5" max="1.5" step="0.05"
@@ -280,12 +280,12 @@
                                         <span class="badge bg-secondary" style="min-width: 50px;">@((sessionListScale * 100).ToString("0"))%</span>
                                     </div>
                                     <small class="text-muted">
-                                        セッションリストの表示倍率を調整します（50%〜150%）。
+                                        @L["Settings.Display.SessionListScale.Help"]
                                     </small>
                                 </div>
 
                                 <div class="mb-4">
-                                    <label class="form-label">ターミナルフォントサイズ</label>
+                                    <label class="form-label">@L["Settings.Display.TerminalFontSize.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
                                                min="8" max="28" step="1"
@@ -294,12 +294,12 @@
                                         <span class="badge bg-secondary" style="min-width: 50px;">@(terminalFontSize)px</span>
                                     </div>
                                     <small class="text-muted">
-                                        ターミナルのフォントサイズを調整します（8px〜28px）。
+                                        @L["Settings.Display.TerminalFontSize.Help"]
                                     </small>
                                 </div>
 
                                 <div class="mb-4">
-                                    <label class="form-label">サイドバー幅</label>
+                                    <label class="form-label">@L["Settings.Display.SidebarWidth.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
                                                min="15" max="40" step="1"
@@ -308,12 +308,12 @@
                                         <span class="badge bg-secondary" style="min-width: 60px;">@(sidebarWidthPercent)%</span>
                                     </div>
                                     <small class="text-muted">
-                                        セッションリストの幅を調整します（15%〜40%）。境界線のドラッグでも変更できます。
+                                        @L["Settings.Display.SidebarWidth.Help"]
                                     </small>
                                 </div>
 
                                 <div class="mb-4">
-                                    <label class="form-label">ターミナル / 入力パネル比率</label>
+                                    <label class="form-label">@L["Settings.Display.TerminalHeightRatio.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
                                                min="20" max="90" step="1"
@@ -322,7 +322,7 @@
                                         <span class="badge bg-secondary" style="min-width: 80px;">@(terminalHeightPercent) / @(100 - terminalHeightPercent)</span>
                                     </div>
                                     <small class="text-muted">
-                                        ターミナルと入力パネルの高さ比率を調整します（50:50〜90:10）。境界線のドラッグでも変更できます。
+                                        @L["Settings.Display.TerminalHeightRatio.Help"]
                                     </small>
                                 </div>
                             </div>
@@ -330,85 +330,83 @@
                         else if (activeTab == "notifications")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">通知設定</h6>
-                    
+                                <h6 class="mb-3">@L["Settings.Notifications.Header"]</h6>
+
                     <div class="mb-4">
                         <div class="d-flex align-items-center justify-content-between mb-2">
-                            <label class="form-label mb-0">ブラウザ通知</label>
-                            <span class="badge @GetNotificationBadgeClass()">@notificationStatus</span>
+                            <label class="form-label mb-0">@L["Settings.Notifications.Browser.Label"]</label>
+                            <span class="badge @GetNotificationBadgeClass()">@GetNotificationStatusText()</span>
                         </div>
-                        @if (notificationStatus == "許可済み")
+                        @if (notificationStatus == NotifStateGranted)
                         {
                             <div class="form-check form-switch mb-2">
                                 <input class="form-check-input" type="checkbox" @bind="browserNotificationEnabled" id="browserNotificationSwitch">
                                 <label class="form-check-label" for="browserNotificationSwitch">
-                                    ブラウザ通知を有効にする
+                                    @L["Settings.Notifications.Browser.Enable"]
                                 </label>
                             </div>
                             <button class="btn btn-outline-secondary btn-sm" @onclick="OpenBrowserNotificationSettings">
-                                <i class="bi bi-gear me-1"></i>通知許可を解除
+                                <i class="bi bi-gear me-1"></i>@L["Settings.Notifications.Browser.Revoke"]
                             </button>
                             <p class="text-muted small mt-2 mb-0">
-                                ブラウザの設定画面で通知許可を解除できます。
+                                @L["Settings.Notifications.Browser.RevokeHelp"]
                             </p>
                         }
-                        else if (notificationStatus == "未許可")
+                        else if (notificationStatus == NotifStateNotRequested)
                         {
                             <button class="btn btn-primary btn-sm" @onclick="RequestNotificationPermission">
-                                <i class="bi bi-bell me-1"></i>通知を許可する
+                                <i class="bi bi-bell me-1"></i>@L["Settings.Notifications.Browser.Request"]
                             </button>
                             <p class="text-muted small mt-2 mb-0">
-                                処理完了時にデスクトップ通知を受け取るには、ブラウザの通知を許可してください。
+                                @L["Settings.Notifications.Browser.RequestHelp"]
                             </p>
                         }
                     </div>
-                    
+
                     <div class="mb-4">
-                        <label class="form-label">通知を送信する処理時間（秒）</label>
+                        <label class="form-label">@L["Settings.Notifications.Threshold.Label"]</label>
                         <input type="number" class="form-control" @bind="thresholdSeconds" min="0" max="3600" />
-                        <small class="text-muted">0に設定すると、すべての処理完了時に通知します</small>
+                        <small class="text-muted">@L["Settings.Notifications.Threshold.Help"]</small>
                     </div>
-                    
+
                     <hr />
-                    
-                    <h6 class="mb-3">WebHook設定</h6>
-                    
+
+                    <h6 class="mb-3">@L["Settings.Notifications.Webhook.Header"]</h6>
+
                     <div class="mb-3">
                         <div class="form-check form-switch">
                             <input class="form-check-input" type="checkbox" @bind="webHookEnabled" id="webHookSwitch">
                             <label class="form-check-label" for="webHookSwitch">
-                                WebHook通知を有効にする
+                                @L["Settings.Notifications.Webhook.Enable"]
                             </label>
                         </div>
                     </div>
-                    
+
                     @if (webHookEnabled)
                     {
                         <div class="mb-3">
-                            <label class="form-label">WebHook URL</label>
+                            <label class="form-label">@L["Settings.Notifications.Webhook.UrlLabel"]</label>
                             <input type="url" class="form-control" @bind="webHookUrl" placeholder="https://example.com/webhook" />
                         </div>
                     }
 
                     <hr />
 
-                    <h6 class="mb-3">Claude Code Hook設定</h6>
+                    <h6 class="mb-3">@L["Settings.Notifications.ClaudeHook.Header"]</h6>
                     <p class="text-muted small mb-3">
-                        Claude Code の hook 機能を使用して、より確実に通知を受け取ることができます。
-                        セッション作成時に自動的に <code>.claude/settings.local.json</code> に設定が追加されます。
+                        @((MarkupString)L["Settings.Notifications.ClaudeHook.HelpHtml"].Value)
                     </p>
 
                     <div class="mb-3">
                         <div class="form-check form-switch">
                             <input class="form-check-input" type="checkbox" @bind="claudeHookEnabled" id="claudeHookSwitch">
                             <label class="form-check-label" for="claudeHookSwitch">
-                                Claude Code Hook を有効にする
+                                @L["Settings.Notifications.ClaudeHook.Enable"]
                             </label>
                         </div>
                         <small class="text-muted d-block mt-1">
                             <i class="bi bi-info-circle me-1"></i>
-                            この設定は各セッションが次に起動／再起動されたタイミングで <code>.claude/settings.local.json</code> に反映されます。
-                            既に起動中のセッションや、TerminalHub 管理外のワークスペースには即時適用されません。
+                            @((MarkupString)L["Settings.Notifications.ClaudeHook.ApplyNoticeHtml"].Value)
                         </small>
                     </div>
 
@@ -417,16 +415,16 @@
                         else if (activeTab == "sessions")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">セッション設定</h6>
+                                <h6 class="mb-3">@L["Settings.Sessions.Header"]</h6>
 
                                 <div class="mb-4">
-                                    <label class="form-label">セッション一覧の並び順</label>
+                                    <label class="form-label">@L["Settings.Sessions.SortOrder.Label"]</label>
                                     <div class="form-check">
                                         <input class="form-check-input" type="radio" name="sessionSortMode"
                                                id="sortByCreatedAt" value="createdAt" checked="@(sessionSortMode == "createdAt")"
                                                @onchange="@(() => sessionSortMode = "createdAt")">
                                         <label class="form-check-label" for="sortByCreatedAt">
-                                            <i class="bi bi-calendar-plus me-1"></i>作成日時順
+                                            <i class="bi bi-calendar-plus me-1"></i>@L["Settings.Sessions.SortOrder.ByCreatedAt"]
                                         </label>
                                     </div>
                                     <div class="form-check">
@@ -434,8 +432,8 @@
                                                id="sortByLastAccessed" value="lastAccessed" checked="@(sessionSortMode == "lastAccessed")"
                                                @onchange="@(() => sessionSortMode = "lastAccessed")">
                                         <label class="form-check-label" for="sortByLastAccessed">
-                                            <i class="bi bi-clock-history me-1"></i>最終利用日時順
-                                            <span class="text-muted small">（最近使用したセッションが上に表示）</span>
+                                            <i class="bi bi-clock-history me-1"></i>@L["Settings.Sessions.SortOrder.ByLastAccessed"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.SortOrder.ByLastAccessedSub"]）</span>
                                         </label>
                                     </div>
                                     <div class="form-check">
@@ -443,53 +441,53 @@
                                                id="sortByName" value="name" checked="@(sessionSortMode == "name")"
                                                @onchange="@(() => sessionSortMode = "name")">
                                         <label class="form-check-label" for="sortByName">
-                                            <i class="bi bi-sort-alpha-down me-1"></i>名前順
+                                            <i class="bi bi-sort-alpha-down me-1"></i>@L["Settings.Sessions.SortOrder.ByName"]
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        「最終利用日時順」では、子セッション（Worktree）の利用も親セッションの順序に反映されます。
+                                        @L["Settings.Sessions.SortOrder.Help"]
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <label class="form-label">セッション一覧の表示設定</label>
+                                    <label class="form-label">@L["Settings.Sessions.Display.Label"]</label>
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" @bind="showTerminalType" id="showTerminalType">
                                         <label class="form-check-label" for="showTerminalType">
-                                            <i class="bi bi-tag me-1"></i>ターミナル種別を表示
-                                            <span class="text-muted small">（Claude/Gemini/Codexバッジ）</span>
+                                            <i class="bi bi-tag me-1"></i>@L["Settings.Sessions.Display.ShowTerminalType"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.Display.ShowTerminalTypeSub"]）</span>
                                         </label>
                                     </div>
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" @bind="showGitInfo" id="showGitInfo">
                                         <label class="form-check-label" for="showGitInfo">
-                                            <i class="bi bi-git me-1"></i>Git情報を表示
-                                            <span class="text-muted small">（ブランチ名バッジ）</span>
+                                            <i class="bi bi-git me-1"></i>@L["Settings.Sessions.Display.ShowGitInfo"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.Display.ShowGitInfoSub"]）</span>
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        セッション一覧に表示する追加情報を選択できます。
+                                        @L["Settings.Sessions.Display.Help"]
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <label class="form-label">入力パネル設定</label>
+                                    <label class="form-label">@L["Settings.Sessions.InputPanel.Label"]</label>
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" @bind="hideInputPanel" id="hideInputPanel">
                                         <label class="form-check-label" for="hideInputPanel">
-                                            <i class="bi bi-textarea me-1"></i>入力パネルを非表示
-                                            <span class="text-muted small">（ターミナルのみ表示）</span>
+                                            <i class="bi bi-textarea me-1"></i>@L["Settings.Sessions.InputPanel.Hide"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.InputPanel.HideSub"]）</span>
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        下部の入力パネルを非表示にして、ターミナル領域を広く使えます。
+                                        @L["Settings.Sessions.InputPanel.HideHelp"]
                                     </p>
                                 </div>
                             </div>
@@ -1058,7 +1056,16 @@
     [Parameter] public bool IsVisible { get; set; }
     [Parameter] public EventCallback<bool> IsVisibleChanged { get; set; }
 
-    private string notificationStatus = "確認中...";
+    // notificationStatus はブラウザの Notification API の permission 値 ("granted"/"denied"/"default")
+    // に、アプリ側の擬似状態 ("checking"/"error"/"unknown") を追加した state key を保持する。
+    // UI 表示文字列は GetNotificationStatusText() / GetNotificationBadgeClass() で解決する。
+    private const string NotifStateChecking = "checking";
+    private const string NotifStateGranted = "granted";
+    private const string NotifStateDenied = "denied";
+    private const string NotifStateNotRequested = "default"; // JS permission "default" = 未許可
+    private const string NotifStateError = "error";
+    private const string NotifStateUnknown = "unknown";
+    private string notificationStatus = NotifStateChecking;
     private int thresholdSeconds = 60;
     private bool browserNotificationEnabled = true;
     private bool webHookEnabled = false;
@@ -1320,15 +1327,15 @@
             var permission = await JSRuntime.InvokeAsync<string>("terminalHubHelpers.checkNotificationPermission");
             notificationStatus = permission switch
             {
-                "granted" => "許可済み",
-                "denied" => "拒否",
-                "default" => "未許可",
-                _ => "不明"
+                "granted" => NotifStateGranted,
+                "denied" => NotifStateDenied,
+                "default" => NotifStateNotRequested,
+                _ => NotifStateUnknown
             };
         }
         catch
         {
-            notificationStatus = "確認エラー";
+            notificationStatus = NotifStateError;
         }
     }
     
@@ -1848,11 +1855,26 @@
     {
         return notificationStatus switch
         {
-            "許可済み" => "bg-success",
-            "拒否" => "bg-danger",
-            "未許可" => "bg-warning",
+            NotifStateGranted => "bg-success",
+            NotifStateDenied => "bg-danger",
+            NotifStateNotRequested => "bg-warning",
             _ => "bg-secondary"
         };
+    }
+
+    // notificationStatus (state key) に対応する localized 表示文字列を返す
+    private string GetNotificationStatusText()
+    {
+        var key = notificationStatus switch
+        {
+            NotifStateGranted => "Granted",
+            NotifStateDenied => "Denied",
+            NotifStateNotRequested => "NotRequested",
+            NotifStateChecking => "Checking",
+            NotifStateError => "CheckError",
+            _ => "Unknown"
+        };
+        return L[$"Settings.Notifications.Status.{key}"];
     }
     
     private async Task Close()

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -94,4 +94,61 @@
   <data name="Settings.General.Community.Header" xml:space="preserve"><value>Community</value></data>
   <data name="Settings.General.Community.JoinDiscord" xml:space="preserve"><value>Join the Discord server</value></data>
   <data name="Settings.General.Community.Help" xml:space="preserve"><value>Bug reports, feature requests, and questions are welcome there.</value></data>
+
+  <!-- Settings: Display Tab -->
+  <data name="Settings.Display.Header" xml:space="preserve"><value>Display</value></data>
+  <data name="Settings.Display.Theme.Label" xml:space="preserve"><value>Theme</value></data>
+  <data name="Settings.Display.Theme.Light" xml:space="preserve"><value>Light</value></data>
+  <data name="Settings.Display.Theme.Dark" xml:space="preserve"><value>Dark</value></data>
+  <data name="Settings.Display.SessionListScale.Label" xml:space="preserve"><value>Session list scale</value></data>
+  <data name="Settings.Display.SessionListScale.Help" xml:space="preserve"><value>Adjust the session list display scale (50%–150%).</value></data>
+  <data name="Settings.Display.TerminalFontSize.Label" xml:space="preserve"><value>Terminal font size</value></data>
+  <data name="Settings.Display.TerminalFontSize.Help" xml:space="preserve"><value>Adjust the terminal font size (8px–28px).</value></data>
+  <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>Sidebar width</value></data>
+  <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>Adjust the session list width (15%–40%). You can also drag the border.</value></data>
+  <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>Terminal / input panel ratio</value></data>
+  <data name="Settings.Display.TerminalHeightRatio.Help" xml:space="preserve"><value>Adjust the height ratio between the terminal and input panel (50:50–90:10). You can also drag the border.</value></data>
+
+  <!-- Settings: Notifications Tab -->
+  <data name="Settings.Notifications.Header" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Settings.Notifications.Browser.Label" xml:space="preserve"><value>Browser notifications</value></data>
+  <data name="Settings.Notifications.Status.Granted" xml:space="preserve"><value>Allowed</value></data>
+  <data name="Settings.Notifications.Status.Denied" xml:space="preserve"><value>Denied</value></data>
+  <data name="Settings.Notifications.Status.NotRequested" xml:space="preserve"><value>Not requested</value></data>
+  <data name="Settings.Notifications.Status.Checking" xml:space="preserve"><value>Checking...</value></data>
+  <data name="Settings.Notifications.Status.CheckError" xml:space="preserve"><value>Check failed</value></data>
+  <data name="Settings.Notifications.Status.Unknown" xml:space="preserve"><value>Unknown</value></data>
+  <data name="Settings.Notifications.Browser.Enable" xml:space="preserve"><value>Enable browser notifications</value></data>
+  <data name="Settings.Notifications.Browser.Revoke" xml:space="preserve"><value>Revoke notification permission</value></data>
+  <data name="Settings.Notifications.Browser.RevokeHelp" xml:space="preserve"><value>You can revoke the notification permission from your browser's settings.</value></data>
+  <data name="Settings.Notifications.Browser.Request" xml:space="preserve"><value>Allow notifications</value></data>
+  <data name="Settings.Notifications.Browser.RequestHelp" xml:space="preserve"><value>To receive desktop notifications when processing completes, please allow browser notifications.</value></data>
+  <data name="Settings.Notifications.Threshold.Label" xml:space="preserve"><value>Notify after processing time (seconds)</value></data>
+  <data name="Settings.Notifications.Threshold.Help" xml:space="preserve"><value>Set to 0 to notify on every completion</value></data>
+  <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>Webhook</value></data>
+  <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>Enable webhook notifications</value></data>
+  <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>Webhook URL</value></data>
+  <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>Claude Code Hook</value></data>
+  <data name="Settings.Notifications.ClaudeHook.HelpHtml" xml:space="preserve"><value>Use Claude Code's hook feature to receive notifications more reliably. Settings are automatically added to &lt;code&gt;.claude/settings.local.json&lt;/code&gt; when a session is created.</value></data>
+  <data name="Settings.Notifications.ClaudeHook.Enable" xml:space="preserve"><value>Enable Claude Code Hook</value></data>
+  <data name="Settings.Notifications.ClaudeHook.ApplyNoticeHtml" xml:space="preserve"><value>This setting is applied to &lt;code&gt;.claude/settings.local.json&lt;/code&gt; the next time each session is started/restarted. It is not applied immediately to running sessions or workspaces outside TerminalHub's management.</value></data>
+
+  <!-- Settings: Sessions Tab -->
+  <data name="Settings.Sessions.Header" xml:space="preserve"><value>Sessions</value></data>
+  <data name="Settings.Sessions.SortOrder.Label" xml:space="preserve"><value>Session list sort order</value></data>
+  <data name="Settings.Sessions.SortOrder.ByCreatedAt" xml:space="preserve"><value>By creation date</value></data>
+  <data name="Settings.Sessions.SortOrder.ByLastAccessed" xml:space="preserve"><value>By last accessed</value></data>
+  <data name="Settings.Sessions.SortOrder.ByLastAccessedSub" xml:space="preserve"><value>Most recently used appear at the top</value></data>
+  <data name="Settings.Sessions.SortOrder.ByName" xml:space="preserve"><value>By name</value></data>
+  <data name="Settings.Sessions.SortOrder.Help" xml:space="preserve"><value>In "By last accessed" order, usage of child (worktree) sessions is reflected in the parent's position.</value></data>
+  <data name="Settings.Sessions.Display.Label" xml:space="preserve"><value>Session list display settings</value></data>
+  <data name="Settings.Sessions.Display.ShowTerminalType" xml:space="preserve"><value>Show terminal type</value></data>
+  <data name="Settings.Sessions.Display.ShowTerminalTypeSub" xml:space="preserve"><value>Claude / Gemini / Codex badges</value></data>
+  <data name="Settings.Sessions.Display.ShowGitInfo" xml:space="preserve"><value>Show Git info</value></data>
+  <data name="Settings.Sessions.Display.ShowGitInfoSub" xml:space="preserve"><value>Branch name badge</value></data>
+  <data name="Settings.Sessions.Display.Help" xml:space="preserve"><value>Choose which additional info to display in the session list.</value></data>
+  <data name="Settings.Sessions.InputPanel.Label" xml:space="preserve"><value>Input panel settings</value></data>
+  <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>Hide input panel</value></data>
+  <data name="Settings.Sessions.InputPanel.HideSub" xml:space="preserve"><value>Terminal only</value></data>
+  <data name="Settings.Sessions.InputPanel.HideHelp" xml:space="preserve"><value>Hide the bottom input panel to use more space for the terminal.</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -137,8 +137,8 @@
   <data name="Settings.Sessions.Header" xml:space="preserve"><value>Sessions</value></data>
   <data name="Settings.Sessions.SortOrder.Label" xml:space="preserve"><value>Session list sort order</value></data>
   <data name="Settings.Sessions.SortOrder.ByCreatedAt" xml:space="preserve"><value>By creation date</value></data>
-  <data name="Settings.Sessions.SortOrder.ByLastAccessed" xml:space="preserve"><value>By last accessed</value></data>
-  <data name="Settings.Sessions.SortOrder.ByLastAccessedSub" xml:space="preserve"><value>Most recently used appear at the top</value></data>
+  <data name="Settings.Sessions.SortOrder.ByLastAccessed" xml:space="preserve"><value>By last used</value></data>
+  <data name="Settings.Sessions.SortOrder.ByLastAccessedSub" xml:space="preserve"><value>Most recently used sessions appear at the top</value></data>
   <data name="Settings.Sessions.SortOrder.ByName" xml:space="preserve"><value>By name</value></data>
   <data name="Settings.Sessions.SortOrder.Help" xml:space="preserve"><value>In "By last accessed" order, usage of child (worktree) sessions is reflected in the parent's position.</value></data>
   <data name="Settings.Sessions.Display.Label" xml:space="preserve"><value>Session list display settings</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -94,4 +94,61 @@
   <data name="Settings.General.Community.Header" xml:space="preserve"><value>コミュニティ</value></data>
   <data name="Settings.General.Community.JoinDiscord" xml:space="preserve"><value>Discord サーバーに参加</value></data>
   <data name="Settings.General.Community.Help" xml:space="preserve"><value>バグ報告、機能リクエスト、質問などはこちらで受け付けています。</value></data>
+
+  <!-- Settings: Display Tab -->
+  <data name="Settings.Display.Header" xml:space="preserve"><value>表示設定</value></data>
+  <data name="Settings.Display.Theme.Label" xml:space="preserve"><value>テーマ</value></data>
+  <data name="Settings.Display.Theme.Light" xml:space="preserve"><value>ライト</value></data>
+  <data name="Settings.Display.Theme.Dark" xml:space="preserve"><value>ダーク</value></data>
+  <data name="Settings.Display.SessionListScale.Label" xml:space="preserve"><value>セッションリスト表示倍率</value></data>
+  <data name="Settings.Display.SessionListScale.Help" xml:space="preserve"><value>セッションリストの表示倍率を調整します（50%〜150%）。</value></data>
+  <data name="Settings.Display.TerminalFontSize.Label" xml:space="preserve"><value>ターミナルフォントサイズ</value></data>
+  <data name="Settings.Display.TerminalFontSize.Help" xml:space="preserve"><value>ターミナルのフォントサイズを調整します（8px〜28px）。</value></data>
+  <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>サイドバー幅</value></data>
+  <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>セッションリストの幅を調整します（15%〜40%）。境界線のドラッグでも変更できます。</value></data>
+  <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>ターミナル / 入力パネル比率</value></data>
+  <data name="Settings.Display.TerminalHeightRatio.Help" xml:space="preserve"><value>ターミナルと入力パネルの高さ比率を調整します（50:50〜90:10）。境界線のドラッグでも変更できます。</value></data>
+
+  <!-- Settings: Notifications Tab -->
+  <data name="Settings.Notifications.Header" xml:space="preserve"><value>通知設定</value></data>
+  <data name="Settings.Notifications.Browser.Label" xml:space="preserve"><value>ブラウザ通知</value></data>
+  <data name="Settings.Notifications.Status.Granted" xml:space="preserve"><value>許可済み</value></data>
+  <data name="Settings.Notifications.Status.Denied" xml:space="preserve"><value>拒否</value></data>
+  <data name="Settings.Notifications.Status.NotRequested" xml:space="preserve"><value>未許可</value></data>
+  <data name="Settings.Notifications.Status.Checking" xml:space="preserve"><value>確認中...</value></data>
+  <data name="Settings.Notifications.Status.CheckError" xml:space="preserve"><value>確認エラー</value></data>
+  <data name="Settings.Notifications.Status.Unknown" xml:space="preserve"><value>不明</value></data>
+  <data name="Settings.Notifications.Browser.Enable" xml:space="preserve"><value>ブラウザ通知を有効にする</value></data>
+  <data name="Settings.Notifications.Browser.Revoke" xml:space="preserve"><value>通知許可を解除</value></data>
+  <data name="Settings.Notifications.Browser.RevokeHelp" xml:space="preserve"><value>ブラウザの設定画面で通知許可を解除できます。</value></data>
+  <data name="Settings.Notifications.Browser.Request" xml:space="preserve"><value>通知を許可する</value></data>
+  <data name="Settings.Notifications.Browser.RequestHelp" xml:space="preserve"><value>処理完了時にデスクトップ通知を受け取るには、ブラウザの通知を許可してください。</value></data>
+  <data name="Settings.Notifications.Threshold.Label" xml:space="preserve"><value>通知を送信する処理時間（秒）</value></data>
+  <data name="Settings.Notifications.Threshold.Help" xml:space="preserve"><value>0に設定すると、すべての処理完了時に通知します</value></data>
+  <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>WebHook設定</value></data>
+  <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>WebHook通知を有効にする</value></data>
+  <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>WebHook URL</value></data>
+  <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>Claude Code Hook設定</value></data>
+  <data name="Settings.Notifications.ClaudeHook.HelpHtml" xml:space="preserve"><value>Claude Code の hook 機能を使用して、より確実に通知を受け取ることができます。セッション作成時に自動的に &lt;code&gt;.claude/settings.local.json&lt;/code&gt; に設定が追加されます。</value></data>
+  <data name="Settings.Notifications.ClaudeHook.Enable" xml:space="preserve"><value>Claude Code Hook を有効にする</value></data>
+  <data name="Settings.Notifications.ClaudeHook.ApplyNoticeHtml" xml:space="preserve"><value>この設定は各セッションが次に起動／再起動されたタイミングで &lt;code&gt;.claude/settings.local.json&lt;/code&gt; に反映されます。既に起動中のセッションや、TerminalHub 管理外のワークスペースには即時適用されません。</value></data>
+
+  <!-- Settings: Sessions Tab -->
+  <data name="Settings.Sessions.Header" xml:space="preserve"><value>セッション設定</value></data>
+  <data name="Settings.Sessions.SortOrder.Label" xml:space="preserve"><value>セッション一覧の並び順</value></data>
+  <data name="Settings.Sessions.SortOrder.ByCreatedAt" xml:space="preserve"><value>作成日時順</value></data>
+  <data name="Settings.Sessions.SortOrder.ByLastAccessed" xml:space="preserve"><value>最終利用日時順</value></data>
+  <data name="Settings.Sessions.SortOrder.ByLastAccessedSub" xml:space="preserve"><value>最近使用したセッションが上に表示</value></data>
+  <data name="Settings.Sessions.SortOrder.ByName" xml:space="preserve"><value>名前順</value></data>
+  <data name="Settings.Sessions.SortOrder.Help" xml:space="preserve"><value>「最終利用日時順」では、子セッション（Worktree）の利用も親セッションの順序に反映されます。</value></data>
+  <data name="Settings.Sessions.Display.Label" xml:space="preserve"><value>セッション一覧の表示設定</value></data>
+  <data name="Settings.Sessions.Display.ShowTerminalType" xml:space="preserve"><value>ターミナル種別を表示</value></data>
+  <data name="Settings.Sessions.Display.ShowTerminalTypeSub" xml:space="preserve"><value>Claude/Gemini/Codexバッジ</value></data>
+  <data name="Settings.Sessions.Display.ShowGitInfo" xml:space="preserve"><value>Git情報を表示</value></data>
+  <data name="Settings.Sessions.Display.ShowGitInfoSub" xml:space="preserve"><value>ブランチ名バッジ</value></data>
+  <data name="Settings.Sessions.Display.Help" xml:space="preserve"><value>セッション一覧に表示する追加情報を選択できます。</value></data>
+  <data name="Settings.Sessions.InputPanel.Label" xml:space="preserve"><value>入力パネル設定</value></data>
+  <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>入力パネルを非表示</value></data>
+  <data name="Settings.Sessions.InputPanel.HideSub" xml:space="preserve"><value>ターミナルのみ表示</value></data>
+  <data name="Settings.Sessions.InputPanel.HideHelp" xml:space="preserve"><value>下部の入力パネルを非表示にして、ターミナル領域を広く使えます。</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -125,9 +125,9 @@
   <data name="Settings.Notifications.Browser.RequestHelp" xml:space="preserve"><value>処理完了時にデスクトップ通知を受け取るには、ブラウザの通知を許可してください。</value></data>
   <data name="Settings.Notifications.Threshold.Label" xml:space="preserve"><value>通知を送信する処理時間（秒）</value></data>
   <data name="Settings.Notifications.Threshold.Help" xml:space="preserve"><value>0に設定すると、すべての処理完了時に通知します</value></data>
-  <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>WebHook設定</value></data>
-  <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>WebHook通知を有効にする</value></data>
-  <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>WebHook URL</value></data>
+  <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>Webhook 設定</value></data>
+  <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>Webhook 通知を有効にする</value></data>
+  <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>Webhook URL</value></data>
   <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>Claude Code Hook設定</value></data>
   <data name="Settings.Notifications.ClaudeHook.HelpHtml" xml:space="preserve"><value>Claude Code の hook 機能を使用して、より確実に通知を受け取ることができます。セッション作成時に自動的に &lt;code&gt;.claude/settings.local.json&lt;/code&gt; に設定が追加されます。</value></data>
   <data name="Settings.Notifications.ClaudeHook.Enable" xml:space="preserve"><value>Claude Code Hook を有効にする</value></data>


### PR DESCRIPTION
## Summary
Phase 2B-1 として設定ダイアログの主要 3 タブ (表示 / 通知 / セッション) を英語・日本語対応する。Phase 2A (一般タブ) で構築済みの i18n インフラを使って ~50 文字列を追加 localize。

本 PR マージ後、設定ダイアログの **約 4 割** (一般 + 表示 + 通知 + セッション) が多言語対応完了。

## リソース追加

### `SharedResource.{en,ja}.resx` に追加
- **`Settings.Display.*`** (12 キー): テーマ / スライダー 4 種とヘルプ文
- **`Settings.Notifications.*`** (20 キー): ブラウザ通知 / Webhook / Claude Code Hook
  - `Status.Granted` / `Denied` / `NotRequested` / `Checking` / `CheckError` / `Unknown` の 6 状態
  - HTML (`<code>`) 含むヘルプ文 2 つは `*.Html` サフィックス + `MarkupString` 経由
- **`Settings.Sessions.*`** (17 キー): 並び順 / 表示項目 / 入力パネル

## `notificationStatus` の refactor (重要)

コードが日本語リテラル (`"許可済み"`, `"未許可"` 等) と直接比較していた部分を state key ベースに変更:

```csharp
// Before
if (notificationStatus == "許可済み") { ... }

// After
private const string NotifStateGranted = "granted";
if (notificationStatus == NotifStateGranted) { ... }
```

同時に display 文字列の解決を `GetNotificationStatusText()` に切り出し、state key → resx キー → localized 表示 の 3 段解決に。これで「UI 表示文字列」と「状態判定ロジック」が完全に分離し、翻訳追加で if 文が壊れない構造に。

## 動作確認
- [x] C# コンパイル成功 (`obj/Debug/.../TerminalHub.dll` 更新確認)
- 最終 exe へのコピーは起動中インスタンスによりブロック (次回再起動時に解消)

## 検証手順 (マージ前)
- [ ] dev 再起動 → 設定ダイアログを開く
- [ ] 表示タブ: 日本語/英語ともに正しく表示
- [ ] 通知タブ:
  - 許可済み/未許可の状態遷移で UI 分岐が正しく動作
  - バッジ色 (success/warning/secondary) が状態キーで正しく切替
- [ ] セッションタブ: 並び順ラジオ、表示チェックボックスの localize 確認

## 後続 Phase
- **Phase 2B-2**: エクスポート・インポート / コマンド / リモート起動 の 3 タブ
- **Phase 2B-3**: 特殊 + 開発系 3 タブ (devDiagnose / devBuffer / devNotify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)