### PR TITLE
feat: 新規セッション作成ダイアログを多言語対応 (Phase 2C-1)

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -1,5 +1,6 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
+@using Microsoft.Extensions.Localization
 @using Microsoft.JSInterop
 @using System.IO
 @inject IJSRuntime JSRuntime
@@ -7,27 +8,28 @@
 @inject ILogger<SessionCreateDialog> Logger
 @inject IAppSettingsService AppSettingsService
 @inject IFolderPickerService FolderPicker
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsVisible && !showCreateFolderDialog ? "show" : "")" tabindex="-1" style="@(IsVisible && !showCreateFolderDialog ? "display: block;" : "display: none;")" @onmousedown="OnBackdropMouseDown" @onmouseup="OnBackdropMouseUp">
     <div class="modal-dialog modal-dialog-centered modal-lg" @onclick:stopPropagation="true" @onmousedown:stopPropagation="true" @onmouseup:stopPropagation="true">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">新しいセッションを作成</h5>
+                <h5 class="modal-title">@L["SessionCreate.Title"]</h5>
                 <button type="button" class="btn-close" @onclick="Cancel"></button>
             </div>
             <div class="modal-body">
                 <div class="mb-3">
-                    <label class="form-label">フォルダを選択</label>
+                    <label class="form-label">@L["SessionCreate.FolderLabel"]</label>
                     <div class="input-group">
-                        <input type="text" class="form-control" @bind="folderPath" placeholder="フォルダパスを入力または選択" />
+                        <input type="text" class="form-control" @bind="folderPath" placeholder="@L["SessionCreate.FolderPlaceholder"]" />
                         <div class="dropdown">
                             <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="bi bi-folder-open"></i> 参照
