### PR TITLE
feat: 設定ダイアログ 特殊/開発系 4 タブ + 横断メッセージを多言語対応 (Phase 2B-3)

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -788,11 +788,11 @@
                         else if (activeTab == "special")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">特殊設定</h6>
+                                <h6 class="mb-3">@L["Settings.Special.Header"]</h6>
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">Claude Code モード切替キー</h6>
-                                    <p class="text-muted small">Claude Codeでモード切替に使用するキーボードショートカットを選択します。</p>
+                                    <h6 class="mb-2">@L["Settings.Special.ClaudeModeKey.Header"]</h6>
+                                    <p class="text-muted small">@L["Settings.Special.ClaudeModeKey.Help"]</p>
 
                                     <div class="mb-3">
                                         <div class="form-check">
@@ -800,7 +800,7 @@
                                                    id="keyNone" value="none" checked="@(claudeModeSwitchKey == "none")"
                                                    @onchange="@(() => claudeModeSwitchKey = "none")">
                                             <label class="form-check-label" for="keyNone">
-                                                無し <span class="text-muted">（デフォルト）</span>
+                                                @L["Settings.Special.ClaudeModeKey.None"] <span class="text-muted">@L["Settings.Special.ClaudeModeKey.DefaultNote"]</span>
                                             </label>
                                         </div>
                                         <div class="form-check">
@@ -822,70 +822,68 @@
                                     </div>
                                     <p class="text-muted small mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        環境によってはAlt+Mが他の機能と競合する場合があります。その場合はShift+Tabをお試しください。
+                                        @L["Settings.Special.ClaudeModeKey.ConflictNote"]
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">音声入力</h6>
+                                    <h6 class="mb-2">@L["Settings.Special.VoiceInput.Header"]</h6>
                                     <div class="form-check form-switch">
                                         <input class="form-check-input" type="checkbox" @bind="voiceInputEnabled" id="voiceInputSwitch">
                                         <label class="form-check-label" for="voiceInputSwitch">
-                                            音声入力を有効にする（実験的）
+                                            @L["Settings.Special.VoiceInput.Enable"]
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        有効にすると、テキスト入力パネルにマイクボタンが表示されます。ボタンを押している間だけ音声認識が動作します（Chrome推奨）。
+                                        @L["Settings.Special.VoiceInput.Help"]
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">テキスト事前整形</h6>
+                                    <h6 class="mb-2">@L["Settings.Special.TextRefine.Header"]</h6>
                                     <div class="form-check form-switch">
                                         <input class="form-check-input" type="checkbox" @bind="textRefineEnabled" id="textRefineSwitch">
                                         <label class="form-check-label" for="textRefineSwitch">
-                                            事前整形ボタンを有効にする（実験的）
+                                            @L["Settings.Special.TextRefine.Enable"]
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        有効にすると、テキスト入力パネルに「<i class="bi bi-stars"></i> 事前整形」ボタンが表示されます。
-                                        押すと Claude Code CLI（Haiku モデル）で誤字脱字や表現の揺れを修正します。<br/>
-                                        整形指示は <code>%LOCALAPPDATA%\TerminalHub\refine-workdir\CLAUDE.md</code> を編集してカスタマイズ可能。
+                                        @((MarkupString)L["Settings.Special.TextRefine.HelpHtml"].Value)
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">開発ツール</h6>
+                                    <h6 class="mb-2">@L["Settings.Special.DevTools.Header"]</h6>
                                     <div class="form-check form-switch">
                                         <input class="form-check-input" type="checkbox" @bind="devToolsEnabled" id="devToolsSwitch">
                                         <label class="form-check-label" for="devToolsSwitch">
-                                            開発ツールを有効にする
+                                            @L["Settings.Special.DevTools.Enable"]
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        有効にすると、診断・バッファ・通知テストのタブが表示されます。
+                                        @L["Settings.Special.DevTools.Help"]
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">ログファイル</h6>
+                                    <h6 class="mb-2">@L["Settings.Special.Logs.Header"]</h6>
                                     <button class="btn btn-outline-secondary btn-sm" @onclick="OpenLogFolder">
-                                        <i class="bi bi-folder2-open me-1"></i>ログフォルダを開く
+                                        <i class="bi bi-folder2-open me-1"></i>@L["Settings.Special.Logs.OpenFolder"]
                                     </button>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        アプリケーションのログファイルが保存されているフォルダを開きます。
+                                        @L["Settings.Special.Logs.Help"]
                                     </p>
                                 </div>
                             </div>
@@ -893,25 +891,25 @@
                         else if (activeTab == "devDiagnose")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">診断情報</h6>
+                                <h6 class="mb-3">@L["Settings.DevDiagnose.Header"]</h6>
 
                                 <div class="mb-3">
                                     <button class="btn btn-info btn-sm me-2" @onclick="RefreshDiagnostics">
-                                        <i class="bi bi-arrow-clockwise me-1"></i>診断情報を更新
+                                        <i class="bi bi-arrow-clockwise me-1"></i>@L["Settings.DevDiagnose.Refresh"]
                                     </button>
                                     <button class="btn btn-warning btn-sm" @onclick="RunJSDiagnostics">
-                                        <i class="bi bi-bug me-1"></i>JS診断実行
+                                        <i class="bi bi-bug me-1"></i>@L["Settings.DevDiagnose.RunJs"]
                                     </button>
                                 </div>
 
                                 <div class="mb-3">
-                                    <h6>セッション一覧</h6>
+                                    <h6>@L["Settings.DevDiagnose.SessionList"]</h6>
                                     <div class="table-responsive" style="max-height: 200px; overflow-y: auto;">
                                         <table class="table table-sm table-striped">
                                             <thead>
                                                 <tr>
-                                                    <th>名前</th>
-                                                    <th>状態</th>
+                                                    <th>@L["Settings.DevDiagnose.ColName"]</th>
+                                                    <th>@L["Settings.DevDiagnose.ColStatus"]</th>
                                                     <th>ConPTY</th>
                                                 </tr>
                                             </thead>
@@ -927,7 +925,7 @@
                                                         </td>
                                                         <td>
                                                             <span class="badge @(session.ConPtySession != null ? "bg-primary" : "bg-warning")">
-                                                                @(session.ConPtySession != null ? "有" : "無")
+                                                                @(session.ConPtySession != null ? L["Settings.DevDiagnose.ConPtyPresent"] : L["Settings.DevDiagnose.ConPtyAbsent"])
                                                             </span>
                                                         </td>
                                                     </tr>
@@ -938,22 +936,22 @@
                                 </div>
 
                                 <div class="mb-3">
-                                    <h6>ターミナル情報</h6>
-                                    <p class="mb-1">JavaScript側ターミナル数: <span class="badge bg-info">@jsTerminalCount</span></p>
+                                    <h6>@L["Settings.DevDiagnose.TerminalInfo.Header"]</h6>
+                                    <p class="mb-1">@L["Settings.DevDiagnose.TerminalInfo.JsTerminalCount"] <span class="badge bg-info">@jsTerminalCount</span></p>
                                 </div>
 
                                 <hr />
 
-                                <h6 class="mb-3">ターミナル制御テスト</h6>
+                                <h6 class="mb-3">@L["Settings.DevDiagnose.TerminalTest.Header"]</h6>
                                 <div class="mb-3">
                                     <button class="btn btn-primary btn-sm me-2" @onclick="ScrollToBottom">
