### PR TITLE
feat: セッション設定 + サブセッションダイアログを多言語対応 (Phase 2C-2)

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -1,5 +1,6 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
+@using Microsoft.Extensions.Localization
 @using Microsoft.JSInterop
 @using System.Diagnostics
 @using System.IO
@@ -7,13 +8,14 @@
 @inject IJSRuntime JSRuntime
 @inject ILogger<SessionSettingsDialog> Logger
 @inject ISessionMemoRepository MemoRepository
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
     <div class="modal-dialog modal-dialog-centered modal-lg">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">
-                    <i class="bi bi-gear me-2"></i>セッション設定
+                    <i class="bi bi-gear me-2"></i>@L["SessionSettings.Title"]
                 </h5>
                 <button type="button" class="btn-close" @onclick="OnCancel"></button>
             </div>
@@ -21,24 +23,24 @@
                 @if (sessionInfo != null)
                 {
                     <div class="mb-3">
-                        <h6 class="text-muted">セッション情報</h6>
+                        <h6 class="text-muted">@L["SessionSettings.Info.Header"]</h6>
                         <div class="row">
                             <div class="col-md-6">
-                                <small class="text-muted">セッション名:</small><br/>
+                                <small class="text-muted">@L["SessionSettings.Info.SessionName"]</small><br/>
                                 <strong>@sessionInfo.GetDisplayName()</strong>
                             </div>
                             <div class="col-md-6">
-                                <small class="text-muted">フォルダ:</small><br/>
+                                <small class="text-muted">@L["SessionSettings.Info.Folder"]</small><br/>
                                 <div class="d-flex align-items-start">
                                     <code class="flex-grow-1 me-2 text-break" style="word-wrap: break-word; overflow-wrap: break-word;">@sessionInfo.FolderPath</code>
                                     <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
                                             @onclick="() => CopyToClipboard(sessionInfo.FolderPath)"
-                                            title="フォルダパスをコピー">
+                                            title="@L["SessionSettings.Info.CopyFolderPath"]">
                                         <i class="bi bi-clipboard"></i>
                                     </button>
                                     <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0 ms-1"
                                             @onclick="() => OpenFolder(sessionInfo.FolderPath)"
-                                            title="フォルダを開く">
+                                            title="@L["SessionSettings.Info.OpenFolder"]">
                                         <i class="bi bi-folder2-open"></i>
                                     </button>
                                 </div>
@@ -46,12 +48,12 @@
                         </div>
                         <div class="row mt-2">
                             <div class="col-12">
-                                <small class="text-muted">セッションID:</small>
+                                <small class="text-muted">@L["SessionSettings.Info.SessionId"]</small>
                                 <div class="d-flex align-items-center">
                                     <code class="text-muted small">@sessionInfo.SessionId</code>
-                                    <button type="button" class="btn btn-link btn-sm text-muted ms-2" 
-                                            @onclick="() => CopyToClipboard(sessionInfo.SessionId.ToString())" 
-                                            title="セッションIDをコピー">
+                                    <button type="button" class="btn btn-link btn-sm text-muted ms-2"
+                                            @onclick="() => CopyToClipboard(sessionInfo.SessionId.ToString())"
+                                            title="@L["SessionSettings.Info.CopySessionId"]">
                                         <i class="bi bi-clipboard small"></i>
                                     </button>
                                 </div>
@@ -65,13 +67,13 @@
                             @if (!sessionInfo.ParentSessionId.HasValue)
                             {
                                 <button type="button" class="btn btn-outline-success btn-sm" @onclick="HandleCreateSubSession">
-                                    <i class="bi bi-plus-circle me-1"></i>サブセッションを作成
+                                    <i class="bi bi-plus-circle me-1"></i>@L["SessionSettings.CreateSubSession"]
                                 </button>
                             }
                             @if (anyMemoExists)
                             {
                                 <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="OpenMemoManagement">
-                                    <i class="bi bi-journal-text me-1"></i>メモ管理
+                                    <i class="bi bi-journal-text me-1"></i>@L["SessionSettings.OpenMemoManagement"]
                                 </button>
                             }
                         </div>
@@ -81,10 +83,10 @@
 
                     <!-- セッション名の変更 -->
                     <div class="mb-3">
-                        <label class="form-label">表示名</label>
-                        <input type="text" class="form-control" @bind="displayName" placeholder="セッションの表示名" />
+                        <label class="form-label">@L["SessionSettings.DisplayName.Label"]</label>
+                        <input type="text" class="form-control" @bind="displayName" placeholder="@L["SessionSettings.DisplayName.Placeholder"]" />
                         <small class="form-text text-muted">
-                            空白の場合はフォルダ名が使用されます
+                            @L["SessionSettings.DisplayName.Help"]
                         </small>
                     </div>
 
@@ -95,13 +97,13 @@
                             <div class="form-check d-inline-block">
                                 <input class="form-check-input" type="checkbox" @bind="isPinned" id="isPinnedCheck">
                                 <label class="form-check-label" for="isPinnedCheck">
-                                    <i class="bi bi-pin-fill me-1"></i>セッションをピン留め
+                                    <i class="bi bi-pin-fill me-1"></i>@L["SessionSettings.Pin.Label"]
                                 </label>
                             </div>
                             @if (isPinned)
                             {
                                 <div class="d-inline-block ms-3">
-                                    <label class="form-label mb-0 me-1 small">優先度:</label>
+                                    <label class="form-label mb-0 me-1 small">@L["SessionSettings.Pin.PriorityLabel"]</label>
                                     <input type="number" class="form-control form-control-sm d-inline-block" style="width: 80px;"
                                            @bind="pinPriority" placeholder="--" />
                                 </div>
@@ -111,10 +113,10 @@
 
                     <!-- メモ -->
                     <div class="mb-3">
-                        <label class="form-label">メモ</label>
-                        <textarea class="form-control" @bind="memo" placeholder="セッションに関するメモ" rows="3"></textarea>
+                        <label class="form-label">@L["SessionSettings.Memo.Label"]</label>
+                        <textarea class="form-control" @bind="memo" placeholder="@L["SessionSettings.Memo.Placeholder"]" rows="3"></textarea>
                         <small class="form-text text-muted">
-                            このセッションに関する任意のメモを記入できます
+                            @L["SessionSettings.Memo.Help"]
                         </small>
                     </div>
 
@@ -134,7 +136,7 @@
                 {
                     <div class="text-center">
                         <span class="spinner-border spinner-border-sm" role="status"></span>
-                        セッション情報を読み込み中...
+                        @L["SessionSettings.Loading"]
                     </div>
                 }
             </div>
@@ -142,14 +144,14 @@
                 <div class="form-check me-auto">
                     <input class="form-check-input" type="checkbox" @bind="restartSession" id="restartSessionCheck">
                     <label class="form-check-label" for="restartSessionCheck">
-                        変更を即座に適用（セッションを再起動）
+                        @L["SessionSettings.RestartOnSave"]
                     </label>
                 </div>
                 <button type="button" class="btn btn-secondary" @onclick="OnCancel">
-                    キャンセル
+                    @L["Common.Cancel"]
                 </button>
                 <button type="button" class="btn btn-primary" @onclick="SaveSettings" disabled="@(sessionInfo == null)">
-                    <i class="bi bi-check-circle me-2"></i>保存
+                    <i class="bi bi-check-circle me-2"></i>@L["SessionSettings.Save"]
                 </button>
             </div>
         </div>
@@ -332,7 +334,7 @@
                 var success = await SessionManager.RestartSessionAsync(SessionId.Value);
                 if (!success)
                 {
-                    errorMessage = "設定は保存されましたが、セッションの再起動に失敗しました。";
+                    errorMessage = L["SessionSettings.RestartFailed"];
                 }
             }
 
@@ -344,7 +346,7 @@
         }
         catch (Exception ex)
         {
-            errorMessage = $"設定の保存に失敗しました: {ex.Message}";
+            errorMessage = string.Format(L["SessionSettings.SaveErrorFormat"], ex.Message);
         }
     }
 

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -193,7 +193,7 @@
                                                 (@worktree.BranchName)
                                                 @if (worktree.IsMain)
                                                 {
-                                                    <text> - @L["SubSession.WorktreeMainSuffix"]</text>
+                                                    <text> @L["SubSession.WorktreeMainSuffix"]</text>
                                                 }
                                             </option>
                                         }

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -1,13 +1,15 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
+@using Microsoft.Extensions.Localization
 @inject IGitService GitService
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
     <div class="modal-dialog modal-dialog-centered modal-lg">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">
