### PR TITLE
feat: Root.razor を多言語対応 (Phase 2C-5) — Phase 2 完走

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -10,7 +10,9 @@
 @using Microsoft.JSInterop
 @using Microsoft.Extensions.Configuration
 @using Microsoft.Extensions.Logging
+@using Microsoft.Extensions.Localization
 @inject ISessionManager SessionManager
+@inject IStringLocalizer<SharedResource> L
 @inject IJSRuntime JSRuntime
 @inject ILocalStorageService LocalStorageService
 @inject IConfiguration Configuration
@@ -167,7 +169,7 @@
                  style="display: @(hasActiveSession ? "none" : "flex");">
                 <div class="text-center text-muted">
                     <i class="bi bi-terminal" style="font-size: 4rem;"></i>
-                    <p class="mt-3">左側からセッションを選択してください</p>
+                    <p class="mt-3">@L["Root.NoSessionSelected"]</p>
                 </div>
             </div>
         </div>
@@ -776,7 +778,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Session creation failed");
-            toast?.ShowError($"セッション作成エラー: {ex.Message}");
+            toast?.ShowError(string.Format(L["Root.Toast.SessionCreateErrorFormat"], ex.Message));
         }
         finally
         {
@@ -831,7 +833,7 @@
         if (sessionInfo != null && !string.IsNullOrEmpty(sessionInfo.FolderPath) && !Directory.Exists(sessionInfo.FolderPath))
         {
             Logger.LogWarning("セッション {SessionId} のディレクトリが存在しません: {FolderPath}", sessionId, sessionInfo.FolderPath);
-            toast?.ShowError($"ディレクトリが見つかりません: {sessionInfo.FolderPath}");
+            toast?.ShowError(string.Format(L["Root.Toast.DirectoryNotFoundFormat"], sessionInfo.FolderPath));
             activeSessionId = null;
             return;
         }
@@ -844,7 +846,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "セッション {SessionId} の初期化に失敗", sessionId);
-            toast?.ShowError($"セッション初期化エラー: {ex.Message}");
+            toast?.ShowError(string.Format(L["Root.Toast.SessionInitErrorFormat"], ex.Message));
             activeSession = null;
         }
 
@@ -1496,14 +1498,14 @@
 
             if (showAlert)
             {
-                toast?.ShowSuccess("ターミナルを破棄しました");
+                toast?.ShowSuccess(L["Root.Toast.TerminalDisposed"]);
             }
         }
         catch (Exception ex)
         {
             if (showAlert)
             {
-                toast?.ShowError($"ターミナル破棄エラー: {ex.Message}");
+                toast?.ShowError(string.Format(L["Root.Toast.TerminalDisposeErrorFormat"], ex.Message));
             }
         }
     }
@@ -1532,16 +1534,16 @@
                     ConPtyConnection.SubscribeToSession(selectedSessionInfo.SessionId, selectedSessionInfo.ConPtySession);
                 }
 
-                toast?.ShowSuccess("ターミナルを再作成しました");
+                toast?.ShowSuccess(L["Root.Toast.TerminalRecreated"]);
             }
             else
             {
-                toast?.ShowWarning("このセッションを選択してからターミナルを再作成してください");
+                toast?.ShowWarning(L["Root.Toast.SelectSessionFirst"]);
             }
         }
         catch (Exception ex)
         {
-            toast?.ShowError($"ターミナル再作成エラー: {ex.Message}");
+            toast?.ShowError(string.Format(L["Root.Toast.TerminalRecreateErrorFormat"], ex.Message));
         }
     }
 
@@ -1642,9 +1644,9 @@
     {
         return terminalType switch
         {
-            TerminalType.ClaudeCode => "Claude Codeへのメッセージを入力...",
-            TerminalType.GeminiCLI => "Gemini CLIへのメッセージを入力...",
-            _ => "コマンドを入力..."
+            TerminalType.ClaudeCode => L["Root.Placeholder.ClaudeCode"],
+            TerminalType.GeminiCLI => L["Root.Placeholder.GeminiCLI"],
+            _ => L["Root.Placeholder.Terminal"]
         };
     }
 
