### PR TITLE
feat: SessionList + ArchivedSessionsDialog を多言語対応 (Phase 2C-3)

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/ArchivedSessionsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/ArchivedSessionsDialog.razor
@@ -73,7 +73,7 @@
                                             </div>
                                         }
                                         <div class="small text-muted mt-1">
-                                            <i class="bi bi-clock me-1"></i>@string.Format(L["ArchivedSessions.ArchivedAtFormat"], session.ArchivedAt?.ToString("yyyy/MM/dd HH:mm") ?? L["ArchivedSessions.Unknown"].Value)
+                                            <i class="bi bi-clock me-1"></i>@string.Format(L["ArchivedSessions.ArchivedAtFormat"], session.ArchivedAt?.ToString("yyyy/MM/dd HH:mm") ?? L["ArchivedSessions.DateUnknown"].Value)
                                         </div>
                                     </div>
                                     <div class="btn-group btn-group-sm">

--- a/TerminalHub/Components/Shared/Dialogs/ArchivedSessionsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/ArchivedSessionsDialog.razor
@@ -1,11 +1,13 @@
 @using System.IO
 @using TerminalHub.Models
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="@(IsVisible ? "display: block;" : "display: none;")" @onmousedown="OnBackdropMouseDown" @onmouseup="OnBackdropMouseUp">
     <div class="modal-dialog modal-dialog-centered modal-lg" @onclick:stopPropagation="true" @onmousedown:stopPropagation="true" @onmouseup:stopPropagation="true">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title"><i class="bi bi-archive me-2"></i>アーカイブ済みセッション</h5>
+                <h5 class="modal-title"><i class="bi bi-archive me-2"></i>@L["ArchivedSessions.Title"]</h5>
                 <button type="button" class="btn-close" @onclick="Close"></button>
             </div>
             <div class="modal-body" style="max-height: 60vh; overflow-y: auto;">
@@ -14,7 +16,7 @@
                     <div class="mb-3">
                         <div class="input-group input-group-sm">
                             <span class="input-group-text"><i class="bi bi-search"></i></span>
-                            <input type="text" class="form-control" placeholder="アーカイブを検索..."
+                            <input type="text" class="form-control" placeholder="@L["ArchivedSessions.SearchPlaceholder"]"
                                    value="@searchText" @oninput="OnSearchTextChanged" />
                             @if (!string.IsNullOrEmpty(searchText))
                             {
@@ -30,13 +32,13 @@
                             <input type="checkbox" class="form-check-input" id="selectAllArchived"
                                    checked="@IsAllSelected"
                                    @onchange="ToggleSelectAll" />
-                            <label class="form-check-label small" for="selectAllArchived">全選択</label>
+                            <label class="form-check-label small" for="selectAllArchived">@L["ArchivedSessions.SelectAll"]</label>
                         </div>
                         @if (selectedSessionIds.Count > 0)
                         {
-                            <span class="small text-muted me-2">@selectedSessionIds.Count 件選択中</span>
+                            <span class="small text-muted me-2">@string.Format(L["ArchivedSessions.SelectedCountFormat"], selectedSessionIds.Count)</span>
                             <button class="btn btn-outline-danger btn-sm" @onclick="ConfirmDeleteSelected">
-                                <i class="bi bi-trash me-1"></i>選択を削除
+                                <i class="bi bi-trash me-1"></i>@L["ArchivedSessions.DeleteSelected"]
                             </button>
                         }
                     </div>
@@ -56,7 +58,7 @@
                                             @session.GetDisplayName()
                                             @if (!string.IsNullOrEmpty(session.FolderPath) && !Directory.Exists(session.FolderPath))
                                             {
-                                                <span class="text-warning ms-1" title="ディレクトリが見つかりません">
+                                                <span class="text-warning ms-1" title="@L["ArchivedSessions.DirectoryNotFound"]">
                                                     <i class="bi bi-exclamation-triangle-fill" style="font-size: 0.75rem;"></i>
                                                 </span>
                                             }
@@ -71,14 +73,14 @@
                                             </div>
                                         }
                                         <div class="small text-muted mt-1">
