### PR TITLE
feat: 設定ダイアログ エクスポート/コマンド/リモート起動 タブを多言語対応 (Phase 2B-2)

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -495,24 +495,24 @@
                         else if (activeTab == "export")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">データのエクスポート/インポート</h6>
+                                <h6 class="mb-3">@L["Settings.Export.Header"]</h6>
 
                                 <!-- エクスポート -->
                                 <div class="mb-4">
-                                    <h6 class="mb-2">エクスポート</h6>
+                                    <h6 class="mb-2">@L["Settings.Export.Export.Header"]</h6>
                                     <p class="text-muted small">
-                                        現在のストレージ（@("SQLite")）からセッション情報をJSONファイルとしてダウンロードします。
+                                        @string.Format(L["Settings.Export.Export.Help"], "SQLite")
                                     </p>
 
                                     <div class="alert alert-secondary mb-3">
                                         <small>
                                             <i class="bi bi-info-circle me-1"></i>
-                                            エクスポート対象: セッション情報（@SessionManager.GetAllSessions().Count() 件）
+                                            @string.Format(L["Settings.Export.Export.TargetInfo"], SessionManager.GetAllSessions().Count())
                                         </small>
                                     </div>
 
                                     <button class="btn btn-primary btn-sm" @onclick="ExportSettings" disabled="@(SessionManager.GetAllSessions().Count() == 0)">
-                                        <i class="bi bi-download me-1"></i>エクスポート
+                                        <i class="bi bi-download me-1"></i>@L["Settings.Export.Export.Button"]
                                     </button>
                                 </div>
 
@@ -520,10 +520,9 @@
 
                                 <!-- インポート -->
                                 <div>
-                                    <h6 class="mb-2">インポート</h6>
+                                    <h6 class="mb-2">@L["Settings.Export.Import.Header"]</h6>
                                     <p class="text-muted small">
-                                        JSONファイルを選択してセッション情報をインポートします。
-                                        現在のストレージ（@("SQLite")）に追加されます。
+                                        @string.Format(L["Settings.Export.Import.Help"], "SQLite")
                                     </p>
 
                                     <div class="mb-3">
@@ -533,14 +532,14 @@
                                     @if (importSessionCount > 0)
                                     {
                                         <div class="alert alert-info">
-                                            <h6 class="alert-heading">インポートプレビュー</h6>
+                                            <h6 class="alert-heading">@L["Settings.Export.Import.PreviewHeader"]</h6>
                                             <small>
-                                                <i class="bi bi-terminal me-1"></i>セッション情報: @importSessionCount 件
+                                                <i class="bi bi-terminal me-1"></i>@string.Format(L["Settings.Export.Import.PreviewSessions"], importSessionCount)
                                             </small>
                                         </div>
 
                                         <button class="btn btn-warning btn-sm" @onclick="ImportSettings">
-                                            <i class="bi bi-upload me-1"></i>インポート実行
+                                            <i class="bi bi-upload me-1"></i>@L["Settings.Export.Import.RunButton"]
                                         </button>
                                     }
                                 </div>
@@ -549,9 +548,9 @@
                         else if (activeTab == "commands")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">カスタムコマンド</h6>
+                                <h6 class="mb-3">@L["Settings.Commands.Header"]</h6>
                                 <small class="text-muted d-block mb-3">
-                                    ターミナル種別ごとにボタンバーに表示するコマンドを登録できます。
+                                    @L["Settings.Commands.Help"]
                                 </small>
 
                                 @foreach (var terminalType in new[] { "Terminal", "ClaudeCode", "GeminiCLI", "CodexCLI" })
@@ -570,12 +569,12 @@
                                         <div class="input-group input-group-sm mb-2">
                                             <select class="form-select" style="max-width: 110px;"
                                                     @bind="newCommandTypes[type]">
-                                                <option value="@CustomCommandType.Text">テキスト</option>
-                                                <option value="@CustomCommandType.KeySequence">キー</option>
+                                                <option value="@CustomCommandType.Text">@L["Settings.Commands.Type.Text"]</option>
+                                                <option value="@CustomCommandType.KeySequence">@L["Settings.Commands.Type.Key"]</option>
                                             </select>
                                             <input type="text" class="form-control"
                                                    @bind="newCommandTitles[type]" @bind:event="oninput"