@@ -1797,28 +1799,28 @@
 
                 string successMessage = result.OperationType switch
                 {
-                    SubSessionDialog.SubSessionType.CreateNew => 
-                        $"Worktree '{result.BranchName}' を作成しました",
-                    SubSessionDialog.SubSessionType.AddExisting => 
-                        $"既存のWorktree '{result.BranchName}' を追加しました",
-                    SubSessionDialog.SubSessionType.SamePath => 
-                        $"新しい{GetSessionTypeName(result.TerminalType)}セッションを作成しました",
-                    SubSessionDialog.SubSessionType.NewFolder => 
-                        $"新しいフォルダ '{result.WorktreePath}' でセッションを作成しました",
-                    _ => "セッションを作成しました"
+                    SubSessionDialog.SubSessionType.CreateNew =>
+                        string.Format(L["Root.Toast.WorktreeCreatedFormat"], result.BranchName),
+                    SubSessionDialog.SubSessionType.AddExisting =>
+                        string.Format(L["Root.Toast.WorktreeAddedFormat"], result.BranchName),
+                    SubSessionDialog.SubSessionType.SamePath =>
+                        string.Format(L["Root.Toast.SamePathSessionCreatedFormat"], GetSessionTypeName(result.TerminalType)),
+                    SubSessionDialog.SubSessionType.NewFolder =>
+                        string.Format(L["Root.Toast.NewFolderSessionCreatedFormat"], result.WorktreePath),
+                    _ => L["Root.Toast.SessionCreated"]
                 };
 
                 toast?.ShowSuccess(successMessage);
             }
             else
             {
-                toast?.ShowError("セッション作成に失敗しました");
+                toast?.ShowError(L["Root.Toast.SessionCreateFailed"]);
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Sub-session creation failed");
-            toast?.ShowError($"セッション作成エラー: {ex.Message}");
+            toast?.ShowError(string.Format(L["Root.Toast.SessionCreateErrorFormat"], ex.Message));
         }
         finally
         {
@@ -1834,10 +1836,10 @@
     {
         return terminalType switch
         {
-            TerminalType.Terminal => "ターミナル",
+            TerminalType.Terminal => L["Root.SessionType.Terminal"],
             TerminalType.ClaudeCode => "Claude Code",
             TerminalType.GeminiCLI => "Gemini CLI",
-            _ => "セッション"
+            _ => L["Root.SessionType.Fallback"]
         };
     }
 
@@ -2141,7 +2143,7 @@
             StateHasChanged();
         }
 
-        toast?.ShowSuccess("セッション設定を保存しました");
+        toast?.ShowSuccess(L["Root.Toast.SessionSettingsSaved"]);
     }
 
     private async Task RefreshGitStatus(Guid sessionId)
@@ -2202,19 +2204,19 @@
                 // forceReinit で強制再初期化（activeSessionId を null にしないので BottomPanel は保持される）
                 await SelectSession(sessionId, forceReinit: true);
                 