-                                            <i class="bi bi-clock me-1"></i>アーカイブ日時: @(session.ArchivedAt?.ToString("yyyy/MM/dd HH:mm") ?? "不明")
+                                            <i class="bi bi-clock me-1"></i>@string.Format(L["ArchivedSessions.ArchivedAtFormat"], session.ArchivedAt?.ToString("yyyy/MM/dd HH:mm") ?? L["ArchivedSessions.Unknown"].Value)
                                         </div>
                                     </div>
                                     <div class="btn-group btn-group-sm">
-                                        <button class="btn btn-outline-success" @onclick="() => RestoreSession(session.SessionId)" title="復帰">
+                                        <button class="btn btn-outline-success" @onclick="() => RestoreSession(session.SessionId)" title="@L["ArchivedSessions.Restore"]">
                                             <i class="bi bi-arrow-counterclockwise"></i>
                                         </button>
-                                        <button class="btn btn-outline-danger" @onclick="() => ConfirmDelete(session)" title="完全に削除">
+                                        <button class="btn btn-outline-danger" @onclick="() => ConfirmDelete(session)" title="@L["ArchivedSessions.DeletePermanently"]">
                                             <i class="bi bi-trash"></i>
                                         </button>
                                     </div>
@@ -90,7 +92,7 @@
                     @if (!_cachedFilteredSessions.Any())
                     {
                         <div class="text-center text-muted py-3">
-                            <i class="bi bi-search"></i> 検索結果がありません
+                            <i class="bi bi-search"></i> @L["ArchivedSessions.NoResults"]
                         </div>
                     }
                 }
@@ -98,7 +100,7 @@
                 {
                     <div class="text-center text-muted py-5">
                         <i class="bi bi-archive" style="font-size: 3rem;"></i>
-                        <p class="mt-3">アーカイブ済みのセッションはありません</p>
+                        <p class="mt-3">@L["ArchivedSessions.Empty"]</p>
                     </div>
                 }
             </div>
@@ -106,10 +108,10 @@
                 @if (ArchivedSessions.Any())
                 {
                     <button type="button" class="btn btn-outline-danger" @onclick="ConfirmDeleteAll">
-                        <i class="bi bi-trash me-1"></i>すべて削除
+                        <i class="bi bi-trash me-1"></i>@L["ArchivedSessions.DeleteAll"]
                     </button>
                 }
-                <button type="button" class="btn btn-secondary" @onclick="Close">閉じる</button>
+                <button type="button" class="btn btn-secondary" @onclick="Close">@L["Common.Close"]</button>
             </div>
         </div>
     </div>
@@ -127,26 +129,26 @@
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">削除の確認</h5>
+                    <h5 class="modal-title">@L["ArchivedSessions.DeleteConfirm.Title"]</h5>
                 </div>
                 <div class="modal-body">
                     @if (deleteAllMode)
                     {
-                        <p>すべてのアーカイブ済みセッション（@ArchivedSessions.Count 件）を完全に削除しますか？</p>
+                        <p>@string.Format(L["ArchivedSessions.DeleteConfirm.AllFormat"], ArchivedSessions.Count)</p>
                     }
                     else if (deleteSelectedMode)
                     {
-                        <p>選択した @selectedSessionIds.Count 件のアーカイブ済みセッションを完全に削除しますか？</p>
+                        <p>@string.Format(L["ArchivedSessions.DeleteConfirm.SelectedFormat"], selectedSessionIds.Count)</p>
                     }
                     else
                     {
-                        <p>「@sessionToDelete?.GetDisplayName()」を完全に削除しますか？</p>
+                        <p>@string.Format(L["ArchivedSessions.DeleteConfirm.SingleFormat"], sessionToDelete?.GetDisplayName())</p>
                     }
