### PR TITLE
feat: SessionOptionsSelector を多言語対応 (Phase 2C-1b)

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -1,19 +1,21 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
 @using Microsoft.Extensions.Configuration
+@using Microsoft.Extensions.Localization
 @using Microsoft.JSInterop
 @inject IConfiguration Configuration
 @inject ILocalStorageService LocalStorage
+@inject IStringLocalizer<SharedResource> L
 
 <div class="session-options">
     <div class="mb-3">
-        <label class="form-label d-block">ターミナルタイプ</label>
+        <label class="form-label d-block">@L["SessionOptions.TerminalType.Label"]</label>
         <div class="btn-group d-flex" role="group">
             <input type="radio" class="btn-check" name="@($"terminalType{UniqueId}")" id="@($"terminalType1{UniqueId}")"
                    checked="@(SelectedType == TerminalType.Terminal)"
                    @onchange="() => OnTerminalTypeChanged(TerminalType.Terminal)" autocomplete="off">
             <label class="btn btn-outline-primary" for="@($"terminalType1{UniqueId}")">
-                <i class="bi bi-terminal"></i> ターミナル
+                <i class="bi bi-terminal"></i> @L["SessionOptions.TerminalType.Terminal"]
             </label>
 
             @if (Configuration.GetValue<bool>("ExternalTools:UseClaudeCode", true))
@@ -51,31 +53,31 @@
     @if (SelectedType == TerminalType.ClaudeCode && Configuration.GetValue<bool>("ExternalTools:UseClaudeCode", true))
     {
         <div class="mb-3">
-            <label class="form-label">Claude Code オプション</label>
+            <label class="form-label">@L["SessionOptions.Claude.Header"]</label>
 
             <!-- 権限モード -->
             <div class="mt-2">
-                <label class="form-label small text-muted mb-1">権限モード</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Claude.PermissionMode.Label"]</label>
                 <div class="btn-group d-flex" role="group">
                     <input type="radio" class="btn-check" name="@($"claudePermMode{UniqueId}")" id="@($"claudePermBypass{UniqueId}")"
                            checked="@(ClaudeOptions.PermissionMode == "bypass")"
                            @onchange="@(() => ClaudeOptions.PermissionMode = "bypass")" autocomplete="off">
-                    <label class="btn btn-outline-danger btn-sm" for="@($"claudePermBypass{UniqueId}")" title="全操作を無条件で自動承認します（危険）">
-                        バイパス
+                    <label class="btn btn-outline-danger btn-sm" for="@($"claudePermBypass{UniqueId}")" title="@L["SessionOptions.Claude.PermissionMode.BypassTitle"]">
+                        @L["SessionOptions.Claude.PermissionMode.BypassLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"claudePermMode{UniqueId}")" id="@($"claudePermAuto{UniqueId}")"
                            checked="@(ClaudeOptions.PermissionMode == "auto")"
                            @onchange="@(() => ClaudeOptions.PermissionMode = "auto")" autocomplete="off">
-                    <label class="btn btn-outline-success btn-sm" for="@($"claudePermAuto{UniqueId}")" title="低リスク操作を自動承認し、高リスク操作のみ確認を求めます">
-                        オートモード
+                    <label class="btn btn-outline-success btn-sm" for="@($"claudePermAuto{UniqueId}")" title="@L["SessionOptions.Claude.PermissionMode.AutoTitle"]">
+                        @L["SessionOptions.Claude.PermissionMode.AutoLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"claudePermMode{UniqueId}")" id="@($"claudePermDefault{UniqueId}")"
                            checked="@(ClaudeOptions.PermissionMode == "default")"
                            @onchange="@(() => ClaudeOptions.PermissionMode = "default")" autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"claudePermDefault{UniqueId}")" title="全ての操作で都度確認を求めます">
-                        デフォルト
+                    <label class="btn btn-outline-primary btn-sm" for="@($"claudePermDefault{UniqueId}")" title="@L["SessionOptions.Claude.PermissionMode.DefaultTitle"]">
+                        @L["SessionOptions.Claude.PermissionMode.DefaultLabel"]
                     </label>
                 </div>
                 @if (!string.IsNullOrWhiteSpace(GetPermissionModeHelp()))
@@ -89,51 +91,51 @@
                 <div class="form-check mt-2">
                     <input class="form-check-input" type="checkbox" @bind="ClaudeOptions.Continue" id="@($"claudeContinue{UniqueId}")">
                     <label class="form-check-label" for="@($"claudeContinue{UniqueId}")">
-                        コンティニュー (--continue)
+                        @L["SessionOptions.Claude.Continue"]
                     </label>
                 </div>
             }
             <div class="form-check mt-2">
                 <input class="form-check-input" type="checkbox" @bind="ClaudeOptions.ChromeMode" id="@($"claudeChrome{UniqueId}")">
                 <label class="form-check-label" for="@($"claudeChrome{UniqueId}")">
-                    ブラウザ連携 (--chrome)
+                    @L["SessionOptions.Claude.Chrome"]
                 </label>
             </div>
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">追加引数</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="ClaudeOptions.ExtraArgs"
-                       placeholder="例: --model claude-sonnet-4-20250514 --verbose" />
-                <div class="form-text small">そのままClaude Codeに渡します</div>
+                       placeholder="@L["SessionOptions.Claude.ExtraArgsPlaceholder"]" />
+                <div class="form-text small">@L["SessionOptions.Claude.PassToCli"]</div>
             </div>
         </div>
     }
     else if (SelectedType == TerminalType.GeminiCLI && Configuration.GetValue<bool>("ExternalTools:UseGeminiCli", true))
     {
         <div class="mb-3">
-            <label class="form-label">Gemini CLI オプション</label>
+            <label class="form-label">@L["SessionOptions.Gemini.Header"]</label>
 
             <!-- Approval Mode -->
             <div class="mt-2">
-                <label class="form-label small text-muted mb-1">承認モード</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Gemini.ApprovalMode.Label"]</label>
                 <div class="btn-group d-flex" role="group">
                     <input type="radio" class="btn-check" name="@($"geminiApprovalMode{UniqueId}")" id="@($"geminiModeDefault{UniqueId}")"
                            checked="@(GeminiOptions.ApprovalMode == "default")"
                            @onchange=@(() => GeminiOptions.ApprovalMode = "default") autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"geminiModeDefault{UniqueId}")" title="ツール使用時に都度確認を求めます（デフォルト）">
+                    <label class="btn btn-outline-primary btn-sm" for="@($"geminiModeDefault{UniqueId}")" title="@L["SessionOptions.Gemini.ApprovalMode.DefaultTitle"]">
                         Default
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"geminiApprovalMode{UniqueId}")" id="@($"geminiModeAutoEdit{UniqueId}")"
                            checked="@(GeminiOptions.ApprovalMode == "auto_edit")"
                            @onchange=@(() => GeminiOptions.ApprovalMode = "auto_edit") autocomplete="off">