-                toast?.ShowInfo("--continueオプションなしでセッションを再作成しました");
+                toast?.ShowInfo(L["Root.Toast.SessionRecreatedWithoutContinue"]);
             }
             else
             {
                 // Session recreation failed
-                toast?.ShowError("セッション再作成に失敗しました");
+                toast?.ShowError(L["Root.Toast.SessionRecreateFailed"]);
             }
         }
         catch (Exception ex)
         {
             // RecreateSessionWithoutContinue error
             Logger.LogError(ex, "Session recreation failed: SessionId={SessionId}", sessionId);
-            toast?.ShowError($"セッション再作成エラー: {ex.Message}");
+            toast?.ShowError(string.Format(L["Root.Toast.SessionRecreateErrorFormat"], ex.Message));
         }
     }
     

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -833,7 +833,7 @@
         if (sessionInfo != null && !string.IsNullOrEmpty(sessionInfo.FolderPath) && !Directory.Exists(sessionInfo.FolderPath))
         {
             Logger.LogWarning("セッション {SessionId} のディレクトリが存在しません: {FolderPath}", sessionId, sessionInfo.FolderPath);
-            toast?.ShowError(string.Format(L["Root.Toast.DirectoryNotFoundFormat"], sessionInfo.FolderPath));
+            toast?.ShowError(string.Format(L["Common.DirectoryNotFoundFormat"], sessionInfo.FolderPath));
             activeSessionId = null;
             return;
         }

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -105,7 +105,7 @@
                             <span class="@GetConnectionOpacityClass(session)">@session.GetDisplayName()</span>
                             @if (!string.IsNullOrEmpty(session.FolderPath) && !Directory.Exists(session.FolderPath))
                             {
-                                <span class="text-warning ms-1" title="@string.Format(L["SessionList.Badge.DirectoryNotFoundFormat"], session.FolderPath)">
+                                <span class="text-warning ms-1" title="@string.Format(L["Common.DirectoryNotFoundFormat"], session.FolderPath)">
                                     <i class="bi bi-exclamation-triangle-fill" style="font-size: 0.75rem;"></i>
                                 </span>
                             }

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -518,4 +518,32 @@
   <data name="BottomPanel.Tab.PowerShellFormat" xml:space="preserve"><value>PowerShell ({0})</value></data>
   <data name="BottomPanel.Tab.GenericFormat" xml:space="preserve"><value>Tab ({0})</value></data>
   <data name="BottomPanel.Tab.MemoFormat" xml:space="preserve"><value>Memo ({0})</value></data>
+
+  <!-- Root page -->
+  <data name="Root.NoSessionSelected" xml:space="preserve"><value>Select a session from the left sidebar</value></data>
+  <data name="Root.Placeholder.ClaudeCode" xml:space="preserve"><value>Type a message for Claude Code...</value></data>
+  <data name="Root.Placeholder.GeminiCLI" xml:space="preserve"><value>Type a message for Gemini CLI...</value></data>
+  <data name="Root.Placeholder.Terminal" xml:space="preserve"><value>Enter a command...</value></data>
+  <data name="Root.SessionType.Terminal" xml:space="preserve"><value>Terminal</value></data>
+  <data name="Root.SessionType.Fallback" xml:space="preserve"><value>Session</value></data>
+
+  <!-- Root: Toast messages -->
+  <data name="Root.Toast.SessionCreateErrorFormat" xml:space="preserve"><value>Session creation error: {0}</value></data>
+  <data name="Root.Toast.DirectoryNotFoundFormat" xml:space="preserve"><value>Directory not found: {0}</value></data>
+  <data name="Root.Toast.SessionInitErrorFormat" xml:space="preserve"><value>Session initialization error: {0}</value></data>
+  <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>Terminal disposed</value></data>
+  <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>Terminal dispose error: {0}</value></data>
+  <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>Terminal recreated</value></data>
+  <data name="Root.Toast.SelectSessionFirst" xml:space="preserve"><value>Please select this session first, then recreate the terminal</value></data>
+  <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>Terminal recreate error: {0}</value></data>
+  <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' created</value></data>
+  <data name="Root.Toast.WorktreeAddedFormat" xml:space="preserve"><value>Existing worktree '{0}' added</value></data>
+  <data name="Root.Toast.SamePathSessionCreatedFormat" xml:space="preserve"><value>New {0} session created</value></data>
+  <data name="Root.Toast.NewFolderSessionCreatedFormat" xml:space="preserve"><value>New session created in folder '{0}'</value></data>
+  <data name="Root.Toast.SessionCreated" xml:space="preserve"><value>Session created</value></data>
+  <data name="Root.Toast.SessionCreateFailed" xml:space="preserve"><value>Failed to create session</value></data>
+  <data name="Root.Toast.SessionSettingsSaved" xml:space="preserve"><value>Session settings saved</value></data>
+  <data name="Root.Toast.SessionRecreatedWithoutContinue" xml:space="preserve"><value>Session recreated without --continue option</value></data>
+  <data name="Root.Toast.SessionRecreateFailed" xml:space="preserve"><value>Failed to recreate session</value></data>
+  <data name="Root.Toast.SessionRecreateErrorFormat" xml:space="preserve"><value>Session recreate error: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -62,6 +62,7 @@
   <data name="Common.Create" xml:space="preserve"><value>Create</value></data>
   <data name="Common.Unspecified" xml:space="preserve"><value>Unspecified</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>Error: {0}</value></data>