-                    <p class="text-danger small"><i class="bi bi-exclamation-triangle me-1"></i>この操作は取り消せません。</p>
+                    <p class="text-danger small"><i class="bi bi-exclamation-triangle me-1"></i>@L["ArchivedSessions.DeleteConfirm.Irreversible"]</p>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="CancelDelete">キャンセル</button>
-                    <button type="button" class="btn btn-danger" @onclick="ExecuteDelete">削除する</button>
+                    <button type="button" class="btn btn-secondary" @onclick="CancelDelete">@L["Common.Cancel"]</button>
+                    <button type="button" class="btn btn-danger" @onclick="ExecuteDelete">@L["ArchivedSessions.DeleteConfirm.Execute"]</button>
                 </div>
             </div>
         </div>

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -1,6 +1,8 @@
 @using System.IO
 @using TerminalHub.Models
 @using TerminalHub.Constants
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SharedResource> L
 
 <style>
     @@keyframes bell-ring {
@@ -29,21 +31,21 @@
 
     <div class="mb-2">
         <button class="btn btn-primary w-100" @onclick="() => OnAddSession.InvokeAsync()" disabled="@IsAddingSession">
-            <i class="bi bi-plus-circle"></i> 新しいセッションを作成
+            <i class="bi bi-plus-circle"></i> @L["SessionList.CreateSession"]
         </button>
     </div>
 
     @if (!Sessions.Any())
     {
         <div class="alert alert-info py-2 px-3 mb-2 small">
-            <i class="bi bi-arrow-up"></i> 上のボタンからセッションを作成してください
+            <i class="bi bi-arrow-up"></i> @L["SessionList.EmptyHint"]
         </div>
     }
 
     <div class="mb-2">
         <div class="input-group input-group-sm">
             <span class="input-group-text"><i class="bi bi-search"></i></span>
-            <input type="text" class="form-control" placeholder="セッションを検索..."
+            <input type="text" class="form-control" placeholder="@L["SessionList.SearchPlaceholder"]"
                    @bind="filterText" @bind:event="oninput" />
             @if (!string.IsNullOrEmpty(filterText))
             {
@@ -52,7 +54,7 @@
                 </button>
             }
             <button class="btn btn-outline-secondary" type="button" @onclick="() => OnShowArchivedSessions.InvokeAsync()"
-                    title="アーカイブ済みセッション">
+                    title="@L["SessionList.ArchivedTooltip"]">
                 <i class="bi bi-archive"></i>
                 @{
                     var archivedCount = Sessions.Count(s => s.IsArchived);
@@ -90,20 +92,20 @@
                                 }
                             @if (session.IsPinned)
                             {
-                                <span class="text-muted me-1" title="ピン留め">
+                                <span class="text-muted me-1" title="@L["SessionList.Badge.Pinned"]">
                                     <i class="bi bi-pin-fill"></i>
                                 </span>
                             }
                             @if (NotificationPendingSessions.Contains(session.SessionId))
                             {
-                                <span class="text-danger me-1" title="処理が完了しました">
+                                <span class="text-danger me-1" title="@L["SessionList.Badge.Notification"]">
                                     <i class="bi bi-bell-fill"></i>
                                 </span>
                             }
                             <span class="@GetConnectionOpacityClass(session)">@session.GetDisplayName()</span>
                             @if (!string.IsNullOrEmpty(session.FolderPath) && !Directory.Exists(session.FolderPath))
                             {
-                                <span class="text-warning ms-1" title="ディレクトリが見つかりません: @session.FolderPath">
+                                <span class="text-warning ms-1" title="@string.Format(L["SessionList.Badge.DirectoryNotFoundFormat"], session.FolderPath)">
                                     <i class="bi bi-exclamation-triangle-fill" style="font-size: 0.75rem;"></i>
                                 </span>
                             }
@@ -113,24 +115,24 @@
                             }
                             @if (ShowGitInfo && session.IsGitRepository && !string.IsNullOrEmpty(session.GitBranch))
                             {
-                                <span class="badge @(session.IsWorktree ? "bg-warning" : "bg-success") ms-1" title="@(session.IsWorktree ? "Worktree" : "Git ブランチ")">
+                                <span class="badge @(session.IsWorktree ? "bg-warning" : "bg-success") ms-1" title="@(session.IsWorktree ? "Worktree" : L["SessionList.Badge.GitBranch"].Value)">
                                     <i class="bi @(session.IsWorktree ? "bi-git" : "bi-git") me-1"></i>@session.GitBranch
                                     @if (session.HasUncommittedChanges)
                                     {
-                                        <i class="bi bi-circle-fill text-danger git-status-indicator" title="未コミットの変更があります"></i>
+                                        <i class="bi bi-circle-fill text-danger git-status-indicator" title="@L["SessionList.Badge.UncommittedChanges"]"></i>
                                     }
                                 </span>
                             }
                             @if (!string.IsNullOrEmpty(session.RemoteControlUrl))
                             {
-                                <span class="badge bg-info ms-1" title="リモートコントロール接続中">
+                                <span class="badge bg-info ms-1" title="@L["SessionList.Badge.RemoteControl"]">
                                     <i class="bi bi-phone-fill"></i>
                                 </span>
                             }
                             @if (!session.ParentSessionId.HasValue && HasChildren(session) && !session.IsExpanded)
                             {
                                 <span class="badge bg-secondary ms-1" style="font-size: 0.7rem;">
-                                    @GetChildrenCount(session) 件
+                                    @string.Format(L["SessionList.Badge.ChildrenCountFormat"], GetChildrenCount(session))
                                 </span>
                             }
                         </h6>