-                    <label class="btn btn-outline-success btn-sm" for="@($"geminiModeAutoEdit{UniqueId}")" title="ファイル編集など、安全な操作を自動で承認します">
+                    <label class="btn btn-outline-success btn-sm" for="@($"geminiModeAutoEdit{UniqueId}")" title="@L["SessionOptions.Gemini.ApprovalMode.AutoEditTitle"]">
                         Auto-Edit
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"geminiApprovalMode{UniqueId}")" id="@($"geminiModeYolo{UniqueId}")"
                            checked="@(GeminiOptions.ApprovalMode == "yolo")"
                            @onchange=@(() => GeminiOptions.ApprovalMode = "yolo") autocomplete="off">
-                    <label class="btn btn-outline-danger btn-sm" for="@($"geminiModeYolo{UniqueId}")" title="全ての操作を警告なしで自動的に承認します（危険）">
+                    <label class="btn btn-outline-danger btn-sm" for="@($"geminiModeYolo{UniqueId}")" title="@L["SessionOptions.Gemini.ApprovalMode.YoloTitle"]">
                         YOLO
                     </label>
                 </div>
@@ -148,10 +150,10 @@
                 <div class="form-check">
                     <input class="form-check-input" type="checkbox" @bind="GeminiOptions.SandboxMode" id="@($"geminiSandbox{UniqueId}")">
                     <label class="form-check-label" for="@($"geminiSandbox{UniqueId}")">
-                        サンドボックスモード (-s)
+                        @L["SessionOptions.Gemini.Sandbox"]
                     </label>
                     <div class="form-text text-muted small mt-0">
-                        <i class="bi bi-info-circle"></i> この機能を使用するには、Docker Desktopがインストールされている必要があります。
+                        <i class="bi bi-info-circle"></i> @L["SessionOptions.Gemini.SandboxHelp"]
                     </div>
                 </div>
 
@@ -160,7 +162,7 @@
                     <div class="form-check mt-2">
                         <input class="form-check-input" type="checkbox" @bind="GeminiOptions.Continue" id="@($"geminiContinue{UniqueId}")">
                         <label class="form-check-label" for="@($"geminiContinue{UniqueId}")">
-                            コンティニュー (--resume latest)
+                            @L["SessionOptions.Gemini.Continue"]
                         </label>
                     </div>
                 }
@@ -171,7 +173,7 @@
                 <div class="form-check">
                     <input class="form-check-input" type="checkbox" @bind="GeminiOptions.UseCustomModel" id="@($"geminiUseCustomModel{UniqueId}")">
                     <label class="form-check-label" for="@($"geminiUseCustomModel{UniqueId}")">
-                        モデルをカスタマイズ
+                        @L["SessionOptions.Gemini.UseCustomModel"]
                     </label>
                 </div>
 