+  <data name="Common.DirectoryNotFoundFormat" xml:space="preserve"><value>Directory not found: {0}</value></data>
 
   <!-- Settings Dialog -->
   <data name="Settings.Title" xml:space="preserve"><value>Settings</value></data>
@@ -465,7 +466,6 @@
   <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>Archived sessions</value></data>
   <data name="SessionList.Badge.Pinned" xml:space="preserve"><value>Pinned</value></data>
   <data name="SessionList.Badge.Notification" xml:space="preserve"><value>Processing completed</value></data>
-  <data name="SessionList.Badge.DirectoryNotFoundFormat" xml:space="preserve"><value>Directory not found: {0}</value></data>
   <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git branch</value></data>
   <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>Uncommitted changes</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>Remote control connected</value></data>
@@ -529,7 +529,6 @@
 
   <!-- Root: Toast messages -->
   <data name="Root.Toast.SessionCreateErrorFormat" xml:space="preserve"><value>Session creation error: {0}</value></data>
-  <data name="Root.Toast.DirectoryNotFoundFormat" xml:space="preserve"><value>Directory not found: {0}</value></data>
   <data name="Root.Toast.SessionInitErrorFormat" xml:space="preserve"><value>Session initialization error: {0}</value></data>
   <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>Terminal disposed</value></data>
   <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>Terminal dispose error: {0}</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -518,4 +518,32 @@
   <data name="BottomPanel.Tab.PowerShellFormat" xml:space="preserve"><value>PowerShell({0})</value></data>
   <data name="BottomPanel.Tab.GenericFormat" xml:space="preserve"><value>タブ({0})</value></data>
   <data name="BottomPanel.Tab.MemoFormat" xml:space="preserve"><value>メモ({0})</value></data>
+
+  <!-- Root page -->
+  <data name="Root.NoSessionSelected" xml:space="preserve"><value>左側からセッションを選択してください</value></data>
+  <data name="Root.Placeholder.ClaudeCode" xml:space="preserve"><value>Claude Code へのメッセージを入力…</value></data>
+  <data name="Root.Placeholder.GeminiCLI" xml:space="preserve"><value>Gemini CLI へのメッセージを入力…</value></data>
+  <data name="Root.Placeholder.Terminal" xml:space="preserve"><value>コマンドを入力…</value></data>
+  <data name="Root.SessionType.Terminal" xml:space="preserve"><value>ターミナル</value></data>
+  <data name="Root.SessionType.Fallback" xml:space="preserve"><value>セッション</value></data>
+
+  <!-- Root: Toast messages -->
+  <data name="Root.Toast.SessionCreateErrorFormat" xml:space="preserve"><value>セッション作成エラー: {0}</value></data>
+  <data name="Root.Toast.DirectoryNotFoundFormat" xml:space="preserve"><value>ディレクトリが見つかりません: {0}</value></data>
+  <data name="Root.Toast.SessionInitErrorFormat" xml:space="preserve"><value>セッション初期化エラー: {0}</value></data>
+  <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>ターミナルを破棄しました</value></data>
+  <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>ターミナル破棄エラー: {0}</value></data>
+  <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>ターミナルを再作成しました</value></data>
+  <data name="Root.Toast.SelectSessionFirst" xml:space="preserve"><value>このセッションを選択してからターミナルを再作成してください</value></data>
+  <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>ターミナル再作成エラー: {0}</value></data>
+  <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' を作成しました</value></data>
+  <data name="Root.Toast.WorktreeAddedFormat" xml:space="preserve"><value>既存の Worktree '{0}' を追加しました</value></data>
+  <data name="Root.Toast.SamePathSessionCreatedFormat" xml:space="preserve"><value>新しい {0} セッションを作成しました</value></data>
+  <data name="Root.Toast.NewFolderSessionCreatedFormat" xml:space="preserve"><value>新しいフォルダ '{0}' でセッションを作成しました</value></data>
+  <data name="Root.Toast.SessionCreated" xml:space="preserve"><value>セッションを作成しました</value></data>
+  <data name="Root.Toast.SessionCreateFailed" xml:space="preserve"><value>セッション作成に失敗しました</value></data>
+  <data name="Root.Toast.SessionSettingsSaved" xml:space="preserve"><value>セッション設定を保存しました</value></data>
+  <data name="Root.Toast.SessionRecreatedWithoutContinue" xml:space="preserve"><value>--continue オプションなしでセッションを再作成しました</value></data>
+  <data name="Root.Toast.SessionRecreateFailed" xml:space="preserve"><value>セッション再作成に失敗しました</value></data>
+  <data name="Root.Toast.SessionRecreateErrorFormat" xml:space="preserve"><value>セッション再作成エラー: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -62,6 +62,7 @@
   <data name="Common.Create" xml:space="preserve"><value>作成</value></data>
   <data name="Common.Unspecified" xml:space="preserve"><value>未指定</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>エラー: {0}</value></data>