@@ -155,15 +157,15 @@
                         }
                     </div>
                     <div class="d-flex align-items-center">
-                        <button class="btn btn-outline-secondary btn-sm border-0 opacity-50" @onclick:stopPropagation="true" 
+                        <button class="btn btn-outline-secondary btn-sm border-0 opacity-50" @onclick:stopPropagation="true"
                                 @onclick="() => OnSessionSettings.InvokeAsync(session.SessionId)"
-                                title="セッション設定"
+                                title="@L["SessionList.Tooltip.Settings"]"
                                 style="font-size: 0.75rem; padding: 0.25rem 0.5rem;">
                             <i class="bi bi-gear"></i>
                         </button>
-                        <button class="btn btn-outline-secondary btn-sm border-0 opacity-50" @onclick:stopPropagation="true" 
+                        <button class="btn btn-outline-secondary btn-sm border-0 opacity-50" @onclick:stopPropagation="true"
                                 @onclick="() => OnSessionRemove.InvokeAsync(session.SessionId)"
-                                title="セッション削除"
+                                title="@L["SessionList.Tooltip.Delete"]"
                                 style="font-size: 0.75rem; padding: 0.25rem 0.5rem;">
                             <i class="bi bi-x-lg"></i>
                         </button>
@@ -188,7 +190,7 @@
     <div class="mt-auto border-top sidebar-footer">
         <div class="p-2">
             <button class="btn btn-outline-secondary btn-sm w-100" @onclick="OnSettingsClick">
-                <i class="bi bi-gear me-1"></i>設定
+                <i class="bi bi-gear me-1"></i>@L["Settings.Title"]
             </button>
         </div>
     </div>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -459,7 +459,7 @@
   <data name="SubSession.ErrorFormat" xml:space="preserve"><value>An error occurred during the operation: {0}</value></data>
 
   <!-- SessionList (left sidebar) -->