-                                        <i class="bi bi-arrow-down me-1"></i>最下部へ
+                                        <i class="bi bi-arrow-down me-1"></i>@L["Settings.DevDiagnose.TerminalTest.ScrollBottom"]
                                     </button>
                                     <button class="btn btn-secondary btn-sm me-2" @onclick="ScrollToTop">
-                                        <i class="bi bi-arrow-up me-1"></i>最上部へ
+                                        <i class="bi bi-arrow-up me-1"></i>@L["Settings.DevDiagnose.TerminalTest.ScrollTop"]
                                     </button>
                                     <button class="btn btn-info btn-sm" @onclick="GetScrollPosition">
-                                        <i class="bi bi-info-circle me-1"></i>位置取得
+                                        <i class="bi bi-info-circle me-1"></i>@L["Settings.DevDiagnose.TerminalTest.GetPosition"]
                                     </button>
                                 </div>
                                 <div class="mb-3">
@@ -964,16 +962,16 @@
                         else if (activeTab == "devBuffer")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">バッファダンプ</h6>
-                                <p class="text-muted small mb-3">セッションの出力バッファ（最大2MB）をファイルにダウンロードします。</p>
+                                <h6 class="mb-3">@L["Settings.DevBuffer.Header"]</h6>
+                                <p class="text-muted small mb-3">@L["Settings.DevBuffer.Help"]</p>
 
                                 <div class="mb-3">
-                                    <label class="form-label">セッション選択</label>
+                                    <label class="form-label">@L["Settings.DevBuffer.SelectLabel"]</label>
                                     <select class="form-select" @bind="selectedSessionForBuffer">
-                                        <option value="">-- セッションを選択 --</option>
+                                        <option value="">@L["Settings.DevBuffer.SelectPlaceholder"]</option>
                                         @foreach (var session in GetAvailableSessions())
                                         {
-                                            var bufferSize = session.TerminalBufferSize > 0 ? $" ({FormatBytes(session.TerminalBufferSize)})" : " (空)";
+                                            var bufferSize = session.TerminalBufferSize > 0 ? $" ({FormatBytes(session.TerminalBufferSize)})" : $" {L["Settings.DevBuffer.Empty"]}";
                                             <option value="@session.SessionId">@session.GetDisplayName()@bufferSize</option>
                                         }
                                     </select>
@@ -982,23 +980,23 @@
                                 @if (GetSelectedBufferSession() is SessionInfo selectedSession)
                                 {
                                     <div class="mb-3">
-                                        <span class="badge bg-info me-2">バッファ: @FormatBytes(selectedSession.TerminalBufferSize)</span>
-                                        <span class="badge bg-secondary">ステータス履歴: @selectedSession.StatusChangeHistoryCount 件</span>
+                                        <span class="badge bg-info me-2">@string.Format(L["Settings.DevBuffer.BufferFormat"], FormatBytes(selectedSession.TerminalBufferSize))</span>
+                                        <span class="badge bg-secondary">@string.Format(L["Settings.DevBuffer.StatusHistoryFormat"], selectedSession.StatusChangeHistoryCount)</span>
                                     </div>
                                 }
 
                                 <div class="mb-3">
                                     <button class="btn btn-primary btn-sm me-2" @onclick="DownloadBuffer"
                                             disabled="@(string.IsNullOrEmpty(selectedSessionForBuffer) || GetSelectedBufferSession()?.TerminalBufferSize == 0)">
-                                        <i class="bi bi-download me-1"></i>バッファ
+                                        <i class="bi bi-download me-1"></i>@L["Settings.DevBuffer.DownloadBuffer"]
                                     </button>
                                     <button class="btn btn-outline-primary btn-sm me-2" @onclick="DownloadBufferClean"
                                             disabled="@(string.IsNullOrEmpty(selectedSessionForBuffer) || GetSelectedBufferSession()?.TerminalBufferSize == 0)">
-                                        <i class="bi bi-file-text me-1"></i>バッファ (ANSI除去)
+                                        <i class="bi bi-file-text me-1"></i>@L["Settings.DevBuffer.DownloadBufferClean"]
                                     </button>
                                     <button class="btn btn-outline-info btn-sm" @onclick="DownloadStatusHistory"
                                             disabled="@(string.IsNullOrEmpty(selectedSessionForBuffer) || GetSelectedBufferSession()?.StatusChangeHistoryCount == 0)">
-                                        <i class="bi bi-clock-history me-1"></i>ステータス履歴 JSON
+                                        <i class="bi bi-clock-history me-1"></i>@L["Settings.DevBuffer.DownloadStatusHistory"]
                                     </button>
                                 </div>
 
@@ -1010,19 +1008,19 @@
                         else if (activeTab == "devNotify")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">通知テスト</h6>
+                                <h6 class="mb-3">@L["Settings.DevNotify.Header"]</h6>
 
                                 <div class="mb-3">
-                                    <label class="form-label">テスト用経過時間（秒）</label>
+                                    <label class="form-label">@L["Settings.DevNotify.TestElapsedLabel"]</label>
                                     <input type="number" class="form-control" @bind="testElapsedSeconds" min="1" max="300" style="max-width: 150px;" />
                                 </div>
 
                                 <div class="mb-3">
                                     <button class="btn btn-warning btn-sm me-2" @onclick="TestBrowserNotification">
-                                        <i class="bi bi-bell me-1"></i>ブラウザ通知テスト
+                                        <i class="bi bi-bell me-1"></i>@L["Settings.DevNotify.TestBrowser"]
                                     </button>
                                     <button class="btn btn-success btn-sm" @onclick="TestWebHookNotification">
-                                        <i class="bi bi-send me-1"></i>WebHook通知テスト
+                                        <i class="bi bi-send me-1"></i>@L["Settings.DevNotify.TestWebhook"]
                                     </button>
                                 </div>
 
@@ -1121,11 +1119,13 @@
     private bool devToolsEnabled = false;
     private List<SessionInfo> diagnosticSessions = new();
     private int jsTerminalCount = 0;
-    private string scrollInfo = "スクロール位置情報が表示されます";
+    // localize 済みの初期メッセージは OnInitialized で設定する (この時点では L インジェクト未完了のため)
+    private string scrollInfo = "";
     private string selectedSessionForBuffer = "";
     private string bufferResult = "";
     private int testElapsedSeconds = 10;
-    private string notificationTestResult = "テスト結果がここに表示されます";
+    // localize 済みの初期メッセージは OnInitialized で設定する (この時点では L インジェクト未完了のため)
+    private string notificationTestResult = "";
 
     [Parameter] public EventCallback<string> OnSessionSortModeChanged { get; set; }
     [Parameter] public string SessionSortMode { get; set; } = "lastAccessed";
@@ -1152,6 +1152,9 @@
         // Blazor Server の初期レンダー時には UseRequestLocalization middleware が
         // 既に CultureInfo.CurrentUICulture を差し替え済みなので、ここで確定値を拾う。
         currentCulture = System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+        // localize 済みの初期値を設定 (field initializer では IStringLocalizer L がまだ inject されていない)
+        scrollInfo = L["Settings.DevDiagnose.ScrollInfo.Initial"];
+        notificationTestResult = L["Settings.DevNotify.Result.Initial"];
     }
 
     public void Dispose()