+  <data name="Common.DirectoryNotFoundFormat" xml:space="preserve"><value>ディレクトリが見つかりません: {0}</value></data>
 
   <!-- Settings Dialog -->
   <data name="Settings.Title" xml:space="preserve"><value>設定</value></data>
@@ -465,7 +466,6 @@
   <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>アーカイブ済みセッション</value></data>
   <data name="SessionList.Badge.Pinned" xml:space="preserve"><value>ピン留め</value></data>
   <data name="SessionList.Badge.Notification" xml:space="preserve"><value>処理が完了しました</value></data>
-  <data name="SessionList.Badge.DirectoryNotFoundFormat" xml:space="preserve"><value>ディレクトリが見つかりません: {0}</value></data>
   <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git ブランチ</value></data>
   <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>未コミットの変更があります</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>リモートコントロール接続中</value></data>
@@ -529,7 +529,6 @@
 
   <!-- Root: Toast messages -->
   <data name="Root.Toast.SessionCreateErrorFormat" xml:space="preserve"><value>セッション作成エラー: {0}</value></data>
-  <data name="Root.Toast.DirectoryNotFoundFormat" xml:space="preserve"><value>ディレクトリが見つかりません: {0}</value></data>
   <data name="Root.Toast.SessionInitErrorFormat" xml:space="preserve"><value>セッション初期化エラー: {0}</value></data>
   <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>ターミナルを破棄しました</value></data>
   <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>ターミナル破棄エラー: {0}</value></data>
@@ -538,7 +537,7 @@
   <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>ターミナル再作成エラー: {0}</value></data>
   <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' を作成しました</value></data>
   <data name="Root.Toast.WorktreeAddedFormat" xml:space="preserve"><value>既存の Worktree '{0}' を追加しました</value></data>
-  <data name="Root.Toast.SamePathSessionCreatedFormat" xml:space="preserve"><value>新しい {0} セッションを作成しました</value></data>
+  <data name="Root.Toast.SamePathSessionCreatedFormat" xml:space="preserve"><value>新しい{0}セッションを作成しました</value></data>
   <data name="Root.Toast.NewFolderSessionCreatedFormat" xml:space="preserve"><value>新しいフォルダ '{0}' でセッションを作成しました</value></data>
   <data name="Root.Toast.SessionCreated" xml:space="preserve"><value>セッションを作成しました</value></data>
   <data name="Root.Toast.SessionCreateFailed" xml:space="preserve"><value>セッション作成に失敗しました</value></data>