-  <data name="SessionList.CreateSession" xml:space="preserve"><value>New session</value></data>
+  <data name="SessionList.CreateSession" xml:space="preserve"><value>New Session</value></data>
   <data name="SessionList.EmptyHint" xml:space="preserve"><value>Use the button above to create a session</value></data>
   <data name="SessionList.SearchPlaceholder" xml:space="preserve"><value>Search sessions...</value></data>
   <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>Archived sessions</value></data>
@@ -481,7 +481,7 @@
   <data name="ArchivedSessions.DeleteSelected" xml:space="preserve"><value>Delete selected</value></data>
   <data name="ArchivedSessions.DirectoryNotFound" xml:space="preserve"><value>Directory not found</value></data>
   <data name="ArchivedSessions.ArchivedAtFormat" xml:space="preserve"><value>Archived at: {0}</value></data>
-  <data name="ArchivedSessions.Unknown" xml:space="preserve"><value>Unknown</value></data>
+  <data name="ArchivedSessions.DateUnknown" xml:space="preserve"><value>Unknown</value></data>
   <data name="ArchivedSessions.Restore" xml:space="preserve"><value>Restore</value></data>
   <data name="ArchivedSessions.DeletePermanently" xml:space="preserve"><value>Delete permanently</value></data>
   <data name="ArchivedSessions.NoResults" xml:space="preserve"><value>No search results</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -457,4 +457,40 @@
   <data name="SubSession.Button.SamePath" xml:space="preserve"><value>Create session</value></data>
   <data name="SubSession.Button.NewFolder" xml:space="preserve"><value>Create folder</value></data>
   <data name="SubSession.ErrorFormat" xml:space="preserve"><value>An error occurred during the operation: {0}</value></data>
+
+  <!-- SessionList (left sidebar) -->
+  <data name="SessionList.CreateSession" xml:space="preserve"><value>New session</value></data>
+  <data name="SessionList.EmptyHint" xml:space="preserve"><value>Use the button above to create a session</value></data>
+  <data name="SessionList.SearchPlaceholder" xml:space="preserve"><value>Search sessions...</value></data>
+  <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>Archived sessions</value></data>
+  <data name="SessionList.Badge.Pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="SessionList.Badge.Notification" xml:space="preserve"><value>Processing completed</value></data>
+  <data name="SessionList.Badge.DirectoryNotFoundFormat" xml:space="preserve"><value>Directory not found: {0}</value></data>
+  <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git branch</value></data>
+  <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>Uncommitted changes</value></data>
+  <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>Remote control connected</value></data>
+  <data name="SessionList.Badge.ChildrenCountFormat" xml:space="preserve"><value>{0} children</value></data>
+  <data name="SessionList.Tooltip.Settings" xml:space="preserve"><value>Session settings</value></data>
+  <data name="SessionList.Tooltip.Delete" xml:space="preserve"><value>Delete session</value></data>
+
+  <!-- ArchivedSessions Dialog -->
+  <data name="ArchivedSessions.Title" xml:space="preserve"><value>Archived Sessions</value></data>
+  <data name="ArchivedSessions.SearchPlaceholder" xml:space="preserve"><value>Search archives...</value></data>
+  <data name="ArchivedSessions.SelectAll" xml:space="preserve"><value>Select all</value></data>
+  <data name="ArchivedSessions.SelectedCountFormat" xml:space="preserve"><value>{0} selected</value></data>
+  <data name="ArchivedSessions.DeleteSelected" xml:space="preserve"><value>Delete selected</value></data>
+  <data name="ArchivedSessions.DirectoryNotFound" xml:space="preserve"><value>Directory not found</value></data>
+  <data name="ArchivedSessions.ArchivedAtFormat" xml:space="preserve"><value>Archived at: {0}</value></data>
+  <data name="ArchivedSessions.Unknown" xml:space="preserve"><value>Unknown</value></data>
+  <data name="ArchivedSessions.Restore" xml:space="preserve"><value>Restore</value></data>
+  <data name="ArchivedSessions.DeletePermanently" xml:space="preserve"><value>Delete permanently</value></data>
+  <data name="ArchivedSessions.NoResults" xml:space="preserve"><value>No search results</value></data>
+  <data name="ArchivedSessions.Empty" xml:space="preserve"><value>No archived sessions</value></data>
+  <data name="ArchivedSessions.DeleteAll" xml:space="preserve"><value>Delete all</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Title" xml:space="preserve"><value>Confirm deletion</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.AllFormat" xml:space="preserve"><value>Permanently delete all {0} archived sessions?</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.SelectedFormat" xml:space="preserve"><value>Permanently delete {0} selected archived sessions?</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.SingleFormat" xml:space="preserve"><value>Permanently delete "{0}"?</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Irreversible" xml:space="preserve"><value>This action cannot be undone.</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Execute" xml:space="preserve"><value>Delete</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -481,7 +481,7 @@
   <data name="ArchivedSessions.DeleteSelected" xml:space="preserve"><value>選択を削除</value></data>
   <data name="ArchivedSessions.DirectoryNotFound" xml:space="preserve"><value>ディレクトリが見つかりません</value></data>
   <data name="ArchivedSessions.ArchivedAtFormat" xml:space="preserve"><value>アーカイブ日時: {0}</value></data>