+                                <i class="bi bi-folder-open"></i> @L["SessionCreate.BrowseButton"]
                             </button>
                             <ul class="dropdown-menu dropdown-menu-end" style="max-height: 300px; overflow-y: auto;">
                                 @if (favoriteFolders.Any())
                                 {
-                                    <li><h6 class="dropdown-header">お気に入りフォルダ</h6></li>
+                                    <li><h6 class="dropdown-header">@L["SessionCreate.FavoriteFolders"]</h6></li>
                                     @foreach (var folder in favoriteFolders)
                                     {
                                         <li>
@@ -51,19 +53,19 @@
                                 {
                                     <li>
                                         <button class="dropdown-item" type="button" @onclick="() => SelectFolder(_cachedDefaultFolderPath)">
-                                            <i class="bi bi-folder-fill text-success me-2"></i>デフォルトフォルダ
+                                            <i class="bi bi-folder-fill text-success me-2"></i>@L["SessionCreate.DefaultFolder"]
                                         </button>
                                     </li>
                                 }
                                 <li>
                                     <button class="dropdown-item" type="button" @onclick="SelectUserHome">
-                                        <i class="bi bi-house-fill text-primary me-2"></i>ユーザーホーム
+                                        <i class="bi bi-house-fill text-primary me-2"></i>@L["SessionCreate.UserHome"]
                                     </button>
                                 </li>
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
                                     <button class="dropdown-item" type="button" @onclick="OpenNativeFolderPicker">
-                                        <i class="bi bi-folder-symlink text-secondary me-2"></i>フォルダを選択...
+                                        <i class="bi bi-folder-symlink text-secondary me-2"></i>@L["SessionCreate.PickFolder"]
                                     </button>
                                 </li>
                             </ul>
@@ -82,9 +84,9 @@
                                       CodexOptions="codexOptions" />
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" @onclick="Cancel">キャンセル</button>
+                <button type="button" class="btn btn-secondary" @onclick="Cancel">@L["Common.Cancel"]</button>
                 <button type="button" class="btn btn-primary" @onclick="CreateSession" disabled="@string.IsNullOrWhiteSpace(folderPath)">
-                    作成
+                    @L["Common.Create"]
                 </button>
             </div>
         </div>
@@ -103,16 +105,16 @@
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">フォルダの作成</h5>
+                    <h5 class="modal-title">@L["SessionCreate.CreateFolder.Title"]</h5>
                 </div>
                 <div class="modal-body">
-                    <p>指定されたフォルダが存在しません。</p>
+                    <p>@L["SessionCreate.CreateFolder.NotExists"]</p>
                     <p class="mb-2"><strong>@folderPath</strong></p>
-                    <p>このフォルダを作成しますか？</p>
+                    <p>@L["SessionCreate.CreateFolder.Question"]</p>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="CancelFolderCreation">キャンセル</button>
-                    <button type="button" class="btn btn-primary" @onclick="ConfirmFolderCreation">作成する</button>
+                    <button type="button" class="btn btn-secondary" @onclick="CancelFolderCreation">@L["Common.Cancel"]</button>
+                    <button type="button" class="btn btn-primary" @onclick="ConfirmFolderCreation">@L["SessionCreate.CreateFolder.Confirm"]</button>
                 </div>
             </div>
         </div>

--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -108,7 +108,7 @@
                     <h5 class="modal-title">@L["SessionCreate.CreateFolder.Title"]</h5>
                 </div>
                 <div class="modal-body">
-                    <p>@L["SessionCreate.CreateFolder.NotExists"]</p>
+                    <p>@L["Settings.Message.FolderNotExists"]</p>
                     <p class="mb-2"><strong>@folderPath</strong></p>
                     <p>@L["SessionCreate.CreateFolder.Question"]</p>
                 </div>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -58,6 +58,8 @@
   <!-- Common -->
   <data name="Common.Close" xml:space="preserve"><value>Close</value></data>
   <data name="Common.Add" xml:space="preserve"><value>Add</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Common.Create" xml:space="preserve"><value>Create</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>Error: {0}</value></data>
 
   <!-- Settings Dialog -->
@@ -285,4 +287,18 @@
   <data name="Settings.Message.FileReadErrorFormat" xml:space="preserve"><value>File read error: {0}</value></data>
   <data name="Settings.Message.ImportResultFormat" xml:space="preserve"><value>Import complete ({0} added, {1} skipped as duplicates). Please reload the page.</value></data>
   <data name="Settings.Message.ImportErrorFormat" xml:space="preserve"><value>Import error: {0}</value></data>
+
+  <!-- SessionCreate Dialog -->
+  <data name="SessionCreate.Title" xml:space="preserve"><value>New Session</value></data>
+  <data name="SessionCreate.FolderLabel" xml:space="preserve"><value>Select folder</value></data>
+  <data name="SessionCreate.FolderPlaceholder" xml:space="preserve"><value>Enter or select a folder path</value></data>
+  <data name="SessionCreate.BrowseButton" xml:space="preserve"><value>Browse</value></data>
+  <data name="SessionCreate.FavoriteFolders" xml:space="preserve"><value>Favorite folders</value></data>
+  <data name="SessionCreate.DefaultFolder" xml:space="preserve"><value>Default folder</value></data>
+  <data name="SessionCreate.UserHome" xml:space="preserve"><value>User home</value></data>
+  <data name="SessionCreate.PickFolder" xml:space="preserve"><value>Pick folder...</value></data>
+  <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>Create Folder</value></data>
+  <data name="SessionCreate.CreateFolder.NotExists" xml:space="preserve"><value>The specified folder does not exist.</value></data>
+  <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>Create this folder?</value></data>
+  <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>Create</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -274,7 +274,7 @@
   <data name="Settings.Message.ThresholdNegative" xml:space="preserve"><value>Notification threshold must be 0 or greater</value></data>
   <data name="Settings.Message.WebhookUrlRequired" xml:space="preserve"><value>Please enter a Webhook URL</value></data>
   <data name="Settings.Message.PathNotExists" xml:space="preserve"><value>The specified path does not exist</value></data>
-  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>The specified folder does not exist</value></data>
+  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>The specified folder does not exist.</value></data>
   <data name="Settings.Message.FolderDuplicate" xml:space="preserve"><value>This folder has already been added</value></data>
   <data name="Settings.Message.SaveSuccess" xml:space="preserve"><value>Settings saved</value></data>
   <data name="Settings.Message.SaveErrorFormat" xml:space="preserve"><value>Save error: {0}</value></data>
@@ -298,7 +298,6 @@
   <data name="SessionCreate.UserHome" xml:space="preserve"><value>User home</value></data>
   <data name="SessionCreate.PickFolder" xml:space="preserve"><value>Pick folder...</value></data>
   <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>Create Folder</value></data>
-  <data name="SessionCreate.CreateFolder.NotExists" xml:space="preserve"><value>The specified folder does not exist.</value></data>
   <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>Create this folder?</value></data>
   <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>Create</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -58,6 +58,8 @@
   <!-- Common -->
   <data name="Common.Close" xml:space="preserve"><value>閉じる</value></data>
   <data name="Common.Add" xml:space="preserve"><value>追加</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>キャンセル</value></data>
+  <data name="Common.Create" xml:space="preserve"><value>作成</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>エラー: {0}</value></data>
 
   <!-- Settings Dialog -->
@@ -285,4 +287,18 @@
   <data name="Settings.Message.FileReadErrorFormat" xml:space="preserve"><value>ファイル読み込みエラー: {0}</value></data>
   <data name="Settings.Message.ImportResultFormat" xml:space="preserve"><value>インポートが完了しました（{0} 件追加、{1} 件は重複のためスキップ）。ページを再読み込みしてください。</value></data>
   <data name="Settings.Message.ImportErrorFormat" xml:space="preserve"><value>インポートエラー: {0}</value></data>
+
+  <!-- SessionCreate Dialog -->
+  <data name="SessionCreate.Title" xml:space="preserve"><value>新しいセッションを作成</value></data>
+  <data name="SessionCreate.FolderLabel" xml:space="preserve"><value>フォルダを選択</value></data>
+  <data name="SessionCreate.FolderPlaceholder" xml:space="preserve"><value>フォルダパスを入力または選択</value></data>
+  <data name="SessionCreate.BrowseButton" xml:space="preserve"><value>参照</value></data>
+  <data name="SessionCreate.FavoriteFolders" xml:space="preserve"><value>お気に入りフォルダ</value></data>
+  <data name="SessionCreate.DefaultFolder" xml:space="preserve"><value>デフォルトフォルダ</value></data>
+  <data name="SessionCreate.UserHome" xml:space="preserve"><value>ユーザーホーム</value></data>
+  <data name="SessionCreate.PickFolder" xml:space="preserve"><value>フォルダを選択...</value></data>
+  <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>フォルダの作成</value></data>
+  <data name="SessionCreate.CreateFolder.NotExists" xml:space="preserve"><value>指定されたフォルダが存在しません。</value></data>
+  <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>このフォルダを作成しますか？</value></data>
+  <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>作成する</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -274,7 +274,7 @@
   <data name="Settings.Message.ThresholdNegative" xml:space="preserve"><value>通知時間は 0 以上にしてください</value></data>
   <data name="Settings.Message.WebhookUrlRequired" xml:space="preserve"><value>Webhook URL を入力してください</value></data>
   <data name="Settings.Message.PathNotExists" xml:space="preserve"><value>指定されたパスが存在しません</value></data>
-  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>指定されたフォルダが存在しません</value></data>
+  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>指定されたフォルダが存在しません。</value></data>
   <data name="Settings.Message.FolderDuplicate" xml:space="preserve"><value>このフォルダは既に追加されています</value></data>
   <data name="Settings.Message.SaveSuccess" xml:space="preserve"><value>設定を保存しました</value></data>
   <data name="Settings.Message.SaveErrorFormat" xml:space="preserve"><value>保存エラー: {0}</value></data>
@@ -298,7 +298,6 @@
   <data name="SessionCreate.UserHome" xml:space="preserve"><value>ユーザーホーム</value></data>
   <data name="SessionCreate.PickFolder" xml:space="preserve"><value>フォルダを選択...</value></data>
   <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>フォルダの作成</value></data>
-  <data name="SessionCreate.CreateFolder.NotExists" xml:space="preserve"><value>指定されたフォルダが存在しません。</value></data>
   <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>このフォルダを作成しますか？</value></data>
   <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>作成する</value></data>
 </root>


### PR DESCRIPTION
## Summary
Phase 2C (アプリ UI 本体) 着手の第 1 弾。新規セッション作成ダイアログの**シェル部分**を英語・日本語対応する。~14 キー追加、+49/-15 行。

## 追加キー

### Common (再利用前提)
- **`Common.Cancel`** / **`Common.Create`**: 他の複数ダイアログで再利用する共通ボタン

### SessionCreate.*
- `Title` / `FolderLabel` / `FolderPlaceholder` / `BrowseButton`
- Dropdown: `FavoriteFolders` / `DefaultFolder` / `UserHome` / `PickFolder`
- Sub-dialog (フォルダ作成確認): `CreateFolder.Title` / `NotExists` / `Question` / `Confirm`

## スコープ外 (次 PR で対応)

`SessionCreateDialog` 内で子コンポーネントとして使われる **`SessionOptionsSelector`** (ターミナルタイプ選択 + Claude/Gemini/Codex 各 CLI のオプション UI) は:
- 698 行 / 94 ja lines と大きい
- `SubSessionDialog` でも共有される

そのため `SessionOptionsSelector` の localize は **Phase 2C-1b** として分離します。

**本 PR マージ直後の挙動**: 「New Session」ダイアログの shell (タイトル・フォルダ選択・キャンセル/作成ボタン) は英語化されるが、その下のオプション選択部分は日本語のまま (Phase 2C-1b 完了で全体完成)。

## 動作確認済み
- [x] C# コンパイル成功

## 検証手順
- [ ] dev 再起動 → 「New Session」ボタンクリック
- [ ] ダイアログタイトル / Browse ドロップダウン / Cancel・Create ボタンが culture 連動
- [ ] 存在しないフォルダパスを入力 → Create → 「Create Folder」確認サブダイアログが英語/日本語切替

## Phase 2C 全体計画
- **本 PR (2C-1)**: SessionCreateDialog ✅
- 2C-1b: SessionOptionsSelector (shared component、大物)
- 2C-2: SessionSettingsDialog + SubSessionDialog
- 2C-3: SessionList + ArchivedSessionsDialog (左サイドバー)
- 2C-4: BottomPanels (TextInput / Memo)
- 2C-5: Root.razor (メインページ、最大、359 ja lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)