### PR DESCRIPTION
## Summary
Phase 2C 最終として **Root.razor** の全ユーザー可視文字列を localize。本 PR マージで **Phase 2 (アプリ UI 多言語対応)** が完走。~24 キー追加、+87/-29 行、3 ファイル。

## 追加キー

### `Root.*` (6 キー): 基本 UI
- `NoSessionSelected`: セッション未選択時のプレースホルダー
- `Placeholder.{ClaudeCode,GeminiCLI,Terminal}`: 下部パネル入力欄 placeholder (`GetPlaceholderText` で terminal type に応じて切替)
- `SessionType.{Terminal,Fallback}`: セッション種別名 (`GetSessionTypeName`)

### `Root.Toast.*` (18 キー): トースト通知全種
- **成功** (5): TerminalDisposed / TerminalRecreated / SessionCreated / SessionSettingsSaved / SessionRecreatedWithoutContinue
- **失敗** (2): SessionCreateFailed / SessionRecreateFailed
- **警告** (1): SelectSessionFirst
- **format string** (6): `ex.Message` 等を埋め込む format
- **サブセッション成功 format** (4): WorktreeCreated / WorktreeAdded / SamePathSessionCreated / NewFolderSessionCreated

## 変更内容

### Razor markup
- セッション未選択時の `<p>` プレースホルダーを `@L[...]` に

### Code-behind
- `GetPlaceholderText()`: switch 式 3 分岐を L[...] 参照に (Claude Code / Gemini CLI / Terminal)
- `GetSessionTypeName()`: 「ターミナル」「セッション」を L[...] 参照に。 **Claude Code / Gemini CLI は製品名 (固有名詞) なのでリテラル維持**
- **15 箇所の toast 呼び出し** (ShowError/ShowSuccess/ShowWarning/ShowInfo) を全て `L[...]` or `string.Format(L[...], arg)` に置換
- SubSession 成功メッセージ 4 分岐 switch を format 化

## PlaceholderText コントラクト確立
Phase 2C-4 で BottomPanel の PlaceholderText parameter default (`"コマンドを入力..."`) を fallback として残置していた。本 PR で呼び出し元の Root.razor.GetPlaceholderText() が localize 済みになり、**呼び出し経路全体 (Root → BottomPanel → TextInputPanel) が culture 連動**。default 値は保険として残置。

## 意図的に残した日本語
- コメント多数 (メンテナ向け)
- `Logger.LogInformation/Warning/Error` 約 20 箇所: 開発ログ用途

## 動作確認済み
- [x] C# コンパイル成功 (obj/ DLL 更新)

## 検証手順
- [ ] dev 再起動 → 英語・日本語切替
- [ ] セッション未選択時のプレースホルダー表示
- [ ] 各 terminal type (Claude/Gemini/Terminal) の placeholder が culture 連動
- [ ] toast 通知 (セッション作成成功/失敗 / ターミナル破棄・再作成 / サブセッション 4 パターン成功 / 設定保存 等)
- [ ] エラー format の `{0}` 埋め込み (例外メッセージ等)

## 🎉 Phase 2 完走

本 PR マージで **TerminalHub のアプリ UI が完全に英日両言語で動作**。

Phase 2 全構成 (時系列):
- **2A**: i18n インフラ構築 + 設定ダイアログ 一般タブ ✅
- **2B-1/2/3**: 設定ダイアログ全 11 タブ + 横断メッセージ ✅
- **2C-1**: SessionCreateDialog shell ✅
- **2C-1b**: SessionOptionsSelector (shared) ✅
- **2C-2**: SessionSettingsDialog + SubSessionDialog ✅
- **2C-3**: SessionList + ArchivedSessionsDialog ✅
- **2C-4**: BottomPanel 3 コンポーネント ✅
- **2C-5**: Root.razor ← 本 PR ✅

## 次のステップ (Phase 2 完走後)
- `feat/i18n` → `master` 最終 PR → マージ → **v1.0.55 リリース**
- Phase 3 (反響次第): 中国語簡体字・繁体字・韓国語対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)