-  <data name="ArchivedSessions.Unknown" xml:space="preserve"><value>不明</value></data>
+  <data name="ArchivedSessions.DateUnknown" xml:space="preserve"><value>不明</value></data>
   <data name="ArchivedSessions.Restore" xml:space="preserve"><value>復帰</value></data>
   <data name="ArchivedSessions.DeletePermanently" xml:space="preserve"><value>完全に削除</value></data>
   <data name="ArchivedSessions.NoResults" xml:space="preserve"><value>検索結果がありません</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -457,4 +457,40 @@
   <data name="SubSession.Button.SamePath" xml:space="preserve"><value>セッション作成</value></data>
   <data name="SubSession.Button.NewFolder" xml:space="preserve"><value>フォルダ作成</value></data>
   <data name="SubSession.ErrorFormat" xml:space="preserve"><value>操作中にエラーが発生しました: {0}</value></data>
+
+  <!-- SessionList (left sidebar) -->
+  <data name="SessionList.CreateSession" xml:space="preserve"><value>新しいセッションを作成</value></data>
+  <data name="SessionList.EmptyHint" xml:space="preserve"><value>上のボタンからセッションを作成してください</value></data>
+  <data name="SessionList.SearchPlaceholder" xml:space="preserve"><value>セッションを検索…</value></data>
+  <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>アーカイブ済みセッション</value></data>
+  <data name="SessionList.Badge.Pinned" xml:space="preserve"><value>ピン留め</value></data>
+  <data name="SessionList.Badge.Notification" xml:space="preserve"><value>処理が完了しました</value></data>
+  <data name="SessionList.Badge.DirectoryNotFoundFormat" xml:space="preserve"><value>ディレクトリが見つかりません: {0}</value></data>
+  <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git ブランチ</value></data>
+  <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>未コミットの変更があります</value></data>
+  <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>リモートコントロール接続中</value></data>
+  <data name="SessionList.Badge.ChildrenCountFormat" xml:space="preserve"><value>{0} 件</value></data>
+  <data name="SessionList.Tooltip.Settings" xml:space="preserve"><value>セッション設定</value></data>
+  <data name="SessionList.Tooltip.Delete" xml:space="preserve"><value>セッション削除</value></data>
+
+  <!-- ArchivedSessions Dialog -->
+  <data name="ArchivedSessions.Title" xml:space="preserve"><value>アーカイブ済みセッション</value></data>
+  <data name="ArchivedSessions.SearchPlaceholder" xml:space="preserve"><value>アーカイブを検索…</value></data>
+  <data name="ArchivedSessions.SelectAll" xml:space="preserve"><value>全選択</value></data>
+  <data name="ArchivedSessions.SelectedCountFormat" xml:space="preserve"><value>{0} 件選択中</value></data>
+  <data name="ArchivedSessions.DeleteSelected" xml:space="preserve"><value>選択を削除</value></data>
+  <data name="ArchivedSessions.DirectoryNotFound" xml:space="preserve"><value>ディレクトリが見つかりません</value></data>
+  <data name="ArchivedSessions.ArchivedAtFormat" xml:space="preserve"><value>アーカイブ日時: {0}</value></data>
+  <data name="ArchivedSessions.Unknown" xml:space="preserve"><value>不明</value></data>
+  <data name="ArchivedSessions.Restore" xml:space="preserve"><value>復帰</value></data>
+  <data name="ArchivedSessions.DeletePermanently" xml:space="preserve"><value>完全に削除</value></data>
+  <data name="ArchivedSessions.NoResults" xml:space="preserve"><value>検索結果がありません</value></data>
+  <data name="ArchivedSessions.Empty" xml:space="preserve"><value>アーカイブ済みのセッションはありません</value></data>
+  <data name="ArchivedSessions.DeleteAll" xml:space="preserve"><value>すべて削除</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Title" xml:space="preserve"><value>削除の確認</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.AllFormat" xml:space="preserve"><value>すべてのアーカイブ済みセッション（{0} 件）を完全に削除しますか？</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.SelectedFormat" xml:space="preserve"><value>選択した {0} 件のアーカイブ済みセッションを完全に削除しますか？</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.SingleFormat" xml:space="preserve"><value>「{0}」を完全に削除しますか？</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Irreversible" xml:space="preserve"><value>この操作は取り消せません。</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Execute" xml:space="preserve"><value>削除する</value></data>
 </root>