-                                                   placeholder="タイトル（省略可）" style="max-width: 140px;" />
+                                                   placeholder="@L["Settings.Commands.TitlePlaceholder"]" style="max-width: 140px;" />
                                             @if (newCommandTypes.GetValueOrDefault(type, CustomCommandType.Text) == CustomCommandType.KeySequence)
                                             {
                                                 <select class="form-select" @bind="newCommandKeyNames[type]">
@@ -593,7 +592,7 @@
                                             {
                                                 <input type="text" class="form-control"
                                                        @bind="newCommandTexts[type]" @bind:event="oninput"
-                                                       placeholder="コマンド（例: /plan）" />
+                                                       placeholder="@L["Settings.Commands.CommandPlaceholder"]" />
                                                 <button class="btn btn-outline-primary" type="button"
                                                         @onclick="() => AddCommand(type)"
                                                         disabled="@string.IsNullOrWhiteSpace(newCommandTexts.GetValueOrDefault(type))">
@@ -626,7 +625,7 @@
                                                         <small class="d-flex align-items-center" style="min-width: 0; flex: 1;">
                                                             @if (canReorder)
                                                             {
-                                                                <i class="bi bi-grip-vertical me-2 text-muted drag-handle" title="ドラッグで並び替え"></i>
+                                                                <i class="bi bi-grip-vertical me-2 text-muted drag-handle" title="@L["Settings.Commands.DragToReorder"]"></i>
                                                             }
                                                             @if (isKey)
                                                             {
@@ -658,16 +657,16 @@
                         else if (activeTab == "remoteLaunch")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">リモート起動</h6>
+                                <h6 class="mb-3">@L["Settings.RemoteLaunch.Header"]</h6>
                                 <small class="text-muted d-block mb-3">
-                                    外出先のスマートフォンからClaude Codeセッションを起動し、Remote Control URLを取得できます。
+                                    @L["Settings.RemoteLaunch.Help"]
                                 </small>
 
                                 <div class="mb-3 form-check form-switch">
                                     <input class="form-check-input" type="checkbox" role="switch" @bind="remoteLaunchEnabled"
                                            @bind:after="OnRemoteLaunchEnabledChanged" id="remoteLaunchEnabled">
                                     <label class="form-check-label" for="remoteLaunchEnabled">
-                                        リモート起動を有効にする
+                                        @L["Settings.RemoteLaunch.Enable"]
                                     </label>
                                 </div>
 
@@ -679,13 +678,13 @@
                                                 @if (MqttService.IsBrokerConnected)
                                                 {
                                                     <span class="badge bg-success">
-                                                        <i class="bi bi-check-circle me-1"></i>接続中
+                                                        <i class="bi bi-check-circle me-1"></i>@L["Settings.RemoteLaunch.Connected"]
                                                     </span>
                                                 }
                                                 else
                                                 {
                                                     <span class="badge bg-danger">
-                                                        <i class="bi bi-x-circle me-1"></i>未接続
+                                                        <i class="bi bi-x-circle me-1"></i>@L["Settings.RemoteLaunch.Disconnected"]
                                                     </span>
                                                 }
                                                 @if (MqttService.LastConnectResult is not null)
@@ -700,7 +699,7 @@
                                                 }
                                                 else if (!MqttService.IsBrokerConnected)
                                                 {
-                                                    <small class="text-muted">接続試行中…</small>
+                                                    <small class="text-muted">@L["Settings.RemoteLaunch.Connecting"]</small>
                                                 }
                                             </div>
                                             <button class="btn btn-outline-primary btn-sm" type="button"
@@ -714,7 +713,7 @@
                                                 {
                                                     <i class="bi bi-broadcast me-1"></i>
                                                 }
-                                                疎通確認
+                                                @L["Settings.RemoteLaunch.DiagPing"]
                                             </button>
                                         </div>
                                         @if (!string.IsNullOrEmpty(diagPingMessage))
@@ -732,7 +731,7 @@
                                     @if (!string.IsNullOrEmpty(remoteLaunchTopicGuid))
                                     {
                                         <div class="mb-3">
-                                            <label class="form-label">アクセスURL</label>
+                                            <label class="form-label">@L["Settings.RemoteLaunch.AccessUrl"]</label>
                                             <div class="d-flex align-items-center gap-2">
                                                 <a href="@GetRemoteLaunchAccessUrl()" target="_blank"
                                                    class="text-truncate" title="@GetRemoteLaunchAccessUrl()">
@@ -740,23 +739,23 @@
                                                 </a>
                                                 <button class="btn btn-outline-secondary btn-sm" type="button"
                                                         @onclick="() => CopyToClipboardText(GetRemoteLaunchAccessUrl())"
-                                                        title="URLをコピー">
+                                                        title="@L["Settings.RemoteLaunch.CopyUrlTitle"]">
                                                     <i class="bi bi-clipboard"></i>
                                                 </button>
                                             </div>
                                             <div class="alert alert-warning mt-2 py-2">
                                                 <i class="bi bi-exclamation-triangle me-1"></i>
-                                                <small>このURLは他人に公開しないでください。URLを知っている人がセッションを起動できます。</small>
+                                                <small>@L["Settings.RemoteLaunch.UrlWarning"]</small>
                                             </div>
                                         </div>
                                     }
 
                                     <div class="mb-3">
-                                        <label class="form-label">パスワード（任意）</label>
+                                        <label class="form-label">@L["Settings.RemoteLaunch.PasswordLabel"]</label>
                                         <div class="input-group">
                                             <input type="password" class="form-control" value="@remoteLaunchPassword"
                                                    @oninput="OnRemoteLaunchPasswordInput"
-                                                   placeholder="設定するとアクセス時にパスワードが必要になります" />
+                                                   placeholder="@L["Settings.RemoteLaunch.PasswordPlaceholder"]" />
                                             @if (remoteLaunchPassword == Constants.MqttConstants.PasswordDummy)
                                             {
                                                 <button class="btn btn-outline-danger" type="button"
@@ -766,22 +765,22 @@
                                             }
                                         </div>
                                         <small class="text-muted">
-                                            空欄の場合はURLのみでアクセスできます。
+                                            @L["Settings.RemoteLaunch.PasswordHelp"]
                                         </small>
                                     </div>
 
                                     <div class="mb-3">
-                                        <label class="form-label small text-muted">トピックGUID</label>
+                                        <label class="form-label small text-muted">@L["Settings.RemoteLaunch.TopicGuid"]</label>
                                         <div class="input-group input-group-sm">
                                             <input type="text" class="form-control font-monospace text-muted"
                                                    value="@remoteLaunchTopicGuid" readonly />
                                             <button class="btn btn-outline-warning" type="button"
                                                     @onclick="RegenerateTopicGuid"
-                                                    title="GUIDを再発行（既存のアクセスURLが無効になります）">
+                                                    title="@L["Settings.RemoteLaunch.RegenerateGuidTitle"]">
                                                 <i class="bi bi-arrow-clockwise"></i>
                                             </button>
                                         </div>
-                                        <small class="text-muted">再発行すると既存のアクセスURLが無効になります。</small>
+                                        <small class="text-muted">@L["Settings.RemoteLaunch.RegenerateGuidHelp"]</small>
                                     </div>
                                 }
                             </div>
@@ -1171,20 +1170,20 @@
         if (isDiagPingRunning) return;
         isDiagPingRunning = true;
         diagPingExecutedAt = DateTime.Now;
-        diagPingMessage = "確認中...";
+        diagPingMessage = L["Settings.RemoteLaunch.DiagPingChecking"];
         diagPingSuccess = false;
         try
         {
             var result = await MqttService.DiagPingAsync(TimeSpan.FromSeconds(3));
             diagPingSuccess = result.Success;
             diagPingMessage = result.Success
-                ? $"OK (往復 {result.RoundTrip?.TotalMilliseconds:F0} ms)"
-                : $"NG: {result.FailureReason}";
+                ? string.Format(L["Settings.RemoteLaunch.DiagPingOkFormat"], result.RoundTrip?.TotalMilliseconds.ToString("F0"))
+                : string.Format(L["Settings.RemoteLaunch.DiagPingNgFormat"], result.FailureReason);
         }
         catch (Exception ex)
         {
             diagPingSuccess = false;
-            diagPingMessage = $"NG: {ex.Message}";
+            diagPingMessage = string.Format(L["Settings.RemoteLaunch.DiagPingNgFormat"], ex.Message);
         }
         finally
         {

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -151,4 +151,46 @@
   <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>Hide input panel</value></data>
   <data name="Settings.Sessions.InputPanel.HideSub" xml:space="preserve"><value>Terminal only</value></data>
   <data name="Settings.Sessions.InputPanel.HideHelp" xml:space="preserve"><value>Hide the bottom input panel to use more space for the terminal.</value></data>
+
+  <!-- Settings: Export/Import Tab -->
+  <data name="Settings.Export.Header" xml:space="preserve"><value>Export / Import Data</value></data>
+  <data name="Settings.Export.Export.Header" xml:space="preserve"><value>Export</value></data>
+  <data name="Settings.Export.Export.Help" xml:space="preserve"><value>Downloads session data from the current storage ({0}) as a JSON file.</value></data>
+  <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>Export target: sessions ({0})</value></data>
+  <data name="Settings.Export.Export.Button" xml:space="preserve"><value>Export</value></data>
+  <data name="Settings.Export.Import.Header" xml:space="preserve"><value>Import</value></data>
+  <data name="Settings.Export.Import.Help" xml:space="preserve"><value>Select a JSON file to import session data. It will be added to the current storage ({0}).</value></data>
+  <data name="Settings.Export.Import.PreviewHeader" xml:space="preserve"><value>Import preview</value></data>
+  <data name="Settings.Export.Import.PreviewSessions" xml:space="preserve"><value>Sessions: {0}</value></data>
+  <data name="Settings.Export.Import.RunButton" xml:space="preserve"><value>Run import</value></data>
+
+  <!-- Settings: Commands Tab -->
+  <data name="Settings.Commands.Header" xml:space="preserve"><value>Custom Commands</value></data>
+  <data name="Settings.Commands.Help" xml:space="preserve"><value>Register commands shown in the button bar for each terminal type.</value></data>
+  <data name="Settings.Commands.Type.Text" xml:space="preserve"><value>Text</value></data>
+  <data name="Settings.Commands.Type.Key" xml:space="preserve"><value>Key</value></data>
+  <data name="Settings.Commands.TitlePlaceholder" xml:space="preserve"><value>Title (optional)</value></data>
+  <data name="Settings.Commands.CommandPlaceholder" xml:space="preserve"><value>Command (e.g., /plan)</value></data>
+  <data name="Settings.Commands.DragToReorder" xml:space="preserve"><value>Drag to reorder</value></data>
+
+  <!-- Settings: Remote Launch Tab -->
+  <data name="Settings.RemoteLaunch.Header" xml:space="preserve"><value>Remote Launch</value></data>
+  <data name="Settings.RemoteLaunch.Help" xml:space="preserve"><value>Launch Claude Code sessions from your phone while away and obtain a Remote Control URL.</value></data>
+  <data name="Settings.RemoteLaunch.Enable" xml:space="preserve"><value>Enable remote launch</value></data>
+  <data name="Settings.RemoteLaunch.Connected" xml:space="preserve"><value>Connected</value></data>
+  <data name="Settings.RemoteLaunch.Disconnected" xml:space="preserve"><value>Disconnected</value></data>
+  <data name="Settings.RemoteLaunch.Connecting" xml:space="preserve"><value>Connecting...</value></data>
+  <data name="Settings.RemoteLaunch.DiagPing" xml:space="preserve"><value>Test connection</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingChecking" xml:space="preserve"><value>Checking...</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingOkFormat" xml:space="preserve"><value>OK (round-trip {0} ms)</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingNgFormat" xml:space="preserve"><value>Failed: {0}</value></data>
+  <data name="Settings.RemoteLaunch.AccessUrl" xml:space="preserve"><value>Access URL</value></data>
+  <data name="Settings.RemoteLaunch.CopyUrlTitle" xml:space="preserve"><value>Copy URL</value></data>
+  <data name="Settings.RemoteLaunch.UrlWarning" xml:space="preserve"><value>Do not share this URL. Anyone who knows it can launch sessions.</value></data>
+  <data name="Settings.RemoteLaunch.PasswordLabel" xml:space="preserve"><value>Password (optional)</value></data>
+  <data name="Settings.RemoteLaunch.PasswordPlaceholder" xml:space="preserve"><value>When set, a password will be required at access time</value></data>
+  <data name="Settings.RemoteLaunch.PasswordHelp" xml:space="preserve"><value>If empty, the URL alone grants access.</value></data>
+  <data name="Settings.RemoteLaunch.TopicGuid" xml:space="preserve"><value>Topic GUID</value></data>
+  <data name="Settings.RemoteLaunch.RegenerateGuidTitle" xml:space="preserve"><value>Regenerate GUID (existing access URL will be invalidated)</value></data>
+  <data name="Settings.RemoteLaunch.RegenerateGuidHelp" xml:space="preserve"><value>Regenerating invalidates the existing access URL.</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -87,7 +87,7 @@
   <data name="Settings.General.FavoriteFolders.Help" xml:space="preserve"><value>セッション作成時にフォルダ選択の候補として表示されます。</value></data>
   <data name="Settings.General.Version.Header" xml:space="preserve"><value>バージョン情報</value></data>
   <data name="Settings.General.Version.Current" xml:space="preserve"><value>現在のバージョン:</value></data>
-  <data name="Settings.General.Version.Checking" xml:space="preserve"><value>バージョンを確認中...</value></data>
+  <data name="Settings.General.Version.Checking" xml:space="preserve"><value>バージョンを確認中…</value></data>
   <data name="Settings.General.Version.NewAvailableHtml" xml:space="preserve"><value>新しいバージョン &lt;strong&gt;v{0}&lt;/strong&gt; があります</value></data>
   <data name="Settings.General.Version.CheckOnGitHub" xml:space="preserve"><value>GitHubで確認</value></data>
   <data name="Settings.General.Version.UpToDate" xml:space="preserve"><value>最新バージョンです</value></data>
@@ -115,7 +115,7 @@
   <data name="Settings.Notifications.Status.Granted" xml:space="preserve"><value>許可済み</value></data>
   <data name="Settings.Notifications.Status.Denied" xml:space="preserve"><value>拒否</value></data>
   <data name="Settings.Notifications.Status.NotRequested" xml:space="preserve"><value>未許可</value></data>
-  <data name="Settings.Notifications.Status.Checking" xml:space="preserve"><value>確認中...</value></data>
+  <data name="Settings.Notifications.Status.Checking" xml:space="preserve"><value>確認中…</value></data>
   <data name="Settings.Notifications.Status.CheckError" xml:space="preserve"><value>確認エラー</value></data>
   <data name="Settings.Notifications.Status.Unknown" xml:space="preserve"><value>不明</value></data>
   <data name="Settings.Notifications.Browser.Enable" xml:space="preserve"><value>ブラウザ通知を有効にする</value></data>
@@ -181,7 +181,7 @@
   <data name="Settings.RemoteLaunch.Disconnected" xml:space="preserve"><value>未接続</value></data>
   <data name="Settings.RemoteLaunch.Connecting" xml:space="preserve"><value>接続試行中…</value></data>
   <data name="Settings.RemoteLaunch.DiagPing" xml:space="preserve"><value>疎通確認</value></data>
-  <data name="Settings.RemoteLaunch.DiagPingChecking" xml:space="preserve"><value>確認中...</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingChecking" xml:space="preserve"><value>確認中…</value></data>
   <data name="Settings.RemoteLaunch.DiagPingOkFormat" xml:space="preserve"><value>OK (往復 {0} ms)</value></data>
   <data name="Settings.RemoteLaunch.DiagPingNgFormat" xml:space="preserve"><value>NG: {0}</value></data>
   <data name="Settings.RemoteLaunch.AccessUrl" xml:space="preserve"><value>アクセスURL</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -151,4 +151,46 @@
   <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>入力パネルを非表示</value></data>
   <data name="Settings.Sessions.InputPanel.HideSub" xml:space="preserve"><value>ターミナルのみ表示</value></data>
   <data name="Settings.Sessions.InputPanel.HideHelp" xml:space="preserve"><value>下部の入力パネルを非表示にして、ターミナル領域を広く使えます。</value></data>
+
+  <!-- Settings: Export/Import Tab -->
+  <data name="Settings.Export.Header" xml:space="preserve"><value>データのエクスポート/インポート</value></data>
+  <data name="Settings.Export.Export.Header" xml:space="preserve"><value>エクスポート</value></data>
+  <data name="Settings.Export.Export.Help" xml:space="preserve"><value>現在のストレージ（{0}）からセッション情報をJSONファイルとしてダウンロードします。</value></data>
+  <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>エクスポート対象: セッション情報（{0} 件）</value></data>
+  <data name="Settings.Export.Export.Button" xml:space="preserve"><value>エクスポート</value></data>
+  <data name="Settings.Export.Import.Header" xml:space="preserve"><value>インポート</value></data>
+  <data name="Settings.Export.Import.Help" xml:space="preserve"><value>JSONファイルを選択してセッション情報をインポートします。現在のストレージ（{0}）に追加されます。</value></data>
+  <data name="Settings.Export.Import.PreviewHeader" xml:space="preserve"><value>インポートプレビュー</value></data>
+  <data name="Settings.Export.Import.PreviewSessions" xml:space="preserve"><value>セッション情報: {0} 件</value></data>
+  <data name="Settings.Export.Import.RunButton" xml:space="preserve"><value>インポート実行</value></data>
+
+  <!-- Settings: Commands Tab -->
+  <data name="Settings.Commands.Header" xml:space="preserve"><value>カスタムコマンド</value></data>
+  <data name="Settings.Commands.Help" xml:space="preserve"><value>ターミナル種別ごとにボタンバーに表示するコマンドを登録できます。</value></data>
+  <data name="Settings.Commands.Type.Text" xml:space="preserve"><value>テキスト</value></data>
+  <data name="Settings.Commands.Type.Key" xml:space="preserve"><value>キー</value></data>
+  <data name="Settings.Commands.TitlePlaceholder" xml:space="preserve"><value>タイトル（省略可）</value></data>
+  <data name="Settings.Commands.CommandPlaceholder" xml:space="preserve"><value>コマンド（例: /plan）</value></data>
+  <data name="Settings.Commands.DragToReorder" xml:space="preserve"><value>ドラッグで並び替え</value></data>
+
+  <!-- Settings: Remote Launch Tab -->
+  <data name="Settings.RemoteLaunch.Header" xml:space="preserve"><value>リモート起動</value></data>
+  <data name="Settings.RemoteLaunch.Help" xml:space="preserve"><value>外出先のスマートフォンから Claude Code セッションを起動し、Remote Control URL を取得できます。</value></data>
+  <data name="Settings.RemoteLaunch.Enable" xml:space="preserve"><value>リモート起動を有効にする</value></data>
+  <data name="Settings.RemoteLaunch.Connected" xml:space="preserve"><value>接続中</value></data>
+  <data name="Settings.RemoteLaunch.Disconnected" xml:space="preserve"><value>未接続</value></data>
+  <data name="Settings.RemoteLaunch.Connecting" xml:space="preserve"><value>接続試行中…</value></data>
+  <data name="Settings.RemoteLaunch.DiagPing" xml:space="preserve"><value>疎通確認</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingChecking" xml:space="preserve"><value>確認中...</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingOkFormat" xml:space="preserve"><value>OK (往復 {0} ms)</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingNgFormat" xml:space="preserve"><value>NG: {0}</value></data>
+  <data name="Settings.RemoteLaunch.AccessUrl" xml:space="preserve"><value>アクセスURL</value></data>
+  <data name="Settings.RemoteLaunch.CopyUrlTitle" xml:space="preserve"><value>URLをコピー</value></data>
+  <data name="Settings.RemoteLaunch.UrlWarning" xml:space="preserve"><value>このURLは他人に公開しないでください。URLを知っている人がセッションを起動できます。</value></data>
+  <data name="Settings.RemoteLaunch.PasswordLabel" xml:space="preserve"><value>パスワード（任意）</value></data>
+  <data name="Settings.RemoteLaunch.PasswordPlaceholder" xml:space="preserve"><value>設定するとアクセス時にパスワードが必要になります</value></data>
+  <data name="Settings.RemoteLaunch.PasswordHelp" xml:space="preserve"><value>空欄の場合はURLのみでアクセスできます。</value></data>
+  <data name="Settings.RemoteLaunch.TopicGuid" xml:space="preserve"><value>トピックGUID</value></data>
+  <data name="Settings.RemoteLaunch.RegenerateGuidTitle" xml:space="preserve"><value>GUIDを再発行（既存のアクセスURLが無効になります）</value></data>
+  <data name="Settings.RemoteLaunch.RegenerateGuidHelp" xml:space="preserve"><value>再発行すると既存のアクセスURLが無効になります。</value></data>
 </root>


### PR DESCRIPTION
## Summary
Phase 2B-2 として設定ダイアログの 3 タブ (エクスポート・インポート / コマンド / リモート起動) を英語・日本語対応する。~36 キー追加 + `diagPingMessage` の localize。

本 PR マージ後、設定ダイアログの **約 7 割** が多言語対応完了 (残り: 特殊 + 開発系 3 タブ)。

## リソース追加

### `Settings.Export.*` (10 キー)
Export/Import の全文字列。`{0}` 入りで format string 対応:
- `Export.TargetInfo` → `エクスポート対象: セッション情報（{0} 件）` / `Export target: sessions ({0})`
- `Import.PreviewSessions` → `セッション情報: {0} 件` / `Sessions: {0}`

### `Settings.Commands.*` (7 キー)
- type select ラベル (`Text` / `Key`)
- プレースホルダー (タイトル / コマンド)
- ドラッグハンドル tooltip

### `Settings.RemoteLaunch.*` (19 キー)
- 接続ステータス (`Connected` / `Disconnected` / `Connecting`)
- 疎通確認ボタン + 結果メッセージ (`DiagPingOkFormat` / `DiagPingNgFormat`)
- アクセスURL警告、パスワード、トピックGUID 関連

## `diagPingMessage` の localize

```csharp
// Before
diagPingMessage = "確認中...";
diagPingMessage = $"OK (往復 {ms} ms)";
diagPingMessage = $"NG: {reason}";

// After
diagPingMessage = L["Settings.RemoteLaunch.DiagPingChecking"];
diagPingMessage = string.Format(L["Settings.RemoteLaunch.DiagPingOkFormat"], ms);
diagPingMessage = string.Format(L["Settings.RemoteLaunch.DiagPingNgFormat"], reason);
```

英語 culture では `"Checking..."` / `"OK (round-trip N ms)"` / `"Failed: ..."` と出る。

## Razor
3 タブ内の全表示文字列を `@L["..."]` に置換。`{0}` を含むキーは `@string.Format(L["..."], 引数)` で組み立て。

## 動作確認済み
- [x] C# コンパイル成功 (`obj/` の DLL 更新確認)
- exe ロックで最終コピー失敗 (起動中インスタンス停止で解消)

## 検証手順 (マージ前)
- [ ] dev 再起動 → 3 タブで英日切替
- [ ] Export タブ: セッション件数とストレージ名 (SQLite) が正しく format に埋まる
- [ ] Commands タブ: type select ドロップダウンが英日切替
- [ ] RemoteLaunch タブ:
  - 接続ステータスバッジ (Connected/Disconnected) の表記
  - 疎通確認ボタン → 結果メッセージ (OK/Failed) が culture 連動
- [ ] 本 PR 外のタブ (特殊 / 開発系) はまだ日本語のまま (意図通り)

## 後続 Phase
- **Phase 2B-3**: 特殊 + 開発系 3 タブ (devDiagnose / devBuffer / devNotify) — Phase 2 の最終

🤖 Generated with [Claude Code](https://claude.com/claude-code)