-                    <i class="bi bi-diagram-3 me-2"></i>サブセッション作成
+                    <i class="bi bi-diagram-3 me-2"></i>@L["SubSession.Title"]
                 </h5>
                 <button type="button" class="btn-close" @onclick="OnCancel"></button>
             </div>
@@ -15,37 +17,37 @@
                 @if (!string.IsNullOrEmpty(ParentSessionName))
                 {
                     <div class="mb-3">
-                        <small class="text-muted">親セッション: @ParentSessionName</small>
+                        <small class="text-muted">@string.Format(L["SubSession.ParentSessionFormat"], ParentSessionName)</small>
                     </div>
                 }
-                
+
                 <!-- タブナビゲーション -->
                 <ul class="nav nav-tabs mb-3">
                     @if (IsGitRepository)
                     {
                         <li class="nav-item">
-                            <button class="nav-link @(activeTab == TabType.Create ? "active" : "")" 
+                            <button class="nav-link @(activeTab == TabType.Create ? "active" : "")"
                                     @onclick="@(() => activeTab = TabType.Create)">
-                                <i class="bi bi-plus-circle me-1"></i>Worktree新規作成
+                                <i class="bi bi-plus-circle me-1"></i>@L["SubSession.Tab.CreateWorktree"]
                             </button>
                         </li>
                         <li class="nav-item">
-                            <button class="nav-link @(activeTab == TabType.Existing ? "active" : "")" 
+                            <button class="nav-link @(activeTab == TabType.Existing ? "active" : "")"
                                     @onclick="@(() => activeTab = TabType.Existing)">
-                                <i class="bi bi-folder-plus me-1"></i>既存Worktree追加
+                                <i class="bi bi-folder-plus me-1"></i>@L["SubSession.Tab.ExistingWorktree"]
                             </button>
                         </li>
                     }
                     <li class="nav-item">
-                        <button class="nav-link @(activeTab == TabType.SamePath ? "active" : "")" 
+                        <button class="nav-link @(activeTab == TabType.SamePath ? "active" : "")"
                                 @onclick="@(() => activeTab = TabType.SamePath)">
-                            <i class="bi bi-folder me-1"></i>同じフォルダで開く
+                            <i class="bi bi-folder me-1"></i>@L["SubSession.Tab.SamePath"]
                         </button>
                     </li>
                     <li class="nav-item">