### PR DESCRIPTION
## Summary
Phase 2C-3 として左サイドバー関連 2 コンポーネント (`SessionList` + `ArchivedSessionsDialog`) を localize。~33 キー追加、+112/-36 行、4 ファイル。

## 追加キー

### `SessionList.*` (~13 キー)
- **ボタン・プレースホルダー**: `CreateSession` / `EmptyHint` / `SearchPlaceholder` / `ArchivedTooltip`
- **バッジ tooltip 7 種** (`Badge.*`): Pinned / Notification / DirectoryNotFoundFormat / GitBranch / UncommittedChanges / RemoteControl / ChildrenCountFormat
- **右側ボタン tooltip** (`Tooltip.*`): Settings / Delete

### `ArchivedSessions.*` (~20 キー)
- **ヘッダー**: Title / SearchPlaceholder / SelectAll / SelectedCountFormat / DeleteSelected
- **一覧表示**: DirectoryNotFound / ArchivedAtFormat / Unknown / Restore / DeletePermanently
- **空状態**: NoResults / Empty
- **削除確認ダイアログ** (`DeleteConfirm.*`): Title + 3 パターンの format (All/Selected/Single) + Irreversible / Execute

## Common キーの再利用
- **`Common.Close`**: アーカイブダイアログ本体の「閉じる」
- **`Common.Cancel`**: 削除確認ダイアログの「キャンセル」
- **`Settings.Title`**: サイドバー下部の「設定」ボタン値として流用 (同一文字列なので共通化)

## 動作確認済み
- [x] C# コンパイル成功 (obj/ DLL 更新)

## 検証手順
- [ ] dev 再起動 → 左サイドバーの全ボタン・プレースホルダー切替確認
- [ ] セッションのバッジ tooltip (ピン留め / 通知 / Git / remote control 等)
- [ ] アーカイブボタン → ArchivedSessions ダイアログの英日切替
- [ ] 削除確認ダイアログ 3 パターン (全削除 / 選択削除 / 単一削除) の format 表示

## Phase 2C 残り
- **2C-4**: BottomPanels (TextInput / Memo)
- **2C-5**: Root.razor (メインページ、最大)

🤖 Generated with [Claude Code](https://claude.com/claude-code)