@@ -1305,12 +1308,12 @@
             versionCheckResult = await VersionCheckService.CheckForUpdatesAsync();
             if (versionCheckResult == null)
             {
-                versionCheckError = "バージョン情報を取得できませんでした";
+                versionCheckError = L["Settings.Message.VersionFetchFailed"];
             }
         }
         catch (Exception ex)
         {
-            versionCheckError = $"チェックに失敗しました: {ex.Message}";
+            versionCheckError = string.Format(L["Settings.Message.VersionCheckErrorFormat"], ex.Message);
         }
         finally
         {
@@ -1347,18 +1350,18 @@
 
             if (granted)
             {
-                saveMessage = "通知が許可されました";
+                saveMessage = L["Settings.Message.PermissionGranted"];
                 saveSuccess = true;
             }
             else
             {
-                saveMessage = "通知が拒否されました";
+                saveMessage = L["Settings.Message.PermissionDenied"];
                 saveSuccess = false;
             }
         }
         catch (Exception ex)
         {
-            saveMessage = $"エラー: {ex.Message}";
+            saveMessage = string.Format(L["Common.ErrorFormat"], ex.Message);
             saveSuccess = false;
         }
     }
@@ -1371,7 +1374,7 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"エラー: {ex.Message}";
+            saveMessage = string.Format(L["Common.ErrorFormat"], ex.Message);
             saveSuccess = false;
         }
     }
@@ -1396,7 +1399,7 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"フォルダを開けませんでした: {ex.Message}";
+            saveMessage = string.Format(L["Settings.Message.OpenFolderErrorFormat"], ex.Message);
             saveSuccess = false;
             StateHasChanged();
         }
@@ -1409,14 +1412,14 @@
             // 設定値の検証
             if (thresholdSeconds < 0)
             {
-                saveMessage = "通知時間は0以上にしてください";
+                saveMessage = L["Settings.Message.ThresholdNegative"];
                 saveSuccess = false;
                 return;
             }
 
             if (webHookEnabled && string.IsNullOrWhiteSpace(webHookUrl))
             {
-                saveMessage = "WebHook URLを入力してください";
+                saveMessage = L["Settings.Message.WebhookUrlRequired"];
                 saveSuccess = false;
                 return;
             }
@@ -1435,7 +1438,7 @@
                 // パスの存在チェック
                 if (!Directory.Exists(defaultFolderPath))
                 {
-                    defaultFolderPathWarning = "指定されたパスが存在しません";
+                    defaultFolderPathWarning = L["Settings.Message.PathNotExists"];
                 }
             }
 
@@ -1536,7 +1539,7 @@
                 await MqttService.ConnectAsync(remoteLaunchTopicGuid);
             }
 
-            saveMessage = "設定を保存しました";
+            saveMessage = L["Settings.Message.SaveSuccess"];
             saveSuccess = true;
 
             // 3秒後にメッセージを消す
@@ -1552,11 +1555,11 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"保存エラー: {ex.Message}";
+            saveMessage = string.Format(L["Settings.Message.SaveErrorFormat"], ex.Message);
             saveSuccess = false;
         }
     }
-    
+
     private void AddFavoriteFolder()
     {
         if (string.IsNullOrWhiteSpace(newFavoriteFolder)) return;
@@ -1568,13 +1571,13 @@
 
         if (!Directory.Exists(folder))
         {
-            favoriteFolderError = "指定されたフォルダが存在しません";
+            favoriteFolderError = L["Settings.Message.FolderNotExists"];
             return;
         }
 
         if (favoriteFolders.Contains(folder))
         {
-            favoriteFolderError = "このフォルダは既に追加されています";
+            favoriteFolderError = L["Settings.Message.FolderDuplicate"];
             return;
         }
 
@@ -1927,16 +1930,16 @@
             await JSRuntime.InvokeVoidAsync("terminalHubHelpers.downloadJson",
                 json, $"terminalhub_sessions_{DateTime.Now:yyyyMMdd_HHmmss}.json");
 
-            saveMessage = $"セッション情報（{sessions.Count}件）をエクスポートしました";
+            saveMessage = string.Format(L["Settings.Message.ExportSuccessFormat"], sessions.Count);
             saveSuccess = true;
         }
         catch (Exception ex)
         {
-            saveMessage = $"エクスポートエラー: {ex.Message}";
+            saveMessage = string.Format(L["Settings.Message.ExportErrorFormat"], ex.Message);
             saveSuccess = false;
         }
     }
-    
+
     private async Task LoadImportFile(InputFileChangeEventArgs e)
     {
         try
@@ -1944,7 +1947,7 @@
             var file = e.File;
             if (file.ContentType != "application/json")
             {
-                saveMessage = "JSONファイルを選択してください";
+                saveMessage = L["Settings.Message.JsonFileRequired"];
                 saveSuccess = false;
                 return;
             }
@@ -1967,7 +1970,7 @@
             }
             else
             {
-                saveMessage = "セッション情報が見つかりませんでした";
+                saveMessage = L["Settings.Message.SessionsNotFound"];
                 saveSuccess = false;
                 importSessions = null;
                 importSessionCount = 0;
@@ -1975,7 +1978,7 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"ファイル読み込みエラー: {ex.Message}";
+            saveMessage = string.Format(L["Settings.Message.FileReadErrorFormat"], ex.Message);
             saveSuccess = false;
             importSessions = null;
             importSessionCount = 0;
@@ -2006,7 +2009,7 @@
                 }
             }
 
-            saveMessage = $"インポートが完了しました（{addedCount}件追加、{importSessions.Count - addedCount}件は重複のためスキップ）。ページを再読み込みしてください。";
+            saveMessage = string.Format(L["Settings.Message.ImportResultFormat"], addedCount, importSessions.Count - addedCount);
             saveSuccess = true;
             importSessions = null;
             importSessionCount = 0;
@@ -2014,7 +2017,7 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"インポートエラー: {ex.Message}";
+            saveMessage = string.Format(L["Settings.Message.ImportErrorFormat"], ex.Message);
             saveSuccess = false;
         }
     }