-                        <button class="nav-link @(activeTab == TabType.NewFolder ? "active" : "")" 
+                        <button class="nav-link @(activeTab == TabType.NewFolder ? "active" : "")"
                                 @onclick="@(() => activeTab = TabType.NewFolder)">
-                            <i class="bi bi-folder-plus me-1"></i>新しいフォルダで開く
+                            <i class="bi bi-folder-plus me-1"></i>@L["SubSession.Tab.NewFolder"]
                         </button>
                     </li>
                 </ul>
@@ -60,64 +62,64 @@
                             {
                                 <div class="alert alert-warning">
                                     <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                                    <strong>Git管理が必要です</strong><br/>
-                                    Worktreeの作成にはGitリポジトリが必要です。
+                                    <strong>@L["SubSession.GitRequired.Title"]</strong><br/>
+                                    @L["SubSession.GitRequired.CreateWorktree"]
                                 </div>
                             }
                             else
                             {
                             <div class="mb-3">
-                                <label class="form-label">ブランチ選択方法</label>
+                                <label class="form-label">@L["SubSession.BranchSelection.Label"]</label>
                                 <div class="btn-group d-flex mb-2" role="group">
-                                    <input type="radio" class="btn-check" name="branchOption" id="newBranch" 
+                                    <input type="radio" class="btn-check" name="branchOption" id="newBranch"
                                            checked="@(branchSelectionMode == BranchSelectionMode.NewBranch)"
                                            @onclick="@(() => branchSelectionMode = BranchSelectionMode.NewBranch)">
-                                    <label class="btn btn-outline-secondary" for="newBranch">新規ブランチ</label>
-                                    
-                                    <input type="radio" class="btn-check" name="branchOption" id="existingBranch" 
+                                    <label class="btn btn-outline-secondary" for="newBranch">@L["SubSession.BranchSelection.New"]</label>
+
+                                    <input type="radio" class="btn-check" name="branchOption" id="existingBranch"
                                            checked="@(branchSelectionMode == BranchSelectionMode.ExistingBranch)"
                                            @onclick="@(() => branchSelectionMode = BranchSelectionMode.ExistingBranch)">
-                                    <label class="btn btn-outline-secondary" for="existingBranch">既存ブランチ</label>
+                                    <label class="btn btn-outline-secondary" for="existingBranch">@L["SubSession.BranchSelection.Existing"]</label>
                                 </div>
                             </div>
-                            
+
                             @if (branchSelectionMode == BranchSelectionMode.NewBranch)
                             {
                                 <div class="mb-3">
-                                    <label for="branchName" class="form-label">新しいブランチ名</label>
-                                    <input type="text" class="form-control" id="branchName" 
-                                           @bind="branchName" 
+                                    <label for="branchName" class="form-label">@L["SubSession.NewBranch.Label"]</label>
+                                    <input type="text" class="form-control" id="branchName"
+                                           @bind="branchName"
                                            @bind:event="oninput"
                                            @onkeydown="OnKeyDown"
-                                           placeholder="feature/new-feature" 
+                                           placeholder="feature/new-feature"
                                            autofocus>
                                     <small class="form-text text-muted">
-                                        このブランチ名で新しいWorktreeが作成されます
+                                        @L["SubSession.NewBranch.Help"]
                                     </small>
                                 </div>
                             }
                             else
                             {
                                 <div class="mb-3">
-                                    <label for="existingBranchSelect" class="form-label">既存のブランチを選択</label>
+                                    <label for="existingBranchSelect" class="form-label">@L["SubSession.ExistingBranch.Label"]</label>
                                     @if (availableBranches == null)
                                     {
                                         <div class="text-center">
                                             <span class="spinner-border spinner-border-sm" role="status"></span>
-                                            ブランチ一覧を読み込み中...
+                                            @L["SubSession.ExistingBranch.Loading"]
                                         </div>
                                     }
                                     else if (availableBranches.Count == 0)
                                     {
                                         <div class="alert alert-warning">
-                                            利用可能なブランチがありません
+                                            @L["SubSession.ExistingBranch.Empty"]
                                         </div>
                                     }
                                     else
                                     {
-                                        <select class="form-select" id="existingBranchSelect" 
+                                        <select class="form-select" id="existingBranchSelect"
                                                 @onchange="OnExistingBranchSelected">
-                                            <option value="">ブランチを選択してください</option>
+                                            <option value="">@L["SubSession.ExistingBranch.Placeholder"]</option>
                                             @foreach (var branch in availableBranches)
                                             {
                                                 <option value="@branch">@branch</option>
@@ -125,14 +127,14 @@
                                         </select>
                                     }
                                 </div>
-                                
+
                                 @if (!string.IsNullOrEmpty(selectedExistingBranch) && branchWorktreeInfo != null)
                                 {
                                     <div class="alert alert-warning">
                                         <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                                        <strong>このブランチには既にWorktreeが存在します</strong><br/>
-                                        <span>パス: @branchWorktreeInfo.Path</span><br/>
-                                        <small>「既存Worktree追加」タブから追加してください</small>
+                                        <strong>@L["SubSession.BranchExistingWorktree.Title"]</strong><br/>
+                                        <span>@string.Format(L["SubSession.BranchExistingWorktree.PathFormat"], branchWorktreeInfo.Path)</span><br/>
+                                        <small>@L["SubSession.BranchExistingWorktree.Help"]</small>
                                     </div>
                                 }
                             }
@@ -157,41 +159,41 @@
                             {
                                 <div class="alert alert-warning">
                                     <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                                    <strong>Git管理が必要です</strong><br/>
-                                    既存のWorktreeを追加するにはGitリポジトリが必要です。
+                                    <strong>@L["SubSession.GitRequired.Title"]</strong><br/>
+                                    @L["SubSession.GitRequired.ExistingWorktree"]
                                 </div>
                             }
                             else
                             {
                             <div class="mb-3">
-                                <label for="worktreePath" class="form-label">既存のWorktreeを選択</label>
+                                <label for="worktreePath" class="form-label">@L["SubSession.ExistingWorktree.Label"]</label>
                                 @if (availableWorktrees == null)
                                 {
                                     <div class="text-center">
                                         <span class="spinner-border spinner-border-sm" role="status"></span>
-                                        Worktree一覧を読み込み中...
+                                        @L["SubSession.ExistingWorktree.Loading"]
                                     </div>
                                 }
                                 else if (availableWorktrees.Count == 0)
                                 {
                                     <div class="alert alert-warning">
                                         <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                                        利用可能なWorktreeがありません
+                                        @L["SubSession.ExistingWorktree.Empty"]
                                     </div>
                                 }
                                 else
                                 {
-                                    <select class="form-select" id="worktreeSelect" 
+                                    <select class="form-select" id="worktreeSelect"
                                             value="@selectedWorktreePath"
                                             @onchange="OnWorktreeSelected">
-                                        <option value="">Worktreeを選択してください</option>
+                                        <option value="">@L["SubSession.ExistingWorktree.Placeholder"]</option>
                                         @foreach (var worktree in availableWorktrees)
                                         {
                                             <option value="@worktree.Path">
                                                 (@worktree.BranchName)
                                                 @if (worktree.IsMain)
                                                 {
-                                                    <text> - メイン</text>
+                                                    <text> - @L["SubSession.WorktreeMainSuffix"]</text>
                                                 }
                                             </option>
                                         }
@@ -232,7 +234,7 @@
                             {
                                 <div class="alert alert-info">
                                     <i class="bi bi-info-circle me-2"></i>
-                                    親セッション "@ParentSessionName" と同じフォルダで開きます
+                                    @string.Format(L["SubSession.SamePath.InfoFormat"], ParentSessionName)
                                 </div>
                             }
                         </div>
@@ -242,20 +244,20 @@
                         <!-- 新しいフォルダで開く -->
                         <div class="tab-pane active">
                             <div class="mb-3">
-                                <label for="newFolderPath" class="form-label">新しいフォルダのパス</label>
+                                <label for="newFolderPath" class="form-label">@L["SubSession.NewFolder.Label"]</label>
                                 <div class="input-group">
-                                    <input type="text" class="form-control" id="newFolderPath" 
-                                           @bind="newFolderPath" 
+                                    <input type="text" class="form-control" id="newFolderPath"
+                                           @bind="newFolderPath"
                                            @bind:event="oninput"
                                            @onkeydown="OnKeyDown"
-                                           placeholder="C:\path\to\new\folder または相対パス" 
+                                           placeholder="@L["SubSession.NewFolder.Placeholder"]"
                                            autofocus>
                                     <button class="btn btn-outline-secondary" type="button" @onclick="SelectFolderDialog">
                                         <i class="bi bi-folder2-open"></i>
                                     </button>
                                 </div>
                                 <small class="form-text text-muted">
-                                    フォルダが存在しない場合は自動的に作成されます
+                                    @L["SubSession.NewFolder.Help"]
                                 </small>
                             </div>
                             
@@ -274,7 +276,7 @@
                                 
                                 <div class="alert alert-info mt-3">
                                     <i class="bi bi-info-circle me-2"></i>
-                                    新しいフォルダ "@newFolderPath" でセッションを開始します
+                                    @string.Format(L["SubSession.NewFolder.InfoFormat"], newFolderPath)
                                 </div>
                             }
                         </div>
@@ -285,7 +287,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" @onclick="OnCancel" disabled="@isProcessing">
-                    キャンセル
+                    @L["Common.Cancel"]
                 </button>
                 <button type="button" class="btn btn-success" @onclick="ProcessOperation" 
                         disabled="@(!CanProcess || isProcessing)">
@@ -437,7 +439,7 @@
         }
         catch (Exception ex)
         {
-            errorMessage = $"操作中にエラーが発生しました: {ex.Message}";
+            errorMessage = string.Format(L["SubSession.ErrorFormat"], ex.Message);
             isProcessing = false;
         }
     }
@@ -566,11 +568,11 @@
     {
         return activeTab switch
         {
-            TabType.Create => "Worktree作成",
-            TabType.Existing => "Worktree追加",
-            TabType.SamePath => "セッション作成",
-            TabType.NewFolder => "フォルダ作成",
-            _ => "作成"
+            TabType.Create => L["SubSession.Button.Create"],
+            TabType.Existing => L["SubSession.Button.Existing"],
+            TabType.SamePath => L["SubSession.Button.SamePath"],
+            TabType.NewFolder => L["SubSession.Button.NewFolder"],
+            _ => L["Common.Create"]
         };
     }
     

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -446,7 +446,7 @@
   <data name="SubSession.ExistingWorktree.Loading" xml:space="preserve"><value>Loading worktree list...</value></data>
   <data name="SubSession.ExistingWorktree.Empty" xml:space="preserve"><value>No worktrees available</value></data>
   <data name="SubSession.ExistingWorktree.Placeholder" xml:space="preserve"><value>Please select a worktree</value></data>
-  <data name="SubSession.WorktreeMainSuffix" xml:space="preserve"><value>main</value></data>
+  <data name="SubSession.WorktreeMainSuffix" xml:space="preserve"><value>- main</value></data>
   <data name="SubSession.SamePath.InfoFormat" xml:space="preserve"><value>Opens in the same folder as parent session "{0}"</value></data>
   <data name="SubSession.NewFolder.Label" xml:space="preserve"><value>New folder path</value></data>
   <data name="SubSession.NewFolder.Placeholder" xml:space="preserve"><value>C:\path\to\new\folder or relative path</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -394,4 +394,67 @@
   <data name="SessionOptions.Codex.AdditionalDirs.Help" xml:space="preserve"><value>Each line is passed as --add-dir</value></data>
   <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --reasoning-effort high</value></data>
   <data name="SessionOptions.Codex.PassToCli" xml:space="preserve"><value>Passed as-is to Codex CLI</value></data>
+
+  <!-- SessionSettings Dialog -->
+  <data name="SessionSettings.Title" xml:space="preserve"><value>Session Settings</value></data>
+  <data name="SessionSettings.Info.Header" xml:space="preserve"><value>Session info</value></data>
+  <data name="SessionSettings.Info.SessionName" xml:space="preserve"><value>Session name:</value></data>
+  <data name="SessionSettings.Info.Folder" xml:space="preserve"><value>Folder:</value></data>
+  <data name="SessionSettings.Info.CopyFolderPath" xml:space="preserve"><value>Copy folder path</value></data>
+  <data name="SessionSettings.Info.OpenFolder" xml:space="preserve"><value>Open folder</value></data>
+  <data name="SessionSettings.Info.SessionId" xml:space="preserve"><value>Session ID:</value></data>
+  <data name="SessionSettings.Info.CopySessionId" xml:space="preserve"><value>Copy session ID</value></data>
+  <data name="SessionSettings.CreateSubSession" xml:space="preserve"><value>Create sub-session</value></data>
+  <data name="SessionSettings.OpenMemoManagement" xml:space="preserve"><value>Manage memos</value></data>
+  <data name="SessionSettings.DisplayName.Label" xml:space="preserve"><value>Display name</value></data>
+  <data name="SessionSettings.DisplayName.Placeholder" xml:space="preserve"><value>Session display name</value></data>
+  <data name="SessionSettings.DisplayName.Help" xml:space="preserve"><value>If blank, the folder name will be used</value></data>
+  <data name="SessionSettings.Pin.Label" xml:space="preserve"><value>Pin this session</value></data>
+  <data name="SessionSettings.Pin.PriorityLabel" xml:space="preserve"><value>Priority:</value></data>
+  <data name="SessionSettings.Memo.Label" xml:space="preserve"><value>Memo</value></data>
+  <data name="SessionSettings.Memo.Placeholder" xml:space="preserve"><value>Memo for this session</value></data>
+  <data name="SessionSettings.Memo.Help" xml:space="preserve"><value>Write any notes about this session here</value></data>
+  <data name="SessionSettings.Loading" xml:space="preserve"><value>Loading session info...</value></data>
+  <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>Apply changes immediately (restart session)</value></data>
+  <data name="SessionSettings.Save" xml:space="preserve"><value>Save</value></data>
+  <data name="SessionSettings.SaveErrorFormat" xml:space="preserve"><value>Failed to save settings: {0}</value></data>
+  <data name="SessionSettings.RestartFailed" xml:space="preserve"><value>Settings were saved, but session restart failed.</value></data>
+
+  <!-- SubSession Dialog -->
+  <data name="SubSession.Title" xml:space="preserve"><value>Create Sub-session</value></data>
+  <data name="SubSession.ParentSessionFormat" xml:space="preserve"><value>Parent session: {0}</value></data>
+  <data name="SubSession.Tab.CreateWorktree" xml:space="preserve"><value>New worktree</value></data>
+  <data name="SubSession.Tab.ExistingWorktree" xml:space="preserve"><value>Existing worktree</value></data>
+  <data name="SubSession.Tab.SamePath" xml:space="preserve"><value>Same folder</value></data>
+  <data name="SubSession.Tab.NewFolder" xml:space="preserve"><value>New folder</value></data>
+  <data name="SubSession.GitRequired.Title" xml:space="preserve"><value>Git repository required</value></data>
+  <data name="SubSession.GitRequired.CreateWorktree" xml:space="preserve"><value>A Git repository is required to create a worktree.</value></data>
+  <data name="SubSession.GitRequired.ExistingWorktree" xml:space="preserve"><value>A Git repository is required to add an existing worktree.</value></data>
+  <data name="SubSession.BranchSelection.Label" xml:space="preserve"><value>Branch selection</value></data>
+  <data name="SubSession.BranchSelection.New" xml:space="preserve"><value>New branch</value></data>
+  <data name="SubSession.BranchSelection.Existing" xml:space="preserve"><value>Existing branch</value></data>
+  <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>New branch name</value></data>
+  <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>A new worktree will be created for this branch</value></data>
+  <data name="SubSession.ExistingBranch.Label" xml:space="preserve"><value>Select an existing branch</value></data>
+  <data name="SubSession.ExistingBranch.Loading" xml:space="preserve"><value>Loading branch list...</value></data>
+  <data name="SubSession.ExistingBranch.Empty" xml:space="preserve"><value>No branches available</value></data>
+  <data name="SubSession.ExistingBranch.Placeholder" xml:space="preserve"><value>Please select a branch</value></data>
+  <data name="SubSession.BranchExistingWorktree.Title" xml:space="preserve"><value>A worktree already exists for this branch</value></data>
+  <data name="SubSession.BranchExistingWorktree.PathFormat" xml:space="preserve"><value>Path: {0}</value></data>
+  <data name="SubSession.BranchExistingWorktree.Help" xml:space="preserve"><value>Please use the "Existing worktree" tab to add it</value></data>
+  <data name="SubSession.ExistingWorktree.Label" xml:space="preserve"><value>Select an existing worktree</value></data>
+  <data name="SubSession.ExistingWorktree.Loading" xml:space="preserve"><value>Loading worktree list...</value></data>
+  <data name="SubSession.ExistingWorktree.Empty" xml:space="preserve"><value>No worktrees available</value></data>
+  <data name="SubSession.ExistingWorktree.Placeholder" xml:space="preserve"><value>Please select a worktree</value></data>
+  <data name="SubSession.WorktreeMainSuffix" xml:space="preserve"><value>main</value></data>
+  <data name="SubSession.SamePath.InfoFormat" xml:space="preserve"><value>Opens in the same folder as parent session "{0}"</value></data>
+  <data name="SubSession.NewFolder.Label" xml:space="preserve"><value>New folder path</value></data>
+  <data name="SubSession.NewFolder.Placeholder" xml:space="preserve"><value>C:\path\to\new\folder or relative path</value></data>
+  <data name="SubSession.NewFolder.Help" xml:space="preserve"><value>The folder will be created automatically if it doesn't exist</value></data>
+  <data name="SubSession.NewFolder.InfoFormat" xml:space="preserve"><value>Starts a session in the new folder "{0}"</value></data>
+  <data name="SubSession.Button.Create" xml:space="preserve"><value>Create worktree</value></data>
+  <data name="SubSession.Button.Existing" xml:space="preserve"><value>Add worktree</value></data>
+  <data name="SubSession.Button.SamePath" xml:space="preserve"><value>Create session</value></data>
+  <data name="SubSession.Button.NewFolder" xml:space="preserve"><value>Create folder</value></data>
+  <data name="SubSession.ErrorFormat" xml:space="preserve"><value>An error occurred during the operation: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -394,4 +394,67 @@
   <data name="SessionOptions.Codex.AdditionalDirs.Help" xml:space="preserve"><value>各行を `--add-dir` として渡します</value></data>
   <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --reasoning-effort high</value></data>
   <data name="SessionOptions.Codex.PassToCli" xml:space="preserve"><value>そのまま Codex CLI に渡します</value></data>
+
+  <!-- SessionSettings Dialog -->
+  <data name="SessionSettings.Title" xml:space="preserve"><value>セッション設定</value></data>
+  <data name="SessionSettings.Info.Header" xml:space="preserve"><value>セッション情報</value></data>
+  <data name="SessionSettings.Info.SessionName" xml:space="preserve"><value>セッション名:</value></data>
+  <data name="SessionSettings.Info.Folder" xml:space="preserve"><value>フォルダ:</value></data>
+  <data name="SessionSettings.Info.CopyFolderPath" xml:space="preserve"><value>フォルダパスをコピー</value></data>
+  <data name="SessionSettings.Info.OpenFolder" xml:space="preserve"><value>フォルダを開く</value></data>
+  <data name="SessionSettings.Info.SessionId" xml:space="preserve"><value>セッションID:</value></data>
+  <data name="SessionSettings.Info.CopySessionId" xml:space="preserve"><value>セッションIDをコピー</value></data>
+  <data name="SessionSettings.CreateSubSession" xml:space="preserve"><value>サブセッションを作成</value></data>
+  <data name="SessionSettings.OpenMemoManagement" xml:space="preserve"><value>メモ管理</value></data>
+  <data name="SessionSettings.DisplayName.Label" xml:space="preserve"><value>表示名</value></data>
+  <data name="SessionSettings.DisplayName.Placeholder" xml:space="preserve"><value>セッションの表示名</value></data>
+  <data name="SessionSettings.DisplayName.Help" xml:space="preserve"><value>空白の場合はフォルダ名が使用されます</value></data>
+  <data name="SessionSettings.Pin.Label" xml:space="preserve"><value>セッションをピン留め</value></data>
+  <data name="SessionSettings.Pin.PriorityLabel" xml:space="preserve"><value>優先度:</value></data>
+  <data name="SessionSettings.Memo.Label" xml:space="preserve"><value>メモ</value></data>
+  <data name="SessionSettings.Memo.Placeholder" xml:space="preserve"><value>セッションに関するメモ</value></data>
+  <data name="SessionSettings.Memo.Help" xml:space="preserve"><value>このセッションに関する任意のメモを記入できます</value></data>
+  <data name="SessionSettings.Loading" xml:space="preserve"><value>セッション情報を読み込み中...</value></data>
+  <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>変更を即座に適用（セッションを再起動）</value></data>
+  <data name="SessionSettings.Save" xml:space="preserve"><value>保存</value></data>
+  <data name="SessionSettings.SaveErrorFormat" xml:space="preserve"><value>設定の保存に失敗しました: {0}</value></data>
+  <data name="SessionSettings.RestartFailed" xml:space="preserve"><value>設定は保存されましたが、セッションの再起動に失敗しました。</value></data>
+
+  <!-- SubSession Dialog -->
+  <data name="SubSession.Title" xml:space="preserve"><value>サブセッション作成</value></data>
+  <data name="SubSession.ParentSessionFormat" xml:space="preserve"><value>親セッション: {0}</value></data>
+  <data name="SubSession.Tab.CreateWorktree" xml:space="preserve"><value>Worktree 新規作成</value></data>
+  <data name="SubSession.Tab.ExistingWorktree" xml:space="preserve"><value>既存 Worktree 追加</value></data>
+  <data name="SubSession.Tab.SamePath" xml:space="preserve"><value>同じフォルダで開く</value></data>
+  <data name="SubSession.Tab.NewFolder" xml:space="preserve"><value>新しいフォルダで開く</value></data>
+  <data name="SubSession.GitRequired.Title" xml:space="preserve"><value>Git 管理が必要です</value></data>
+  <data name="SubSession.GitRequired.CreateWorktree" xml:space="preserve"><value>Worktree の作成には Git リポジトリが必要です。</value></data>
+  <data name="SubSession.GitRequired.ExistingWorktree" xml:space="preserve"><value>既存の Worktree を追加するには Git リポジトリが必要です。</value></data>
+  <data name="SubSession.BranchSelection.Label" xml:space="preserve"><value>ブランチ選択方法</value></data>
+  <data name="SubSession.BranchSelection.New" xml:space="preserve"><value>新規ブランチ</value></data>
+  <data name="SubSession.BranchSelection.Existing" xml:space="preserve"><value>既存ブランチ</value></data>
+  <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>新しいブランチ名</value></data>
+  <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>このブランチ名で新しい Worktree が作成されます</value></data>
+  <data name="SubSession.ExistingBranch.Label" xml:space="preserve"><value>既存のブランチを選択</value></data>
+  <data name="SubSession.ExistingBranch.Loading" xml:space="preserve"><value>ブランチ一覧を読み込み中...</value></data>
+  <data name="SubSession.ExistingBranch.Empty" xml:space="preserve"><value>利用可能なブランチがありません</value></data>
+  <data name="SubSession.ExistingBranch.Placeholder" xml:space="preserve"><value>ブランチを選択してください</value></data>
+  <data name="SubSession.BranchExistingWorktree.Title" xml:space="preserve"><value>このブランチには既に Worktree が存在します</value></data>
+  <data name="SubSession.BranchExistingWorktree.PathFormat" xml:space="preserve"><value>パス: {0}</value></data>
+  <data name="SubSession.BranchExistingWorktree.Help" xml:space="preserve"><value>「既存 Worktree 追加」タブから追加してください</value></data>
+  <data name="SubSession.ExistingWorktree.Label" xml:space="preserve"><value>既存の Worktree を選択</value></data>
+  <data name="SubSession.ExistingWorktree.Loading" xml:space="preserve"><value>Worktree 一覧を読み込み中...</value></data>
+  <data name="SubSession.ExistingWorktree.Empty" xml:space="preserve"><value>利用可能な Worktree がありません</value></data>
+  <data name="SubSession.ExistingWorktree.Placeholder" xml:space="preserve"><value>Worktree を選択してください</value></data>
+  <data name="SubSession.WorktreeMainSuffix" xml:space="preserve"><value>メイン</value></data>
+  <data name="SubSession.SamePath.InfoFormat" xml:space="preserve"><value>親セッション "{0}" と同じフォルダで開きます</value></data>
+  <data name="SubSession.NewFolder.Label" xml:space="preserve"><value>新しいフォルダのパス</value></data>
+  <data name="SubSession.NewFolder.Placeholder" xml:space="preserve"><value>C:\path\to\new\folder または相対パス</value></data>
+  <data name="SubSession.NewFolder.Help" xml:space="preserve"><value>フォルダが存在しない場合は自動的に作成されます</value></data>
+  <data name="SubSession.NewFolder.InfoFormat" xml:space="preserve"><value>新しいフォルダ "{0}" でセッションを開始します</value></data>
+  <data name="SubSession.Button.Create" xml:space="preserve"><value>Worktree 作成</value></data>
+  <data name="SubSession.Button.Existing" xml:space="preserve"><value>Worktree 追加</value></data>
+  <data name="SubSession.Button.SamePath" xml:space="preserve"><value>セッション作成</value></data>
+  <data name="SubSession.Button.NewFolder" xml:space="preserve"><value>フォルダ作成</value></data>
+  <data name="SubSession.ErrorFormat" xml:space="preserve"><value>操作中にエラーが発生しました: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -414,7 +414,7 @@
   <data name="SessionSettings.Memo.Label" xml:space="preserve"><value>メモ</value></data>
   <data name="SessionSettings.Memo.Placeholder" xml:space="preserve"><value>セッションに関するメモ</value></data>
   <data name="SessionSettings.Memo.Help" xml:space="preserve"><value>このセッションに関する任意のメモを記入できます</value></data>
-  <data name="SessionSettings.Loading" xml:space="preserve"><value>セッション情報を読み込み中...</value></data>
+  <data name="SessionSettings.Loading" xml:space="preserve"><value>セッション情報を読み込み中…</value></data>
   <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>変更を即座に適用（セッションを再起動）</value></data>
   <data name="SessionSettings.Save" xml:space="preserve"><value>保存</value></data>
   <data name="SessionSettings.SaveErrorFormat" xml:space="preserve"><value>設定の保存に失敗しました: {0}</value></data>
@@ -436,17 +436,17 @@
   <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>新しいブランチ名</value></data>
   <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>このブランチ名で新しい Worktree が作成されます</value></data>
   <data name="SubSession.ExistingBranch.Label" xml:space="preserve"><value>既存のブランチを選択</value></data>
-  <data name="SubSession.ExistingBranch.Loading" xml:space="preserve"><value>ブランチ一覧を読み込み中...</value></data>
+  <data name="SubSession.ExistingBranch.Loading" xml:space="preserve"><value>ブランチ一覧を読み込み中…</value></data>
   <data name="SubSession.ExistingBranch.Empty" xml:space="preserve"><value>利用可能なブランチがありません</value></data>
   <data name="SubSession.ExistingBranch.Placeholder" xml:space="preserve"><value>ブランチを選択してください</value></data>
   <data name="SubSession.BranchExistingWorktree.Title" xml:space="preserve"><value>このブランチには既に Worktree が存在します</value></data>
   <data name="SubSession.BranchExistingWorktree.PathFormat" xml:space="preserve"><value>パス: {0}</value></data>
   <data name="SubSession.BranchExistingWorktree.Help" xml:space="preserve"><value>「既存 Worktree 追加」タブから追加してください</value></data>
   <data name="SubSession.ExistingWorktree.Label" xml:space="preserve"><value>既存の Worktree を選択</value></data>
-  <data name="SubSession.ExistingWorktree.Loading" xml:space="preserve"><value>Worktree 一覧を読み込み中...</value></data>
+  <data name="SubSession.ExistingWorktree.Loading" xml:space="preserve"><value>Worktree 一覧を読み込み中…</value></data>
   <data name="SubSession.ExistingWorktree.Empty" xml:space="preserve"><value>利用可能な Worktree がありません</value></data>
   <data name="SubSession.ExistingWorktree.Placeholder" xml:space="preserve"><value>Worktree を選択してください</value></data>
-  <data name="SubSession.WorktreeMainSuffix" xml:space="preserve"><value>メイン</value></data>
+  <data name="SubSession.WorktreeMainSuffix" xml:space="preserve"><value>- メイン</value></data>
   <data name="SubSession.SamePath.InfoFormat" xml:space="preserve"><value>親セッション "{0}" と同じフォルダで開きます</value></data>
   <data name="SubSession.NewFolder.Label" xml:space="preserve"><value>新しいフォルダのパス</value></data>
   <data name="SubSession.NewFolder.Placeholder" xml:space="preserve"><value>C:\path\to\new\folder または相対パス</value></data>


### PR DESCRIPTION
## Summary
Phase 2C-2 として **SessionSettingsDialog** と **SubSessionDialog** を localize。両ダイアログとも内部で SessionOptionsSelector を使用しており、Phase 2C-1b で既に options 部分は localize 済みのため今回は shell 部分を対応。~50 キー追加、4 ファイル変更。

## 追加キー

### `SessionSettings.*` (~23 キー)
- セッション情報表示 (SessionName/Folder/SessionId + Copy/OpenFolder tooltip)
- アクションボタン (CreateSubSession / OpenMemoManagement)
- 編集可能フィールド (DisplayName / Pin / Memo)
- フッター (RestartOnSave / Save + エラーメッセージ 2 種)

### `SubSession.*` (~30 キー、ダイアログ規模大)
- Title / ParentSessionFormat
- **4 タブのラベル** (CreateWorktree / ExistingWorktree / SamePath / NewFolder)
- **Git 必須警告** (Title + 2 バリエーション)
- **Branch 選択** (Label / New / Existing + 入力欄の Label/Placeholder/Help)
- **ExistingBranch / ExistingWorktree の共通パターン** (Loading / Empty / Placeholder で始まる 4 状態)
- **動的ボタンラベル** (4 つのタブに応じて変化、`GetButtonText()` で切替)
- format string: ParentSessionFormat / PathFormat / SamePath.InfoFormat / NewFolder.InfoFormat / ErrorFormat

## Common キーの活用
- **`Common.Cancel`** (Phase 2C-1): 両ダイアログの Cancel ボタンで再利用 ✓
- **`Common.Create`**: `GetButtonText()` の default case フォールバック値で再利用

## Code-behind 変更
- `SessionSettingsDialog.SaveSettings()`: restart 失敗メッセージ + save エラーメッセージを localize
- `SubSessionDialog.GetButtonText()`: switch 式内の 4 つの日本語リテラルを L[...] に
- `SubSessionDialog.ProcessOperation()`: catch のエラーメッセージを localize

## 意図的に残した日本語
- `Logger.LogError` の日本語メッセージ 2 箇所 (SessionSettingsDialog.razor): 開発ログ用途、メンテナ向け

## 動作確認済み
- [x] C# コンパイル成功 (obj/ DLL 更新)

## 検証手順
- [ ] dev 再起動 → セッション右クリック → 「Session Settings」
- [ ] タイトル・情報表示・入力ラベルが culture 連動
- [ ] サブセッション作成ボタンクリック → SubSession ダイアログ表示
- [ ] 4 タブすべての切替 (Git リポジトリあり/なしの分岐)
- [ ] 動的ボタンラベル (タブ切替で変化)
- [ ] Git 必須警告が Worktree 新規作成 / 既存追加タブで正しく切り替わる

## Phase 2C 残り
- **2C-3**: SessionList + ArchivedSessionsDialog (左サイドバー)
- **2C-4**: BottomPanels (TextInput / Memo)
- **2C-5**: Root.razor (メインページ、**最大**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)