@@ -179,7 +181,7 @@
                 {
                     <div class="mt-2 ps-4">
                         <div class="mb-2">
-                            <label for="@($"geminiModelSelect{UniqueId}")" class="form-label small text-muted mb-1">使用するモデル</label>
+                            <label for="@($"geminiModelSelect{UniqueId}")" class="form-label small text-muted mb-1">@L["SessionOptions.Gemini.ModelSelectLabel"]</label>
                             <select class="form-select form-select-sm" id="@($"geminiModelSelect{UniqueId}")" @bind="GeminiOptions.Model">
                                 @foreach (var model in geminiModelList)
                                 {
@@ -188,10 +190,10 @@
                             </select>
                         </div>
                         <div>
-                            <label class="form-label small text-muted mb-1">モデルリスト管理</label>
+                            <label class="form-label small text-muted mb-1">@L["SessionOptions.Gemini.ModelManagementLabel"]</label>
                             <div class="input-group input-group-sm">
-                                <input type="text" class="form-control" @bind="newGeminiModelName" placeholder="モデル名を追加..." @onkeydown="OnModelInputKeyDown" />
-                                <button class="btn btn-outline-secondary" type="button" @onclick="AddGeminiModel">追加</button>
+                                <input type="text" class="form-control" @bind="newGeminiModelName" placeholder="@L["SessionOptions.Gemini.ModelAddPlaceholder"]" @onkeydown="OnModelInputKeyDown" />
+                                <button class="btn btn-outline-secondary" type="button" @onclick="AddGeminiModel">@L["Common.Add"]</button>
                             </div>
                             <ul class="list-group mt-2" style="max-height: 150px; overflow-y: auto;">
                                 @foreach (var model in geminiModelList.OrderBy(m => m))
@@ -210,40 +212,40 @@
             </div>
             
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">追加引数</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="GeminiOptions.ExtraArgs"
-                       placeholder="例: --debug --allowed-tools shell,file" />
-                <div class="form-text small">そのままGemini CLIに渡します</div>
+                       placeholder="@L["SessionOptions.Gemini.ExtraArgsPlaceholder"]" />
+                <div class="form-text small">@L["SessionOptions.Gemini.PassToCli"]</div>
             </div>
         </div>
     }
     else if (SelectedType == TerminalType.CodexCLI && Configuration.GetValue<bool>("ExternalTools:UseCodexCli", true))
     {
         <div class="mb-3">
-            <label class="form-label">Codex CLI オプション</label>
+            <label class="form-label">@L["SessionOptions.Codex.Header"]</label>
 
             <div class="mt-2">
-                <label class="form-label small text-muted mb-1">実行モード</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Mode.Label"]</label>
                 <div class="btn-group d-flex" role="group">
                     <input type="radio" class="btn-check" name="@($"codexMode{UniqueId}")" id="@($"codexModeAuto{UniqueId}")"
                            checked="@(CodexOptions.Mode == "auto")"
                            @onchange="() => SetCodexMode(CodexMode.Auto)" autocomplete="off">
-                    <label class="btn btn-outline-success btn-sm" for="@($"codexModeAuto{UniqueId}")" title="編集＋ビルド/テスト等を基本自動化">
-                        Auto (推奨)
+                    <label class="btn btn-outline-success btn-sm" for="@($"codexModeAuto{UniqueId}")" title="@L["SessionOptions.Codex.Mode.AutoTitle"]">
+                        @L["SessionOptions.Codex.Mode.AutoLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"codexMode{UniqueId}")" id="@($"codexModeStandard{UniqueId}")"
                            checked="@(CodexOptions.Mode == "standard")"
                            @onchange="() => SetCodexMode(CodexMode.Standard)" autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"codexModeStandard{UniqueId}")" title="明示的な自動実行フラグを付けず、対話ベースで進行します">
-                        Interactive
+                    <label class="btn btn-outline-primary btn-sm" for="@($"codexModeStandard{UniqueId}")" title="@L["SessionOptions.Codex.Mode.StandardTitle"]">
+                        @L["SessionOptions.Codex.Mode.StandardLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"codexMode{UniqueId}")" id="@($"codexModeYolo{UniqueId}")"
                            checked="@(CodexOptions.Mode == "yolo")"
                            @onchange="() => SetCodexMode(CodexMode.Yolo)" autocomplete="off">
-                    <label class="btn btn-outline-danger btn-sm" for="@($"codexModeYolo{UniqueId}")" title="全自動実行（危険）。隔離環境推奨。">
-                        YOLO (危険)
+                    <label class="btn btn-outline-danger btn-sm" for="@($"codexModeYolo{UniqueId}")" title="@L["SessionOptions.Codex.Mode.YoloTitle"]">
+                        @L["SessionOptions.Codex.Mode.YoloLabel"]
                     </label>
                 </div>
                 @if (!string.IsNullOrWhiteSpace(GetCodexModeHelp()))
@@ -256,49 +258,49 @@
             {
                 <div class="alert alert-danger mt-2 py-2 small">
                     <i class="bi bi-exclamation-triangle-fill me-1"></i>
-                    <strong>警告:</strong> YOLOモードは隔離環境（WSL/Docker/VM/CI）でのみ使用してください。
+                    <strong>@L["SessionOptions.Codex.YoloWarning.Label"]</strong> @L["SessionOptions.Codex.YoloWarning.Message"]
                 </div>
             }
 
             <div class="form-check mt-3">
                 <input class="form-check-input" type="checkbox" @bind="CodexOptions.ResumeLast" id="@($"codexResumeLast{UniqueId}")">
                 <label class="form-check-label" for="@($"codexResumeLast{UniqueId}")">
-                    最新セッションを再開 (resume --last)
+                    @L["SessionOptions.Codex.ResumeLast"]
                 </label>
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">サンドボックスモード</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Sandbox.Label"]</label>
                 <div class="btn-group d-flex" role="group">
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxNone{UniqueId}")"
                            checked="@(string.IsNullOrEmpty(CodexOptions.SandboxMode))"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.Default)" autocomplete="off">
-                    <label class="btn btn-outline-secondary btn-sm" for="@($"codexSandboxNone{UniqueId}")" title="--sandbox を付けず、Codex CLI の既定値に任せます。">
-                        CLI既定
+                    <label class="btn btn-outline-secondary btn-sm" for="@($"codexSandboxNone{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.DefaultTitle"]">
+                        @L["SessionOptions.Codex.Sandbox.DefaultLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxReadOnly{UniqueId}")"
                            checked="@(CodexOptions.SandboxMode == "read-only")"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.ReadOnly)" autocomplete="off">
-                    <label class="btn btn-outline-success btn-sm" for="@($"codexSandboxReadOnly{UniqueId}")" title="読み取り専用。書き込みはブロック。">
-                        読み取り専用
+                    <label class="btn btn-outline-success btn-sm" for="@($"codexSandboxReadOnly{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.ReadOnlyTitle"]">
+                        @L["SessionOptions.Codex.Sandbox.ReadOnlyLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxWorkspace{UniqueId}")"
                            checked="@(CodexOptions.SandboxMode == "workspace-write")"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.WorkspaceWrite)" autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"codexSandboxWorkspace{UniqueId}")" title="ワークスペース内のみ書き込み可能。">
-                        ワークスペース (推奨)
+                    <label class="btn btn-outline-primary btn-sm" for="@($"codexSandboxWorkspace{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.WorkspaceTitle"]">
+                        @L["SessionOptions.Codex.Sandbox.WorkspaceLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxFull{UniqueId}")"
                            checked="@(CodexOptions.SandboxMode == "danger-full-access")"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.FullAccess)" autocomplete="off">
-                    <label class="btn btn-outline-danger btn-sm" for="@($"codexSandboxFull{UniqueId}")" title="フルアクセス（危険）。">
-                        フルアクセス
+                    <label class="btn btn-outline-danger btn-sm" for="@($"codexSandboxFull{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.FullAccessTitle"]">
+                        @L["SessionOptions.Codex.Sandbox.FullAccessLabel"]
                     </label>
                 </div>
-                <div class="form-text small">外部通信やファイルアクセス範囲を制限</div>
+                <div class="form-text small">@L["SessionOptions.Codex.Sandbox.Help"]</div>
                 @if (!string.IsNullOrWhiteSpace(GetSandboxModeHelp()))
                 {
                     <div class="form-text small">@GetSandboxModeHelp()</div>
@@ -306,14 +308,14 @@
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">承認ポリシー</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.ApprovalPolicy.Label"]</label>
                 <select class="form-select form-select-sm" @bind="CodexOptions.ApprovalPolicy">
-                    <option value="">未指定</option>
+                    <option value="">@L["SessionOptions.Codex.ApprovalPolicy.Unspecified"]</option>
                     <option value="untrusted">untrusted</option>
                     <option value="on-request">on-request</option>
                     <option value="never">never</option>
                 </select>
-                <div class="form-text small">操作の承認レベル（--ask-for-approval）</div>
+                <div class="form-text small">@L["SessionOptions.Codex.ApprovalPolicy.Help"]</div>
                 @if (!string.IsNullOrWhiteSpace(GetApprovalPolicyHelp()))
                 {
                     <div class="form-text small">@GetApprovalPolicyHelp()</div>
@@ -321,13 +323,13 @@
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">ネットワークアクセス</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.NetworkAccess.Label"]</label>
                 <select class="form-select form-select-sm" @bind="CodexOptions.NetworkAccess">
-                    <option value="">未指定</option>
+                    <option value="">@L["SessionOptions.Codex.ApprovalPolicy.Unspecified"]</option>
                     <option value="restricted">restricted</option>
                     <option value="enabled">enabled</option>
                 </select>
-                <div class="form-text small">workspace-write時の通信許可（-c sandbox_workspace_write.network_access）。デフォルトは enabled。</div>
+                <div class="form-text small">@L["SessionOptions.Codex.NetworkAccess.Help"]</div>
                 @if (!string.IsNullOrWhiteSpace(GetNetworkAccessHelp()))
                 {
                     <div class="form-text small">@GetNetworkAccessHelp()</div>
@@ -335,46 +337,46 @@
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">プロファイル</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Profile.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="CodexOptions.Profile"
-                       placeholder="例: trusted" />
-                <div class="form-text small">Codex CLI の `--profile` を指定します</div>
+                       placeholder="@L["SessionOptions.Codex.Profile.Placeholder"]" />
+                <div class="form-text small">@L["SessionOptions.Codex.Profile.Help"]</div>
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">モデル</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Model.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="CodexOptions.Model"
-                       placeholder="例: gpt-5-codex" />
-                <div class="form-text small">Codex CLI の `--model` を指定します</div>
+                       placeholder="@L["SessionOptions.Codex.Model.Placeholder"]" />
+                <div class="form-text small">@L["SessionOptions.Codex.Model.Help"]</div>
             </div>
 
             <div class="form-check mt-3">
                 <input class="form-check-input" type="checkbox" @bind="CodexOptions.SearchEnabled" id="@($"codexSearch{UniqueId}")">
                 <label class="form-check-label" for="@($"codexSearch{UniqueId}")">
-                    Web 検索を有効化 (--search)
+                    @L["SessionOptions.Codex.Search"]
                 </label>
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">追加ディレクトリ</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.AdditionalDirs.Label"]</label>
                 <textarea class="form-control form-control-sm" @bind="CodexOptions.AdditionalDirectories"
-                          rows="3" placeholder="1行に1ディレクトリずつ指定"></textarea>
-                <div class="form-text small">各行を `--add-dir` として渡します</div>
+                          rows="3" placeholder="@L["SessionOptions.Codex.AdditionalDirs.Placeholder"]"></textarea>
+                <div class="form-text small">@L["SessionOptions.Codex.AdditionalDirs.Help"]</div>
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">追加引数</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="CodexOptions.ExtraArgs"
-                       placeholder="例: --reasoning-effort high" />
-                <div class="form-text small">そのままCodex CLIに渡します</div>
+                       placeholder="@L["SessionOptions.Codex.ExtraArgsPlaceholder"]" />
+                <div class="form-text small">@L["SessionOptions.Codex.PassToCli"]</div>
             </div>
         </div>
     }
     else
     {
         <div class="mb-3">
-            <label class="form-label">起動コマンド（任意）</label>
-            <input type="text" class="form-control" @bind="StartupCommand" placeholder="例: cmd.exe, powershell.exe" />
+            <label class="form-label">@L["SessionOptions.Terminal.StartupCommand.Label"]</label>
+            <input type="text" class="form-control" @bind="StartupCommand" placeholder="@L["SessionOptions.Terminal.StartupCommand.Placeholder"]" />
         </div>
     }
 </div>
@@ -634,9 +636,9 @@
     {
         return ClaudeOptions.PermissionMode switch
         {
-            "bypass" => "全操作を無条件で自動承認します（--dangerously-skip-permissions）。",
-            "auto" => "低リスク操作を自動承認し、高リスク操作のみ確認を求めます（--enable-auto-mode）。",
-            "default" => "全ての操作で都度確認を求めます。",
+            "bypass" => L["SessionOptions.Claude.PermissionMode.HelpBypass"],
+            "auto" => L["SessionOptions.Claude.PermissionMode.HelpAuto"],
+            "default" => L["SessionOptions.Claude.PermissionMode.HelpDefault"],
             _ => ""
         };
     }
@@ -645,9 +647,9 @@
     {
         return GeminiOptions.ApprovalMode switch
         {
-            "default" => "ツール使用時に都度確認を求めます（デフォルト）。",
-            "auto_edit" => "ファイル編集など、安全な操作を自動で承認します。",
-            "yolo" => "全ての操作を警告なしで自動的に承認します（危険）。",
+            "default" => L["SessionOptions.Gemini.ApprovalMode.HelpDefault"],
+            "auto_edit" => L["SessionOptions.Gemini.ApprovalMode.HelpAutoEdit"],
+            "yolo" => L["SessionOptions.Gemini.ApprovalMode.HelpYolo"],
             _ => ""
         };
     }
@@ -656,9 +658,9 @@
     {
         return CodexOptions.ApprovalPolicy switch
         {
-            "untrusted" => "未信頼扱い。すべての操作で承認を求めます。",
-            "on-request" => "必要なときだけ承認を求めます（デフォルトに近い挙動）。",
-            "never" => "承認を求めません（危険）。",
+            "untrusted" => L["SessionOptions.Codex.ApprovalPolicy.HelpUntrusted"],
+            "on-request" => L["SessionOptions.Codex.ApprovalPolicy.HelpOnRequest"],
+            "never" => L["SessionOptions.Codex.ApprovalPolicy.HelpNever"],
             _ => ""
         };
     }
@@ -667,9 +669,9 @@
     {
         return CodexOptions.Mode switch
         {
-            "auto" => "推奨。`--full-auto` を付けて自動実行寄りに進めます。",
-            "standard" => "明示的な自動実行フラグを付けず、対話ベースで進行します。",
-            "yolo" => "全自動実行（危険）。隔離環境推奨です。",
+            "auto" => L["SessionOptions.Codex.Mode.HelpAuto"],
+            "standard" => L["SessionOptions.Codex.Mode.HelpStandard"],
+            "yolo" => L["SessionOptions.Codex.Mode.HelpYolo"],
             _ => ""
         };
     }
@@ -678,10 +680,10 @@
     {
         return CodexOptions.SandboxMode switch
         {
-            "" => "Codex CLI の既定値に任せます。",
-            "read-only" => "読み取り専用。書き込みはブロック。",
-            "workspace-write" => "ワークスペース内のみ書き込み可能。",
-            "danger-full-access" => "フルアクセス（危険）。",
+            "" => L["SessionOptions.Codex.Sandbox.HelpDefault"],
+            "read-only" => L["SessionOptions.Codex.Sandbox.ReadOnlyTitle"],
+            "workspace-write" => L["SessionOptions.Codex.Sandbox.WorkspaceTitle"],
+            "danger-full-access" => L["SessionOptions.Codex.Sandbox.FullAccessTitle"],
             _ => ""
         };
     }
@@ -690,8 +692,8 @@
     {
         return CodexOptions.NetworkAccess switch
         {
-            "enabled" => "ネットワークアクセスを許可します。",
-            "restricted" => "ネットワークアクセスを制限します。",
+            "enabled" => L["SessionOptions.Codex.NetworkAccess.HelpEnabled"],
+            "restricted" => L["SessionOptions.Codex.NetworkAccess.HelpRestricted"],
             _ => ""
         };
     }

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -310,7 +310,7 @@
             <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.ApprovalPolicy.Label"]</label>
                 <select class="form-select form-select-sm" @bind="CodexOptions.ApprovalPolicy">
-                    <option value="">@L["SessionOptions.Codex.ApprovalPolicy.Unspecified"]</option>
+                    <option value="">@L["Common.Unspecified"]</option>
                     <option value="untrusted">untrusted</option>
                     <option value="on-request">on-request</option>
                     <option value="never">never</option>
@@ -325,7 +325,7 @@
             <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.NetworkAccess.Label"]</label>
                 <select class="form-select form-select-sm" @bind="CodexOptions.NetworkAccess">
-                    <option value="">@L["SessionOptions.Codex.ApprovalPolicy.Unspecified"]</option>
+                    <option value="">@L["Common.Unspecified"]</option>
                     <option value="restricted">restricted</option>
                     <option value="enabled">enabled</option>
                 </select>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -60,6 +60,7 @@
   <data name="Common.Add" xml:space="preserve"><value>Add</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
   <data name="Common.Create" xml:space="preserve"><value>Create</value></data>
+  <data name="Common.Unspecified" xml:space="preserve"><value>Unspecified</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>Error: {0}</value></data>
 
   <!-- Settings Dialog -->
@@ -373,7 +374,6 @@
   <data name="SessionOptions.Codex.Sandbox.Help" xml:space="preserve"><value>Limits external communication and file access.</value></data>
   <data name="SessionOptions.Codex.Sandbox.HelpDefault" xml:space="preserve"><value>Uses the Codex CLI default.</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.Label" xml:space="preserve"><value>Approval policy</value></data>
-  <data name="SessionOptions.Codex.ApprovalPolicy.Unspecified" xml:space="preserve"><value>Unspecified</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.Help" xml:space="preserve"><value>Operation approval level (--ask-for-approval)</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>Treat as untrusted. Prompts for every operation.</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>Prompts only when needed (near-default behavior).</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -300,4 +300,98 @@
   <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>Create Folder</value></data>
   <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>Create this folder?</value></data>
   <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>Create</value></data>
+
+  <!-- SessionOptionsSelector: common -->
+  <data name="SessionOptions.TerminalType.Label" xml:space="preserve"><value>Terminal type</value></data>
+  <data name="SessionOptions.TerminalType.Terminal" xml:space="preserve"><value>Terminal</value></data>
+  <data name="SessionOptions.ExtraArgs.Label" xml:space="preserve"><value>Additional arguments</value></data>
+
+  <!-- SessionOptionsSelector: Terminal (default startup command) -->
+  <data name="SessionOptions.Terminal.StartupCommand.Label" xml:space="preserve"><value>Startup command (optional)</value></data>
+  <data name="SessionOptions.Terminal.StartupCommand.Placeholder" xml:space="preserve"><value>e.g., cmd.exe, powershell.exe</value></data>
+
+  <!-- SessionOptionsSelector: Claude Code -->
+  <data name="SessionOptions.Claude.Header" xml:space="preserve"><value>Claude Code Options</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.Label" xml:space="preserve"><value>Permission mode</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.BypassLabel" xml:space="preserve"><value>Bypass</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.BypassTitle" xml:space="preserve"><value>Auto-approves all operations unconditionally (dangerous)</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoLabel" xml:space="preserve"><value>Auto mode</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoTitle" xml:space="preserve"><value>Auto-approves low-risk operations and prompts only for high-risk ones</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.DefaultLabel" xml:space="preserve"><value>Default</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.DefaultTitle" xml:space="preserve"><value>Prompts for confirmation on every operation</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpBypass" xml:space="preserve"><value>Auto-approves all operations unconditionally (--dangerously-skip-permissions).</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpAuto" xml:space="preserve"><value>Auto-approves low-risk operations and prompts only for high-risk ones (--enable-auto-mode).</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpDefault" xml:space="preserve"><value>Prompts for confirmation on every operation.</value></data>
+  <data name="SessionOptions.Claude.Continue" xml:space="preserve"><value>Continue (--continue)</value></data>
+  <data name="SessionOptions.Claude.Chrome" xml:space="preserve"><value>Browser integration (--chrome)</value></data>
+  <data name="SessionOptions.Claude.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --model claude-sonnet-4-20250514 --verbose</value></data>
+  <data name="SessionOptions.Claude.PassToCli" xml:space="preserve"><value>Passed as-is to Claude Code</value></data>
+
+  <!-- SessionOptionsSelector: Gemini CLI -->
+  <data name="SessionOptions.Gemini.Header" xml:space="preserve"><value>Gemini CLI Options</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.Label" xml:space="preserve"><value>Approval mode</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.DefaultTitle" xml:space="preserve"><value>Prompts for confirmation on every tool use (default)</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.AutoEditTitle" xml:space="preserve"><value>Auto-approves safe operations like file edits</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.YoloTitle" xml:space="preserve"><value>Auto-approves all operations without warning (dangerous)</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpDefault" xml:space="preserve"><value>Prompts for confirmation on every tool use (default).</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpAutoEdit" xml:space="preserve"><value>Auto-approves safe operations like file edits.</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpYolo" xml:space="preserve"><value>Auto-approves all operations without warning (dangerous).</value></data>
+  <data name="SessionOptions.Gemini.Sandbox" xml:space="preserve"><value>Sandbox mode (-s)</value></data>
+  <data name="SessionOptions.Gemini.SandboxHelp" xml:space="preserve"><value>Docker Desktop must be installed to use this feature.</value></data>
+  <data name="SessionOptions.Gemini.Continue" xml:space="preserve"><value>Continue (--resume latest)</value></data>
+  <data name="SessionOptions.Gemini.UseCustomModel" xml:space="preserve"><value>Customize model</value></data>
+  <data name="SessionOptions.Gemini.ModelSelectLabel" xml:space="preserve"><value>Model to use</value></data>
+  <data name="SessionOptions.Gemini.ModelManagementLabel" xml:space="preserve"><value>Model list management</value></data>
+  <data name="SessionOptions.Gemini.ModelAddPlaceholder" xml:space="preserve"><value>Add a model name...</value></data>
+  <data name="SessionOptions.Gemini.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --debug --allowed-tools shell,file</value></data>
+  <data name="SessionOptions.Gemini.PassToCli" xml:space="preserve"><value>Passed as-is to Gemini CLI</value></data>
+
+  <!-- SessionOptionsSelector: Codex CLI -->
+  <data name="SessionOptions.Codex.Header" xml:space="preserve"><value>Codex CLI Options</value></data>
+  <data name="SessionOptions.Codex.Mode.Label" xml:space="preserve"><value>Execution mode</value></data>
+  <data name="SessionOptions.Codex.Mode.AutoLabel" xml:space="preserve"><value>Auto (recommended)</value></data>
+  <data name="SessionOptions.Codex.Mode.AutoTitle" xml:space="preserve"><value>Mostly automates edits, builds, and tests</value></data>
+  <data name="SessionOptions.Codex.Mode.StandardLabel" xml:space="preserve"><value>Interactive</value></data>
+  <data name="SessionOptions.Codex.Mode.StandardTitle" xml:space="preserve"><value>No explicit auto-run flags; proceeds interactively</value></data>
+  <data name="SessionOptions.Codex.Mode.YoloLabel" xml:space="preserve"><value>YOLO (dangerous)</value></data>
+  <data name="SessionOptions.Codex.Mode.YoloTitle" xml:space="preserve"><value>Fully automatic execution (dangerous). Isolated environment recommended.</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpAuto" xml:space="preserve"><value>Recommended. Adds `--full-auto` for mostly automatic execution.</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpStandard" xml:space="preserve"><value>No explicit auto-run flags; proceeds interactively.</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpYolo" xml:space="preserve"><value>Fully automatic execution (dangerous). Isolated environment recommended.</value></data>
+  <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>Warning:</value></data>
+  <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO mode should only be used in isolated environments (WSL/Docker/VM/CI).</value></data>
+  <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>Resume last session (resume --last)</value></data>
+  <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>Sandbox mode</value></data>
+  <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI default</value></data>
+  <data name="SessionOptions.Codex.Sandbox.DefaultTitle" xml:space="preserve"><value>Do not add --sandbox; use the Codex CLI default.</value></data>
+  <data name="SessionOptions.Codex.Sandbox.ReadOnlyLabel" xml:space="preserve"><value>Read-only</value></data>
+  <data name="SessionOptions.Codex.Sandbox.ReadOnlyTitle" xml:space="preserve"><value>Read-only. Writes are blocked.</value></data>
+  <data name="SessionOptions.Codex.Sandbox.WorkspaceLabel" xml:space="preserve"><value>Workspace (recommended)</value></data>
+  <data name="SessionOptions.Codex.Sandbox.WorkspaceTitle" xml:space="preserve"><value>Writable only within the workspace.</value></data>
+  <data name="SessionOptions.Codex.Sandbox.FullAccessLabel" xml:space="preserve"><value>Full access</value></data>
+  <data name="SessionOptions.Codex.Sandbox.FullAccessTitle" xml:space="preserve"><value>Full access (dangerous).</value></data>
+  <data name="SessionOptions.Codex.Sandbox.Help" xml:space="preserve"><value>Limits external communication and file access.</value></data>
+  <data name="SessionOptions.Codex.Sandbox.HelpDefault" xml:space="preserve"><value>Uses the Codex CLI default.</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Label" xml:space="preserve"><value>Approval policy</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Unspecified" xml:space="preserve"><value>Unspecified</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Help" xml:space="preserve"><value>Operation approval level (--ask-for-approval)</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>Treat as untrusted. Prompts for every operation.</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>Prompts only when needed (near-default behavior).</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpNever" xml:space="preserve"><value>Never prompts (dangerous).</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.Label" xml:space="preserve"><value>Network access</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.Help" xml:space="preserve"><value>Network permission for workspace-write (-c sandbox_workspace_write.network_access). Default is enabled.</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.HelpEnabled" xml:space="preserve"><value>Allows network access.</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.HelpRestricted" xml:space="preserve"><value>Restricts network access.</value></data>
+  <data name="SessionOptions.Codex.Profile.Label" xml:space="preserve"><value>Profile</value></data>
+  <data name="SessionOptions.Codex.Profile.Placeholder" xml:space="preserve"><value>e.g., trusted</value></data>
+  <data name="SessionOptions.Codex.Profile.Help" xml:space="preserve"><value>Specifies --profile for Codex CLI</value></data>
+  <data name="SessionOptions.Codex.Model.Label" xml:space="preserve"><value>Model</value></data>
+  <data name="SessionOptions.Codex.Model.Placeholder" xml:space="preserve"><value>e.g., gpt-5-codex</value></data>
+  <data name="SessionOptions.Codex.Model.Help" xml:space="preserve"><value>Specifies --model for Codex CLI</value></data>
+  <data name="SessionOptions.Codex.Search" xml:space="preserve"><value>Enable web search (--search)</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Label" xml:space="preserve"><value>Additional directories</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Placeholder" xml:space="preserve"><value>One directory per line</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Help" xml:space="preserve"><value>Each line is passed as --add-dir</value></data>
+  <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --reasoning-effort high</value></data>
+  <data name="SessionOptions.Codex.PassToCli" xml:space="preserve"><value>Passed as-is to Codex CLI</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -300,4 +300,98 @@
   <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>フォルダの作成</value></data>
   <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>このフォルダを作成しますか？</value></data>
   <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>作成する</value></data>
+
+  <!-- SessionOptionsSelector: common -->
+  <data name="SessionOptions.TerminalType.Label" xml:space="preserve"><value>ターミナルタイプ</value></data>
+  <data name="SessionOptions.TerminalType.Terminal" xml:space="preserve"><value>ターミナル</value></data>
+  <data name="SessionOptions.ExtraArgs.Label" xml:space="preserve"><value>追加引数</value></data>
+
+  <!-- SessionOptionsSelector: Terminal (default startup command) -->
+  <data name="SessionOptions.Terminal.StartupCommand.Label" xml:space="preserve"><value>起動コマンド（任意）</value></data>
+  <data name="SessionOptions.Terminal.StartupCommand.Placeholder" xml:space="preserve"><value>例: cmd.exe, powershell.exe</value></data>
+
+  <!-- SessionOptionsSelector: Claude Code -->
+  <data name="SessionOptions.Claude.Header" xml:space="preserve"><value>Claude Code オプション</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.Label" xml:space="preserve"><value>権限モード</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.BypassLabel" xml:space="preserve"><value>バイパス</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.BypassTitle" xml:space="preserve"><value>全操作を無条件で自動承認します（危険）</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoLabel" xml:space="preserve"><value>オートモード</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoTitle" xml:space="preserve"><value>低リスク操作を自動承認し、高リスク操作のみ確認を求めます</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.DefaultLabel" xml:space="preserve"><value>デフォルト</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.DefaultTitle" xml:space="preserve"><value>全ての操作で都度確認を求めます</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpBypass" xml:space="preserve"><value>全操作を無条件で自動承認します（--dangerously-skip-permissions）。</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpAuto" xml:space="preserve"><value>低リスク操作を自動承認し、高リスク操作のみ確認を求めます（--enable-auto-mode）。</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpDefault" xml:space="preserve"><value>全ての操作で都度確認を求めます。</value></data>
+  <data name="SessionOptions.Claude.Continue" xml:space="preserve"><value>コンティニュー (--continue)</value></data>
+  <data name="SessionOptions.Claude.Chrome" xml:space="preserve"><value>ブラウザ連携 (--chrome)</value></data>
+  <data name="SessionOptions.Claude.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --model claude-sonnet-4-20250514 --verbose</value></data>
+  <data name="SessionOptions.Claude.PassToCli" xml:space="preserve"><value>そのまま Claude Code に渡します</value></data>
+
+  <!-- SessionOptionsSelector: Gemini CLI -->
+  <data name="SessionOptions.Gemini.Header" xml:space="preserve"><value>Gemini CLI オプション</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.Label" xml:space="preserve"><value>承認モード</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.DefaultTitle" xml:space="preserve"><value>ツール使用時に都度確認を求めます（デフォルト）</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.AutoEditTitle" xml:space="preserve"><value>ファイル編集など、安全な操作を自動で承認します</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.YoloTitle" xml:space="preserve"><value>全ての操作を警告なしで自動的に承認します（危険）</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpDefault" xml:space="preserve"><value>ツール使用時に都度確認を求めます（デフォルト）。</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpAutoEdit" xml:space="preserve"><value>ファイル編集など、安全な操作を自動で承認します。</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpYolo" xml:space="preserve"><value>全ての操作を警告なしで自動的に承認します（危険）。</value></data>
+  <data name="SessionOptions.Gemini.Sandbox" xml:space="preserve"><value>サンドボックスモード (-s)</value></data>
+  <data name="SessionOptions.Gemini.SandboxHelp" xml:space="preserve"><value>この機能を使用するには、Docker Desktop がインストールされている必要があります。</value></data>
+  <data name="SessionOptions.Gemini.Continue" xml:space="preserve"><value>コンティニュー (--resume latest)</value></data>
+  <data name="SessionOptions.Gemini.UseCustomModel" xml:space="preserve"><value>モデルをカスタマイズ</value></data>
+  <data name="SessionOptions.Gemini.ModelSelectLabel" xml:space="preserve"><value>使用するモデル</value></data>
+  <data name="SessionOptions.Gemini.ModelManagementLabel" xml:space="preserve"><value>モデルリスト管理</value></data>
+  <data name="SessionOptions.Gemini.ModelAddPlaceholder" xml:space="preserve"><value>モデル名を追加...</value></data>
+  <data name="SessionOptions.Gemini.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --debug --allowed-tools shell,file</value></data>
+  <data name="SessionOptions.Gemini.PassToCli" xml:space="preserve"><value>そのまま Gemini CLI に渡します</value></data>
+
+  <!-- SessionOptionsSelector: Codex CLI -->
+  <data name="SessionOptions.Codex.Header" xml:space="preserve"><value>Codex CLI オプション</value></data>
+  <data name="SessionOptions.Codex.Mode.Label" xml:space="preserve"><value>実行モード</value></data>
+  <data name="SessionOptions.Codex.Mode.AutoLabel" xml:space="preserve"><value>Auto (推奨)</value></data>
+  <data name="SessionOptions.Codex.Mode.AutoTitle" xml:space="preserve"><value>編集＋ビルド/テスト等を基本自動化</value></data>
+  <data name="SessionOptions.Codex.Mode.StandardLabel" xml:space="preserve"><value>Interactive</value></data>
+  <data name="SessionOptions.Codex.Mode.StandardTitle" xml:space="preserve"><value>明示的な自動実行フラグを付けず、対話ベースで進行します</value></data>
+  <data name="SessionOptions.Codex.Mode.YoloLabel" xml:space="preserve"><value>YOLO (危険)</value></data>
+  <data name="SessionOptions.Codex.Mode.YoloTitle" xml:space="preserve"><value>全自動実行（危険）。隔離環境推奨。</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpAuto" xml:space="preserve"><value>推奨。`--full-auto` を付けて自動実行寄りに進めます。</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpStandard" xml:space="preserve"><value>明示的な自動実行フラグを付けず、対話ベースで進行します。</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpYolo" xml:space="preserve"><value>全自動実行（危険）。隔離環境推奨です。</value></data>
+  <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>警告:</value></data>
+  <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO モードは隔離環境（WSL/Docker/VM/CI）でのみ使用してください。</value></data>
+  <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>最新セッションを再開 (resume --last)</value></data>
+  <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>サンドボックスモード</value></data>
+  <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI 既定</value></data>
+  <data name="SessionOptions.Codex.Sandbox.DefaultTitle" xml:space="preserve"><value>--sandbox を付けず、Codex CLI の既定値に任せます。</value></data>
+  <data name="SessionOptions.Codex.Sandbox.ReadOnlyLabel" xml:space="preserve"><value>読み取り専用</value></data>
+  <data name="SessionOptions.Codex.Sandbox.ReadOnlyTitle" xml:space="preserve"><value>読み取り専用。書き込みはブロック。</value></data>
+  <data name="SessionOptions.Codex.Sandbox.WorkspaceLabel" xml:space="preserve"><value>ワークスペース (推奨)</value></data>
+  <data name="SessionOptions.Codex.Sandbox.WorkspaceTitle" xml:space="preserve"><value>ワークスペース内のみ書き込み可能。</value></data>
+  <data name="SessionOptions.Codex.Sandbox.FullAccessLabel" xml:space="preserve"><value>フルアクセス</value></data>
+  <data name="SessionOptions.Codex.Sandbox.FullAccessTitle" xml:space="preserve"><value>フルアクセス（危険）。</value></data>
+  <data name="SessionOptions.Codex.Sandbox.Help" xml:space="preserve"><value>外部通信やファイルアクセス範囲を制限</value></data>
+  <data name="SessionOptions.Codex.Sandbox.HelpDefault" xml:space="preserve"><value>Codex CLI の既定値に任せます。</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Label" xml:space="preserve"><value>承認ポリシー</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Unspecified" xml:space="preserve"><value>未指定</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Help" xml:space="preserve"><value>操作の承認レベル（--ask-for-approval）</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>未信頼扱い。すべての操作で承認を求めます。</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>必要なときだけ承認を求めます（デフォルトに近い挙動）。</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpNever" xml:space="preserve"><value>承認を求めません（危険）。</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.Label" xml:space="preserve"><value>ネットワークアクセス</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.Help" xml:space="preserve"><value>workspace-write 時の通信許可（-c sandbox_workspace_write.network_access）。デフォルトは enabled。</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.HelpEnabled" xml:space="preserve"><value>ネットワークアクセスを許可します。</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.HelpRestricted" xml:space="preserve"><value>ネットワークアクセスを制限します。</value></data>
+  <data name="SessionOptions.Codex.Profile.Label" xml:space="preserve"><value>プロファイル</value></data>
+  <data name="SessionOptions.Codex.Profile.Placeholder" xml:space="preserve"><value>例: trusted</value></data>
+  <data name="SessionOptions.Codex.Profile.Help" xml:space="preserve"><value>Codex CLI の `--profile` を指定します</value></data>
+  <data name="SessionOptions.Codex.Model.Label" xml:space="preserve"><value>モデル</value></data>
+  <data name="SessionOptions.Codex.Model.Placeholder" xml:space="preserve"><value>例: gpt-5-codex</value></data>
+  <data name="SessionOptions.Codex.Model.Help" xml:space="preserve"><value>Codex CLI の `--model` を指定します</value></data>
+  <data name="SessionOptions.Codex.Search" xml:space="preserve"><value>Web 検索を有効化 (--search)</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Label" xml:space="preserve"><value>追加ディレクトリ</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Placeholder" xml:space="preserve"><value>1 行に 1 ディレクトリずつ指定</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Help" xml:space="preserve"><value>各行を `--add-dir` として渡します</value></data>
+  <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --reasoning-effort high</value></data>
+  <data name="SessionOptions.Codex.PassToCli" xml:space="preserve"><value>そのまま Codex CLI に渡します</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -60,6 +60,7 @@
   <data name="Common.Add" xml:space="preserve"><value>追加</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>キャンセル</value></data>
   <data name="Common.Create" xml:space="preserve"><value>作成</value></data>
+  <data name="Common.Unspecified" xml:space="preserve"><value>未指定</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>エラー: {0}</value></data>
 
   <!-- Settings Dialog -->
@@ -131,7 +132,7 @@
   <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>Webhook 設定</value></data>
   <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>Webhook 通知を有効にする</value></data>
   <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>Webhook URL</value></data>
-  <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>Claude Code Hook設定</value></data>
+  <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>Claude Code Hook 設定</value></data>
   <data name="Settings.Notifications.ClaudeHook.HelpHtml" xml:space="preserve"><value>Claude Code の hook 機能を使用して、より確実に通知を受け取ることができます。セッション作成時に自動的に &lt;code&gt;.claude/settings.local.json&lt;/code&gt; に設定が追加されます。</value></data>
   <data name="Settings.Notifications.ClaudeHook.Enable" xml:space="preserve"><value>Claude Code Hook を有効にする</value></data>
   <data name="Settings.Notifications.ClaudeHook.ApplyNoticeHtml" xml:space="preserve"><value>この設定は各セッションが次に起動／再起動されたタイミングで &lt;code&gt;.claude/settings.local.json&lt;/code&gt; に反映されます。既に起動中のセッションや、TerminalHub 管理外のワークスペースには即時適用されません。</value></data>
@@ -373,7 +374,6 @@
   <data name="SessionOptions.Codex.Sandbox.Help" xml:space="preserve"><value>外部通信やファイルアクセス範囲を制限</value></data>
   <data name="SessionOptions.Codex.Sandbox.HelpDefault" xml:space="preserve"><value>Codex CLI の既定値に任せます。</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.Label" xml:space="preserve"><value>承認ポリシー</value></data>
-  <data name="SessionOptions.Codex.ApprovalPolicy.Unspecified" xml:space="preserve"><value>未指定</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.Help" xml:space="preserve"><value>操作の承認レベル（--ask-for-approval）</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>未信頼扱い。すべての操作で承認を求めます。</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>必要なときだけ承認を求めます（デフォルトに近い挙動）。</value></data>


### PR DESCRIPTION
## Summary
Phase 2C-1b として shared コンポーネント **`SessionOptionsSelector`** (698 行、94 ja lines) を localize。PR #44 (SessionCreateDialog shell) と合わせて、新規セッション作成フローが英日両言語で完成。

## 規模
- ~70 キー追加 (Phase 2 シリーズで最大)
- +280/-90 行、3 ファイル

## 追加キー

### Common
- **`SessionOptions.TerminalType.{Label,Terminal}`**: ターミナルタイプ選択
- **`SessionOptions.ExtraArgs.Label`**: 全 CLI で再利用する「追加引数」(3 箇所で共通化)

### Claude Code (~15 キー)
- `PermissionMode.*`: Bypass/Auto/Default の 3 モード × (Label + Title + Help) + ラベル
- `Continue` / `Chrome` / `ExtraArgsPlaceholder` / `PassToCli`

### Gemini CLI (~17 キー)
- `ApprovalMode.*`: Default/AutoEdit/Yolo × (Title + Help) + ラベル
- `Sandbox` / `SandboxHelp` / `Continue` / `UseCustomModel`
- モデル管理: `ModelSelectLabel` / `ModelManagementLabel` / `ModelAddPlaceholder`

### Codex CLI (~35 キー、最大)
- `Mode.*`: Auto/Standard/Yolo × (Label + Title + Help)
- `YoloWarning.{Label,Message}`
- `Sandbox.*`: 4 モード × (Label + Title) + 共通 Help + HelpDefault
- `ApprovalPolicy.*`: Label + Unspecified + Help + 3 状態別 Help
- `NetworkAccess.*`: Label + Help + 2 状態別 Help
- `Profile.{Label,Placeholder,Help}` / `Model.{Label,Placeholder,Help}`
- `Search` / `AdditionalDirs.{Label,Placeholder,Help}` / `ExtraArgsPlaceholder`

## Code-behind

6 つの `GetXxxHelp()` メソッドの switch 文内の日本語リテラルを `L[...]` 参照に置換:
- `GetPermissionModeHelp` (Claude)
- `GetGeminiApprovalModeHelp`
- `GetApprovalPolicyHelp` (Codex)
- `GetCodexModeHelp`
- `GetSandboxModeHelp`
- `GetNetworkAccessHelp`

## 動作確認済み
- [x] C# コンパイル成功 (obj/ DLL 更新)

## 検証手順 (マージ前)
- [ ] dev 再起動 → 「New Session」ダイアログを開く
- [ ] ターミナルタイプ選択ボタンが culture 連動 (Terminal / Claude Code / Gemini CLI / Codex CLI)
- [ ] 各 CLI を選択 → 固有のオプション UI が英日切替で表示
- [ ] 特に Codex CLI は項目数が多いので全項目確認:
  - Mode (Auto/Interactive/YOLO)、YOLO 警告メッセージ
  - Sandbox 4 モード、ApprovalPolicy、NetworkAccess
  - Profile、Model、Search、AdditionalDirs、ExtraArgs
- [ ] Claude の PermissionMode / Gemini の ApprovalMode → モード切替で runtime Help 文が更新
- [ ] 連鎖効果: SubSessionDialog もこの component を使うので、次回 SubSessionDialog を開いたときに options 部分が自動で多言語化されている (shell は日本語のまま)

## 効果

本 PR マージ後、**新規セッション作成フロー全体が英日両言語で完成**:

| 箇所 | 状態 |
|---|---|
| ダイアログ shell (タイトル・フォルダ・Cancel/Create) | ✅ (PR #44) |
| ターミナルタイプ + 各 CLI オプション | ✅ 本 PR |
| SubSessionDialog の options 部分 | ✅ 自動波及 |

## Phase 2C 残り
- 2C-2: SessionSettingsDialog + SubSessionDialog shell
- 2C-3: SessionList + ArchivedSessionsDialog
- 2C-4: BottomPanels
- 2C-5: Root.razor (最大)

🤖 Generated with [Claude Code](https://claude.com/claude-code)