@@ -2051,11 +2054,11 @@
         try
         {
             await JSRuntime.InvokeVoidAsync("terminalHubHelpers.scrollAllTerminalsToBottom");
-            scrollInfo = $"最下部にスクロールしました - {DateTime.Now:HH:mm:ss}";
+            scrollInfo = string.Format(L["Settings.DevDiagnose.ScrollInfo.BottomFormat"], DateTime.Now.ToString("HH:mm:ss"));
         }
         catch (Exception ex)
         {
-            scrollInfo = $"エラー: {ex.Message}";
+            scrollInfo = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 
@@ -2064,11 +2067,11 @@
         try
         {
             await JSRuntime.InvokeVoidAsync("terminalHubHelpers.scrollAllTerminalsToTop");
-            scrollInfo = $"最上部にスクロールしました - {DateTime.Now:HH:mm:ss}";
+            scrollInfo = string.Format(L["Settings.DevDiagnose.ScrollInfo.TopFormat"], DateTime.Now.ToString("HH:mm:ss"));
         }
         catch (Exception ex)
         {
-            scrollInfo = $"エラー: {ex.Message}";
+            scrollInfo = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 
@@ -2077,11 +2080,12 @@
         try
         {
             var result = await JSRuntime.InvokeAsync<object>("terminalHubHelpers.getAllTerminalScrollPositions");
-            scrollInfo = $"スクロール位置: {System.Text.Json.JsonSerializer.Serialize(result)} - {DateTime.Now:HH:mm:ss}";
+            scrollInfo = string.Format(L["Settings.DevDiagnose.ScrollInfo.PositionFormat"],
+                System.Text.Json.JsonSerializer.Serialize(result), DateTime.Now.ToString("HH:mm:ss"));
         }
         catch (Exception ex)
         {
-            scrollInfo = $"エラー: {ex.Message}";
+            scrollInfo = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 
@@ -2126,7 +2130,9 @@
                 SessionName = sessionInfo.GetDisplayName(),
                 SessionId = sessionInfo.SessionId
             };
-            var header = "--- バッファ情報 ---\n" + System.Text.Json.JsonSerializer.Serialize(bufferInfo, new System.Text.Json.JsonSerializerOptions { WriteIndented = true }) + "\n\n--- バッファ内容 ---\n";
+            var header = $"--- {L["Settings.DevBuffer.HeaderBufferInfo"]} ---\n"
+                + System.Text.Json.JsonSerializer.Serialize(bufferInfo, new System.Text.Json.JsonSerializerOptions { WriteIndented = true })
+                + $"\n\n--- {L["Settings.DevBuffer.HeaderBufferContent"]} ---\n";
 
             return Task.FromResult<(string?, string, string)?>(
                 (header + content, $"buffer_{SanitizeFilename(sessionInfo.GetDisplayName())}_{DateTime.Now:yyyyMMdd_HHmmss}.txt", "text/plain"));
@@ -2191,14 +2197,14 @@
             var sessionInfo = GetSelectedBufferSession();
             if (sessionInfo == null)
             {
-                bufferResult = "セッションを選択してください";
+                bufferResult = L["Settings.DevBuffer.Result.SelectSession"];
                 return;
             }
 
             var result = await contentFactory(sessionInfo);
             if (result == null || result.Value.Content == null)
             {
-                bufferResult = "バッファが空です";
+                bufferResult = L["Settings.DevBuffer.Result.BufferEmpty"];
                 return;
             }
 
@@ -2207,11 +2213,11 @@
             var base64 = Convert.ToBase64String(bytes);
 
             await JSRuntime.InvokeVoidAsync("terminalHubHelpers.downloadBase64File", base64, filename, mimeType);
-            bufferResult = $"ダウンロード完了: {filename} ({FormatBytes(content.Length)})";
+            bufferResult = string.Format(L["Settings.DevBuffer.Result.DownloadedFormat"], filename, FormatBytes(content.Length));
         }
         catch (Exception ex)
         {
-            bufferResult = $"エラー: {ex.Message}";
+            bufferResult = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 
@@ -2241,21 +2247,21 @@
             {
                 SessionId = Guid.NewGuid(),
                 FolderPath = "C:\\TestFolder",
-                DisplayName = "通知テストセッション",
+                DisplayName = L["Settings.DevNotify.SessionName.Browser"],
                 TerminalType = TerminalType.ClaudeCode,
                 ProcessingElapsedSeconds = testElapsedSeconds
             };
 
-            notificationTestResult = $"ブラウザ通知を送信中... ({testElapsedSeconds}秒の処理として)";
+            notificationTestResult = string.Format(L["Settings.DevNotify.Result.BrowserSendingFormat"], testElapsedSeconds);
             StateHasChanged();
 
             await NotificationService.NotifyProcessingCompleteAsync(testSession, testElapsedSeconds);
 
-            notificationTestResult = $"ブラウザ通知を送信しました - {DateTime.Now:HH:mm:ss}";
+            notificationTestResult = string.Format(L["Settings.DevNotify.Result.BrowserSentFormat"], DateTime.Now.ToString("HH:mm:ss"));
         }
         catch (Exception ex)
         {
-            notificationTestResult = $"エラー: {ex.Message}";
+            notificationTestResult = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 
@@ -2267,21 +2273,21 @@
             {
                 SessionId = Guid.NewGuid(),
                 FolderPath = "C:\\TestFolder",
-                DisplayName = "WebHookテストセッション",
+                DisplayName = L["Settings.DevNotify.SessionName.Webhook"],
                 TerminalType = TerminalType.GeminiCLI,
                 ProcessingElapsedSeconds = testElapsedSeconds
             };
 
-            notificationTestResult = $"WebHook通知を送信中... ({testElapsedSeconds}秒の処理として)";
+            notificationTestResult = string.Format(L["Settings.DevNotify.Result.WebhookSendingFormat"], testElapsedSeconds);
             StateHasChanged();
 
             await NotificationService.NotifyProcessingCompleteAsync(testSession, testElapsedSeconds);
 
-            notificationTestResult = $"WebHook通知を送信しました - {DateTime.Now:HH:mm:ss}";
+            notificationTestResult = string.Format(L["Settings.DevNotify.Result.WebhookSentFormat"], DateTime.Now.ToString("HH:mm:ss"));
         }
         catch (Exception ex)
         {
-            notificationTestResult = $"エラー: {ex.Message}";
+            notificationTestResult = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -157,7 +157,7 @@
   <data name="Settings.Export.Header" xml:space="preserve"><value>Export / Import Data</value></data>
   <data name="Settings.Export.Export.Header" xml:space="preserve"><value>Export</value></data>
   <data name="Settings.Export.Export.Help" xml:space="preserve"><value>Downloads session data from the current storage ({0}) as a JSON file.</value></data>
-  <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>Export target: sessions ({0})</value></data>
+  <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>Export target: {0} sessions</value></data>
   <data name="Settings.Export.Export.Button" xml:space="preserve"><value>Export</value></data>
   <data name="Settings.Export.Import.Header" xml:space="preserve"><value>Import</value></data>
   <data name="Settings.Export.Import.Help" xml:space="preserve"><value>Select a JSON file to import session data. It will be added to the current storage ({0}).</value></data>
@@ -278,7 +278,7 @@
   <data name="Settings.Message.SaveErrorFormat" xml:space="preserve"><value>Save error: {0}</value></data>
   <data name="Settings.Message.VersionFetchFailed" xml:space="preserve"><value>Could not retrieve version information</value></data>
   <data name="Settings.Message.VersionCheckErrorFormat" xml:space="preserve"><value>Check failed: {0}</value></data>
-  <data name="Settings.Message.ExportSuccessFormat" xml:space="preserve"><value>Exported sessions ({0})</value></data>
+  <data name="Settings.Message.ExportSuccessFormat" xml:space="preserve"><value>Exported {0} sessions</value></data>
   <data name="Settings.Message.ExportErrorFormat" xml:space="preserve"><value>Export error: {0}</value></data>
   <data name="Settings.Message.JsonFileRequired" xml:space="preserve"><value>Please select a JSON file</value></data>
   <data name="Settings.Message.SessionsNotFound" xml:space="preserve"><value>No sessions found</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -58,6 +58,7 @@
   <!-- Common -->
   <data name="Common.Close" xml:space="preserve"><value>Close</value></data>
   <data name="Common.Add" xml:space="preserve"><value>Add</value></data>
+  <data name="Common.ErrorFormat" xml:space="preserve"><value>Error: {0}</value></data>
 
   <!-- Settings Dialog -->
   <data name="Settings.Title" xml:space="preserve"><value>Settings</value></data>
@@ -193,4 +194,95 @@
   <data name="Settings.RemoteLaunch.TopicGuid" xml:space="preserve"><value>Topic GUID</value></data>
   <data name="Settings.RemoteLaunch.RegenerateGuidTitle" xml:space="preserve"><value>Regenerate GUID (existing access URL will be invalidated)</value></data>
   <data name="Settings.RemoteLaunch.RegenerateGuidHelp" xml:space="preserve"><value>Regenerating invalidates the existing access URL.</value></data>
+
+  <!-- Settings: Special Tab -->
+  <data name="Settings.Special.Header" xml:space="preserve"><value>Special Settings</value></data>
+  <data name="Settings.Special.ClaudeModeKey.Header" xml:space="preserve"><value>Claude Code mode switch key</value></data>
+  <data name="Settings.Special.ClaudeModeKey.Help" xml:space="preserve"><value>Select the keyboard shortcut used for mode switching in Claude Code.</value></data>
+  <data name="Settings.Special.ClaudeModeKey.None" xml:space="preserve"><value>None</value></data>
+  <data name="Settings.Special.ClaudeModeKey.DefaultNote" xml:space="preserve"><value>(default)</value></data>
+  <data name="Settings.Special.ClaudeModeKey.ConflictNote" xml:space="preserve"><value>Alt+M can conflict with other functions in some environments. If that happens, try Shift+Tab instead.</value></data>
+  <data name="Settings.Special.VoiceInput.Header" xml:space="preserve"><value>Voice input</value></data>
+  <data name="Settings.Special.VoiceInput.Enable" xml:space="preserve"><value>Enable voice input (experimental)</value></data>
+  <data name="Settings.Special.VoiceInput.Help" xml:space="preserve"><value>When enabled, a microphone button appears in the text input panel. Speech recognition only runs while the button is held down (Chrome recommended).</value></data>
+  <data name="Settings.Special.TextRefine.Header" xml:space="preserve"><value>Text pre-refinement</value></data>
+  <data name="Settings.Special.TextRefine.Enable" xml:space="preserve"><value>Enable pre-refinement button (experimental)</value></data>
+  <data name="Settings.Special.TextRefine.HelpHtml" xml:space="preserve"><value>When enabled, a &lt;i class="bi bi-stars"&gt;&lt;/i&gt; Refine button appears in the text input panel. Pressing it uses Claude Code CLI (Haiku model) to fix typos and inconsistencies.&lt;br/&gt;The refinement instructions can be customized by editing &lt;code&gt;%LOCALAPPDATA%\TerminalHub\refine-workdir\CLAUDE.md&lt;/code&gt;.</value></data>
+  <data name="Settings.Special.DevTools.Header" xml:space="preserve"><value>Developer tools</value></data>
+  <data name="Settings.Special.DevTools.Enable" xml:space="preserve"><value>Enable developer tools</value></data>
+  <data name="Settings.Special.DevTools.Help" xml:space="preserve"><value>When enabled, the Diagnostics, Buffer, and Notification Test tabs are shown.</value></data>
+  <data name="Settings.Special.Logs.Header" xml:space="preserve"><value>Log files</value></data>
+  <data name="Settings.Special.Logs.OpenFolder" xml:space="preserve"><value>Open log folder</value></data>
+  <data name="Settings.Special.Logs.Help" xml:space="preserve"><value>Opens the folder where application log files are stored.</value></data>
+
+  <!-- Settings: Dev Diagnose Tab -->
+  <data name="Settings.DevDiagnose.Header" xml:space="preserve"><value>Diagnostics</value></data>
+  <data name="Settings.DevDiagnose.Refresh" xml:space="preserve"><value>Refresh diagnostics</value></data>
+  <data name="Settings.DevDiagnose.RunJs" xml:space="preserve"><value>Run JS diagnostics</value></data>
+  <data name="Settings.DevDiagnose.SessionList" xml:space="preserve"><value>Session list</value></data>
+  <data name="Settings.DevDiagnose.ColName" xml:space="preserve"><value>Name</value></data>
+  <data name="Settings.DevDiagnose.ColStatus" xml:space="preserve"><value>Status</value></data>
+  <data name="Settings.DevDiagnose.ConPtyPresent" xml:space="preserve"><value>Yes</value></data>
+  <data name="Settings.DevDiagnose.ConPtyAbsent" xml:space="preserve"><value>No</value></data>
+  <data name="Settings.DevDiagnose.TerminalInfo.Header" xml:space="preserve"><value>Terminal info</value></data>
+  <data name="Settings.DevDiagnose.TerminalInfo.JsTerminalCount" xml:space="preserve"><value>JavaScript terminal count:</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.Header" xml:space="preserve"><value>Terminal control test</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.ScrollBottom" xml:space="preserve"><value>Scroll to bottom</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.ScrollTop" xml:space="preserve"><value>Scroll to top</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.GetPosition" xml:space="preserve"><value>Get position</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.Initial" xml:space="preserve"><value>Scroll position info will appear here</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.BottomFormat" xml:space="preserve"><value>Scrolled to bottom - {0}</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.TopFormat" xml:space="preserve"><value>Scrolled to top - {0}</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.PositionFormat" xml:space="preserve"><value>Scroll position: {0} - {1}</value></data>
+
+  <!-- Settings: Dev Buffer Tab -->
+  <data name="Settings.DevBuffer.Header" xml:space="preserve"><value>Buffer Dump</value></data>
+  <data name="Settings.DevBuffer.Help" xml:space="preserve"><value>Downloads the session's output buffer (up to 2MB) as a file.</value></data>
+  <data name="Settings.DevBuffer.SelectLabel" xml:space="preserve"><value>Select session</value></data>
+  <data name="Settings.DevBuffer.SelectPlaceholder" xml:space="preserve"><value>-- Select a session --</value></data>
+  <data name="Settings.DevBuffer.Empty" xml:space="preserve"><value>(empty)</value></data>
+  <data name="Settings.DevBuffer.BufferFormat" xml:space="preserve"><value>Buffer: {0}</value></data>
+  <data name="Settings.DevBuffer.StatusHistoryFormat" xml:space="preserve"><value>Status history: {0}</value></data>
+  <data name="Settings.DevBuffer.DownloadBuffer" xml:space="preserve"><value>Buffer</value></data>
+  <data name="Settings.DevBuffer.DownloadBufferClean" xml:space="preserve"><value>Buffer (ANSI stripped)</value></data>
+  <data name="Settings.DevBuffer.DownloadStatusHistory" xml:space="preserve"><value>Status history JSON</value></data>
+  <data name="Settings.DevBuffer.Result.SelectSession" xml:space="preserve"><value>Please select a session</value></data>
+  <data name="Settings.DevBuffer.Result.BufferEmpty" xml:space="preserve"><value>Buffer is empty</value></data>
+  <data name="Settings.DevBuffer.Result.DownloadedFormat" xml:space="preserve"><value>Download complete: {0} ({1})</value></data>
+  <data name="Settings.DevBuffer.HeaderBufferInfo" xml:space="preserve"><value>Buffer Info</value></data>
+  <data name="Settings.DevBuffer.HeaderBufferContent" xml:space="preserve"><value>Buffer Content</value></data>
+
+  <!-- Settings: Dev Notify Tab -->
+  <data name="Settings.DevNotify.Header" xml:space="preserve"><value>Notification Test</value></data>
+  <data name="Settings.DevNotify.TestElapsedLabel" xml:space="preserve"><value>Test elapsed time (seconds)</value></data>
+  <data name="Settings.DevNotify.TestBrowser" xml:space="preserve"><value>Test browser notification</value></data>
+  <data name="Settings.DevNotify.TestWebhook" xml:space="preserve"><value>Test webhook notification</value></data>
+  <data name="Settings.DevNotify.Result.Initial" xml:space="preserve"><value>Test results will appear here</value></data>
+  <data name="Settings.DevNotify.Result.BrowserSendingFormat" xml:space="preserve"><value>Sending browser notification... (as {0}s process)</value></data>
+  <data name="Settings.DevNotify.Result.BrowserSentFormat" xml:space="preserve"><value>Browser notification sent - {0}</value></data>
+  <data name="Settings.DevNotify.Result.WebhookSendingFormat" xml:space="preserve"><value>Sending webhook notification... (as {0}s process)</value></data>
+  <data name="Settings.DevNotify.Result.WebhookSentFormat" xml:space="preserve"><value>Webhook notification sent - {0}</value></data>
+  <data name="Settings.DevNotify.SessionName.Browser" xml:space="preserve"><value>Browser notification test</value></data>
+  <data name="Settings.DevNotify.SessionName.Webhook" xml:space="preserve"><value>Webhook notification test</value></data>
+
+  <!-- Settings: Cross-tab messages (saveMessage / validation / version / export / import) -->
+  <data name="Settings.Message.PermissionGranted" xml:space="preserve"><value>Notifications allowed</value></data>
+  <data name="Settings.Message.PermissionDenied" xml:space="preserve"><value>Notifications denied</value></data>
+  <data name="Settings.Message.OpenFolderErrorFormat" xml:space="preserve"><value>Could not open folder: {0}</value></data>
+  <data name="Settings.Message.ThresholdNegative" xml:space="preserve"><value>Notification threshold must be 0 or greater</value></data>
+  <data name="Settings.Message.WebhookUrlRequired" xml:space="preserve"><value>Please enter a Webhook URL</value></data>
+  <data name="Settings.Message.PathNotExists" xml:space="preserve"><value>The specified path does not exist</value></data>
+  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>The specified folder does not exist</value></data>
+  <data name="Settings.Message.FolderDuplicate" xml:space="preserve"><value>This folder has already been added</value></data>
+  <data name="Settings.Message.SaveSuccess" xml:space="preserve"><value>Settings saved</value></data>
+  <data name="Settings.Message.SaveErrorFormat" xml:space="preserve"><value>Save error: {0}</value></data>
+  <data name="Settings.Message.VersionFetchFailed" xml:space="preserve"><value>Could not retrieve version information</value></data>
+  <data name="Settings.Message.VersionCheckErrorFormat" xml:space="preserve"><value>Check failed: {0}</value></data>
+  <data name="Settings.Message.ExportSuccessFormat" xml:space="preserve"><value>Exported sessions ({0})</value></data>
+  <data name="Settings.Message.ExportErrorFormat" xml:space="preserve"><value>Export error: {0}</value></data>
+  <data name="Settings.Message.JsonFileRequired" xml:space="preserve"><value>Please select a JSON file</value></data>
+  <data name="Settings.Message.SessionsNotFound" xml:space="preserve"><value>No sessions found</value></data>
+  <data name="Settings.Message.FileReadErrorFormat" xml:space="preserve"><value>File read error: {0}</value></data>
+  <data name="Settings.Message.ImportResultFormat" xml:space="preserve"><value>Import complete ({0} added, {1} skipped as duplicates). Please reload the page.</value></data>
+  <data name="Settings.Message.ImportErrorFormat" xml:space="preserve"><value>Import error: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -256,14 +256,14 @@
   <data name="Settings.DevNotify.Header" xml:space="preserve"><value>通知テスト</value></data>
   <data name="Settings.DevNotify.TestElapsedLabel" xml:space="preserve"><value>テスト用経過時間（秒）</value></data>
   <data name="Settings.DevNotify.TestBrowser" xml:space="preserve"><value>ブラウザ通知テスト</value></data>
-  <data name="Settings.DevNotify.TestWebhook" xml:space="preserve"><value>WebHook 通知テスト</value></data>
+  <data name="Settings.DevNotify.TestWebhook" xml:space="preserve"><value>Webhook 通知テスト</value></data>
   <data name="Settings.DevNotify.Result.Initial" xml:space="preserve"><value>テスト結果がここに表示されます</value></data>
   <data name="Settings.DevNotify.Result.BrowserSendingFormat" xml:space="preserve"><value>ブラウザ通知を送信中… ({0} 秒の処理として)</value></data>
   <data name="Settings.DevNotify.Result.BrowserSentFormat" xml:space="preserve"><value>ブラウザ通知を送信しました - {0}</value></data>
-  <data name="Settings.DevNotify.Result.WebhookSendingFormat" xml:space="preserve"><value>WebHook 通知を送信中… ({0} 秒の処理として)</value></data>
-  <data name="Settings.DevNotify.Result.WebhookSentFormat" xml:space="preserve"><value>WebHook 通知を送信しました - {0}</value></data>
+  <data name="Settings.DevNotify.Result.WebhookSendingFormat" xml:space="preserve"><value>Webhook 通知を送信中… ({0} 秒の処理として)</value></data>
+  <data name="Settings.DevNotify.Result.WebhookSentFormat" xml:space="preserve"><value>Webhook 通知を送信しました - {0}</value></data>
   <data name="Settings.DevNotify.SessionName.Browser" xml:space="preserve"><value>通知テストセッション</value></data>
-  <data name="Settings.DevNotify.SessionName.Webhook" xml:space="preserve"><value>WebHook テストセッション</value></data>
+  <data name="Settings.DevNotify.SessionName.Webhook" xml:space="preserve"><value>Webhook テストセッション</value></data>
 
   <!-- Settings: Cross-tab messages (saveMessage / validation / version / export / import) -->
   <data name="Settings.Message.PermissionGranted" xml:space="preserve"><value>通知が許可されました</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -58,6 +58,7 @@
   <!-- Common -->
   <data name="Common.Close" xml:space="preserve"><value>閉じる</value></data>
   <data name="Common.Add" xml:space="preserve"><value>追加</value></data>
+  <data name="Common.ErrorFormat" xml:space="preserve"><value>エラー: {0}</value></data>
 
   <!-- Settings Dialog -->
   <data name="Settings.Title" xml:space="preserve"><value>設定</value></data>
@@ -193,4 +194,95 @@
   <data name="Settings.RemoteLaunch.TopicGuid" xml:space="preserve"><value>トピックGUID</value></data>
   <data name="Settings.RemoteLaunch.RegenerateGuidTitle" xml:space="preserve"><value>GUIDを再発行（既存のアクセスURLが無効になります）</value></data>
   <data name="Settings.RemoteLaunch.RegenerateGuidHelp" xml:space="preserve"><value>再発行すると既存のアクセスURLが無効になります。</value></data>
+
+  <!-- Settings: Special Tab -->
+  <data name="Settings.Special.Header" xml:space="preserve"><value>特殊設定</value></data>
+  <data name="Settings.Special.ClaudeModeKey.Header" xml:space="preserve"><value>Claude Code モード切替キー</value></data>
+  <data name="Settings.Special.ClaudeModeKey.Help" xml:space="preserve"><value>Claude Code でモード切替に使用するキーボードショートカットを選択します。</value></data>
+  <data name="Settings.Special.ClaudeModeKey.None" xml:space="preserve"><value>無し</value></data>
+  <data name="Settings.Special.ClaudeModeKey.DefaultNote" xml:space="preserve"><value>（デフォルト）</value></data>
+  <data name="Settings.Special.ClaudeModeKey.ConflictNote" xml:space="preserve"><value>環境によっては Alt+M が他の機能と競合する場合があります。その場合は Shift+Tab をお試しください。</value></data>
+  <data name="Settings.Special.VoiceInput.Header" xml:space="preserve"><value>音声入力</value></data>
+  <data name="Settings.Special.VoiceInput.Enable" xml:space="preserve"><value>音声入力を有効にする（実験的）</value></data>
+  <data name="Settings.Special.VoiceInput.Help" xml:space="preserve"><value>有効にすると、テキスト入力パネルにマイクボタンが表示されます。ボタンを押している間だけ音声認識が動作します（Chrome 推奨）。</value></data>
+  <data name="Settings.Special.TextRefine.Header" xml:space="preserve"><value>テキスト事前整形</value></data>
+  <data name="Settings.Special.TextRefine.Enable" xml:space="preserve"><value>事前整形ボタンを有効にする（実験的）</value></data>
+  <data name="Settings.Special.TextRefine.HelpHtml" xml:space="preserve"><value>有効にすると、テキスト入力パネルに「&lt;i class="bi bi-stars"&gt;&lt;/i&gt; 事前整形」ボタンが表示されます。押すと Claude Code CLI（Haiku モデル）で誤字脱字や表現の揺れを修正します。&lt;br/&gt;整形指示は &lt;code&gt;%LOCALAPPDATA%\TerminalHub\refine-workdir\CLAUDE.md&lt;/code&gt; を編集してカスタマイズ可能。</value></data>
+  <data name="Settings.Special.DevTools.Header" xml:space="preserve"><value>開発ツール</value></data>
+  <data name="Settings.Special.DevTools.Enable" xml:space="preserve"><value>開発ツールを有効にする</value></data>
+  <data name="Settings.Special.DevTools.Help" xml:space="preserve"><value>有効にすると、診断・バッファ・通知テストのタブが表示されます。</value></data>
+  <data name="Settings.Special.Logs.Header" xml:space="preserve"><value>ログファイル</value></data>
+  <data name="Settings.Special.Logs.OpenFolder" xml:space="preserve"><value>ログフォルダを開く</value></data>
+  <data name="Settings.Special.Logs.Help" xml:space="preserve"><value>アプリケーションのログファイルが保存されているフォルダを開きます。</value></data>
+
+  <!-- Settings: Dev Diagnose Tab -->
+  <data name="Settings.DevDiagnose.Header" xml:space="preserve"><value>診断情報</value></data>
+  <data name="Settings.DevDiagnose.Refresh" xml:space="preserve"><value>診断情報を更新</value></data>
+  <data name="Settings.DevDiagnose.RunJs" xml:space="preserve"><value>JS 診断実行</value></data>
+  <data name="Settings.DevDiagnose.SessionList" xml:space="preserve"><value>セッション一覧</value></data>
+  <data name="Settings.DevDiagnose.ColName" xml:space="preserve"><value>名前</value></data>
+  <data name="Settings.DevDiagnose.ColStatus" xml:space="preserve"><value>状態</value></data>
+  <data name="Settings.DevDiagnose.ConPtyPresent" xml:space="preserve"><value>有</value></data>
+  <data name="Settings.DevDiagnose.ConPtyAbsent" xml:space="preserve"><value>無</value></data>
+  <data name="Settings.DevDiagnose.TerminalInfo.Header" xml:space="preserve"><value>ターミナル情報</value></data>
+  <data name="Settings.DevDiagnose.TerminalInfo.JsTerminalCount" xml:space="preserve"><value>JavaScript 側ターミナル数:</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.Header" xml:space="preserve"><value>ターミナル制御テスト</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.ScrollBottom" xml:space="preserve"><value>最下部へ</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.ScrollTop" xml:space="preserve"><value>最上部へ</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.GetPosition" xml:space="preserve"><value>位置取得</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.Initial" xml:space="preserve"><value>スクロール位置情報が表示されます</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.BottomFormat" xml:space="preserve"><value>最下部にスクロールしました - {0}</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.TopFormat" xml:space="preserve"><value>最上部にスクロールしました - {0}</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.PositionFormat" xml:space="preserve"><value>スクロール位置: {0} - {1}</value></data>
+
+  <!-- Settings: Dev Buffer Tab -->
+  <data name="Settings.DevBuffer.Header" xml:space="preserve"><value>バッファダンプ</value></data>
+  <data name="Settings.DevBuffer.Help" xml:space="preserve"><value>セッションの出力バッファ（最大2MB）をファイルにダウンロードします。</value></data>
+  <data name="Settings.DevBuffer.SelectLabel" xml:space="preserve"><value>セッション選択</value></data>
+  <data name="Settings.DevBuffer.SelectPlaceholder" xml:space="preserve"><value>-- セッションを選択 --</value></data>
+  <data name="Settings.DevBuffer.Empty" xml:space="preserve"><value>(空)</value></data>
+  <data name="Settings.DevBuffer.BufferFormat" xml:space="preserve"><value>バッファ: {0}</value></data>
+  <data name="Settings.DevBuffer.StatusHistoryFormat" xml:space="preserve"><value>ステータス履歴: {0} 件</value></data>
+  <data name="Settings.DevBuffer.DownloadBuffer" xml:space="preserve"><value>バッファ</value></data>
+  <data name="Settings.DevBuffer.DownloadBufferClean" xml:space="preserve"><value>バッファ (ANSI 除去)</value></data>
+  <data name="Settings.DevBuffer.DownloadStatusHistory" xml:space="preserve"><value>ステータス履歴 JSON</value></data>
+  <data name="Settings.DevBuffer.Result.SelectSession" xml:space="preserve"><value>セッションを選択してください</value></data>
+  <data name="Settings.DevBuffer.Result.BufferEmpty" xml:space="preserve"><value>バッファが空です</value></data>
+  <data name="Settings.DevBuffer.Result.DownloadedFormat" xml:space="preserve"><value>ダウンロード完了: {0} ({1})</value></data>
+  <data name="Settings.DevBuffer.HeaderBufferInfo" xml:space="preserve"><value>バッファ情報</value></data>
+  <data name="Settings.DevBuffer.HeaderBufferContent" xml:space="preserve"><value>バッファ内容</value></data>
+
+  <!-- Settings: Dev Notify Tab -->
+  <data name="Settings.DevNotify.Header" xml:space="preserve"><value>通知テスト</value></data>
+  <data name="Settings.DevNotify.TestElapsedLabel" xml:space="preserve"><value>テスト用経過時間（秒）</value></data>
+  <data name="Settings.DevNotify.TestBrowser" xml:space="preserve"><value>ブラウザ通知テスト</value></data>
+  <data name="Settings.DevNotify.TestWebhook" xml:space="preserve"><value>WebHook 通知テスト</value></data>
+  <data name="Settings.DevNotify.Result.Initial" xml:space="preserve"><value>テスト結果がここに表示されます</value></data>
+  <data name="Settings.DevNotify.Result.BrowserSendingFormat" xml:space="preserve"><value>ブラウザ通知を送信中… ({0} 秒の処理として)</value></data>
+  <data name="Settings.DevNotify.Result.BrowserSentFormat" xml:space="preserve"><value>ブラウザ通知を送信しました - {0}</value></data>
+  <data name="Settings.DevNotify.Result.WebhookSendingFormat" xml:space="preserve"><value>WebHook 通知を送信中… ({0} 秒の処理として)</value></data>
+  <data name="Settings.DevNotify.Result.WebhookSentFormat" xml:space="preserve"><value>WebHook 通知を送信しました - {0}</value></data>
+  <data name="Settings.DevNotify.SessionName.Browser" xml:space="preserve"><value>通知テストセッション</value></data>
+  <data name="Settings.DevNotify.SessionName.Webhook" xml:space="preserve"><value>WebHook テストセッション</value></data>
+
+  <!-- Settings: Cross-tab messages (saveMessage / validation / version / export / import) -->
+  <data name="Settings.Message.PermissionGranted" xml:space="preserve"><value>通知が許可されました</value></data>
+  <data name="Settings.Message.PermissionDenied" xml:space="preserve"><value>通知が拒否されました</value></data>
+  <data name="Settings.Message.OpenFolderErrorFormat" xml:space="preserve"><value>フォルダを開けませんでした: {0}</value></data>
+  <data name="Settings.Message.ThresholdNegative" xml:space="preserve"><value>通知時間は 0 以上にしてください</value></data>
+  <data name="Settings.Message.WebhookUrlRequired" xml:space="preserve"><value>Webhook URL を入力してください</value></data>
+  <data name="Settings.Message.PathNotExists" xml:space="preserve"><value>指定されたパスが存在しません</value></data>
+  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>指定されたフォルダが存在しません</value></data>
+  <data name="Settings.Message.FolderDuplicate" xml:space="preserve"><value>このフォルダは既に追加されています</value></data>
+  <data name="Settings.Message.SaveSuccess" xml:space="preserve"><value>設定を保存しました</value></data>
+  <data name="Settings.Message.SaveErrorFormat" xml:space="preserve"><value>保存エラー: {0}</value></data>
+  <data name="Settings.Message.VersionFetchFailed" xml:space="preserve"><value>バージョン情報を取得できませんでした</value></data>
+  <data name="Settings.Message.VersionCheckErrorFormat" xml:space="preserve"><value>チェックに失敗しました: {0}</value></data>
+  <data name="Settings.Message.ExportSuccessFormat" xml:space="preserve"><value>セッション情報（{0} 件）をエクスポートしました</value></data>
+  <data name="Settings.Message.ExportErrorFormat" xml:space="preserve"><value>エクスポートエラー: {0}</value></data>
+  <data name="Settings.Message.JsonFileRequired" xml:space="preserve"><value>JSON ファイルを選択してください</value></data>
+  <data name="Settings.Message.SessionsNotFound" xml:space="preserve"><value>セッション情報が見つかりませんでした</value></data>
+  <data name="Settings.Message.FileReadErrorFormat" xml:space="preserve"><value>ファイル読み込みエラー: {0}</value></data>
+  <data name="Settings.Message.ImportResultFormat" xml:space="preserve"><value>インポートが完了しました（{0} 件追加、{1} 件は重複のためスキップ）。ページを再読み込みしてください。</value></data>
+  <data name="Settings.Message.ImportErrorFormat" xml:space="preserve"><value>インポートエラー: {0}</value></data>
 </root>


### PR DESCRIPTION
## Summary
Phase 2B-3 として設定ダイアログの残り 4 タブ (特殊 / 診断 / バッファ / 通知テスト) + 横断的な save/validation/export/import メッセージを localize。

本 PR マージで **設定ダイアログ 100% 多言語対応完了**。

## 新キー追加 (~80 キー)

### 新規セクション
- **`Common.ErrorFormat`**: `"エラー: {0}"` / `"Error: {0}"` を共通キー化 (複数箇所で再利用)
- **`Settings.Special.*`** (18 キー): Claude Code モード切替 / 音声入力 / 事前整形 / 開発ツール / ログ
- **`Settings.DevDiagnose.*`** (17 キー): 診断タブ全文字列 + `scrollInfo` format 3 種
- **`Settings.DevBuffer.*`** (13 キー): バッファタブ全部 + ダウンロードヘッダ + result メッセージ
- **`Settings.DevNotify.*`** (9 キー): 通知テスト + sending/sent format + session names
- **`Settings.Message.*`** (19 キー): 横断 save/validation/version/export/import メッセージ

### HTML 含むキー
事前整形のヘルプは `<code>` / `<i>` タグを含むため `Settings.Special.TextRefine.HelpHtml` として `*Html` サフィックス + `MarkupString` 経由でレンダリング (Phase 2B-1 と同パターン)。

## Code-behind の全面 localize

多数の日本語リテラルを resx 参照に置換 (~20 箇所):
- **`ScrollToBottom` / `ScrollToTop` / `GetScrollPosition`**: format 文字列 + `Common.ErrorFormat`
- **`WithSelectedBufferSession`**: result/error メッセージ全 localize
- **`TestBrowserNotification` / `TestWebHookNotification`**: sending/sent format + session name
- **`SaveSettings`**: validation 2 種 + save success/error
- **`AddFavoriteFolder`**: folder not exists / duplicate
- **`RequestNotificationPermission` / `OpenBrowserNotificationSettings` / `OpenLogFolder`**: 各エラーパス
- **`CheckForVersionUpdates`**: fetch failed / check error
- **`ExportSettings` / `LoadImportFile` / `ImportSettings`**: 全成功/エラーパス

### 初期値の設定方法
`scrollInfo` と `notificationTestResult` の初期値は `L` が field initializer 時点で inject されていないため、`OnInitialized` 内で localize 済みの値をセットする:

```csharp
private string scrollInfo = "";  // field は空で初期化
// ...
protected override void OnInitialized()
{
    // L はここで inject 済み
    scrollInfo = L["Settings.DevDiagnose.ScrollInfo.Initial"];
    notificationTestResult = L["Settings.DevNotify.Result.Initial"];
}
```

## 意図的に残した日本語 (3 箇所)
- `<option value="ja">日本語</option>`: 言語ピッカーの選択肢は自言語表記が慣例
- `Console.WriteLine` 3 箇所: 開発ログ用途、メンテナ向け
- `NotifStateNotRequested` コメント内の「未許可」: 内部コメント

## 動作確認済み
- [x] C# コンパイル成功 (`obj/` DLL 更新)
- 最終 exe コピーは起動中インスタンスでブロック (再起動で解消)

## 検証手順 (マージ前)
- [ ] dev 再起動 → 設定ダイアログを英語/日本語両方で開く
- [ ] 特殊タブ: 各セクション表示、事前整形の HTML 含むヘルプ文が MarkupString で正しく描画
- [ ] 開発ツールを ON にして表示される 3 タブを確認:
  - 診断タブ: セッション一覧テーブル、ConPTY 列の Yes/No、スクロールテストの結果メッセージ
  - バッファタブ: セッション選択、「バッファ: N」format 表示、ダウンロード成功メッセージ
  - 通知テストタブ: 送信中/送信完了 format、Common.Error fallback
- [ ] 設定保存時の各メッセージ:
  - バリデーションエラー (threshold / webhook URL)
  - パス存在チェック
  - お気に入りフォルダ追加の各エラー
  - 保存成功メッセージが 3 秒で消える

## Phase 2 完走 🎉
本 PR で **設定ダイアログの全 11 タブが多言語対応完了**。Phase 2 の当初目標を達成。

## 今後
- Phase 2C (任意): 新規セッションダイアログ、メイン UI (左サイドバー・ボタン・トースト)
- Phase 3 (反響次第): 中国語簡体字・繁体字・韓国語
- もしくは `feat/i18n` → `master` の最終 PR で v1.0.55 リリース

🤖 Generated with [Claude Code](https://claude.com/claude-code)