### PR TITLE
feat: アプリ UI 多言語対応 (Phase 2 完走) — 英語/日本語の完全サポート

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -10,7 +10,9 @@
 @using Microsoft.JSInterop
 @using Microsoft.Extensions.Configuration
 @using Microsoft.Extensions.Logging
+@using Microsoft.Extensions.Localization
 @inject ISessionManager SessionManager
+@inject IStringLocalizer<SharedResource> L
 @inject IJSRuntime JSRuntime
 @inject ILocalStorageService LocalStorageService
 @inject IConfiguration Configuration
@@ -167,7 +169,7 @@
                  style="display: @(hasActiveSession ? "none" : "flex");">
                 <div class="text-center text-muted">
                     <i class="bi bi-terminal" style="font-size: 4rem;"></i>
-                    <p class="mt-3">左側からセッションを選択してください</p>
+                    <p class="mt-3">@L["Root.NoSessionSelected"]</p>
                 </div>
             </div>
         </div>
@@ -776,7 +778,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Session creation failed");
-            toast?.ShowError($"セッション作成エラー: {ex.Message}");
+            toast?.ShowError(string.Format(L["Root.Toast.SessionCreateErrorFormat"], ex.Message));
         }
         finally
         {
@@ -831,7 +833,7 @@
         if (sessionInfo != null && !string.IsNullOrEmpty(sessionInfo.FolderPath) && !Directory.Exists(sessionInfo.FolderPath))
         {
             Logger.LogWarning("セッション {SessionId} のディレクトリが存在しません: {FolderPath}", sessionId, sessionInfo.FolderPath);
-            toast?.ShowError($"ディレクトリが見つかりません: {sessionInfo.FolderPath}");
+            toast?.ShowError(string.Format(L["Common.DirectoryNotFoundFormat"], sessionInfo.FolderPath));
             activeSessionId = null;
             return;
         }
@@ -844,7 +846,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "セッション {SessionId} の初期化に失敗", sessionId);
-            toast?.ShowError($"セッション初期化エラー: {ex.Message}");
+            toast?.ShowError(string.Format(L["Root.Toast.SessionInitErrorFormat"], ex.Message));
             activeSession = null;
         }
 
@@ -1496,14 +1498,14 @@
 
             if (showAlert)
             {
-                toast?.ShowSuccess("ターミナルを破棄しました");
+                toast?.ShowSuccess(L["Root.Toast.TerminalDisposed"]);
             }
         }
         catch (Exception ex)
         {
             if (showAlert)
             {
-                toast?.ShowError($"ターミナル破棄エラー: {ex.Message}");
+                toast?.ShowError(string.Format(L["Root.Toast.TerminalDisposeErrorFormat"], ex.Message));
             }
         }
     }
@@ -1532,16 +1534,16 @@
                     ConPtyConnection.SubscribeToSession(selectedSessionInfo.SessionId, selectedSessionInfo.ConPtySession);
                 }
 
-                toast?.ShowSuccess("ターミナルを再作成しました");
+                toast?.ShowSuccess(L["Root.Toast.TerminalRecreated"]);
             }
             else
             {
-                toast?.ShowWarning("このセッションを選択してからターミナルを再作成してください");
+                toast?.ShowWarning(L["Root.Toast.SelectSessionFirst"]);
             }
         }
         catch (Exception ex)
         {
-            toast?.ShowError($"ターミナル再作成エラー: {ex.Message}");
+            toast?.ShowError(string.Format(L["Root.Toast.TerminalRecreateErrorFormat"], ex.Message));
         }
     }
 
@@ -1642,9 +1644,9 @@
     {
         return terminalType switch
         {
-            TerminalType.ClaudeCode => "Claude Codeへのメッセージを入力...",
-            TerminalType.GeminiCLI => "Gemini CLIへのメッセージを入力...",
-            _ => "コマンドを入力..."
+            TerminalType.ClaudeCode => L["Root.Placeholder.ClaudeCode"],
+            TerminalType.GeminiCLI => L["Root.Placeholder.GeminiCLI"],
+            _ => L["Root.Placeholder.Terminal"]
         };
     }
 
@@ -1797,28 +1799,28 @@
 
                 string successMessage = result.OperationType switch
                 {
-                    SubSessionDialog.SubSessionType.CreateNew => 
-                        $"Worktree '{result.BranchName}' を作成しました",
-                    SubSessionDialog.SubSessionType.AddExisting => 
-                        $"既存のWorktree '{result.BranchName}' を追加しました",
-                    SubSessionDialog.SubSessionType.SamePath => 
-                        $"新しい{GetSessionTypeName(result.TerminalType)}セッションを作成しました",
-                    SubSessionDialog.SubSessionType.NewFolder => 
-                        $"新しいフォルダ '{result.WorktreePath}' でセッションを作成しました",
-                    _ => "セッションを作成しました"
+                    SubSessionDialog.SubSessionType.CreateNew =>
+                        string.Format(L["Root.Toast.WorktreeCreatedFormat"], result.BranchName),
+                    SubSessionDialog.SubSessionType.AddExisting =>
+                        string.Format(L["Root.Toast.WorktreeAddedFormat"], result.BranchName),
+                    SubSessionDialog.SubSessionType.SamePath =>
+                        string.Format(L["Root.Toast.SamePathSessionCreatedFormat"], GetSessionTypeName(result.TerminalType)),
+                    SubSessionDialog.SubSessionType.NewFolder =>
+                        string.Format(L["Root.Toast.NewFolderSessionCreatedFormat"], result.WorktreePath),
+                    _ => L["Root.Toast.SessionCreated"]
                 };
 
                 toast?.ShowSuccess(successMessage);
             }
             else
             {
-                toast?.ShowError("セッション作成に失敗しました");
+                toast?.ShowError(L["Root.Toast.SessionCreateFailed"]);
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Sub-session creation failed");
-            toast?.ShowError($"セッション作成エラー: {ex.Message}");
+            toast?.ShowError(string.Format(L["Root.Toast.SessionCreateErrorFormat"], ex.Message));
         }
         finally
         {
@@ -1834,10 +1836,10 @@
     {
         return terminalType switch
         {
-            TerminalType.Terminal => "ターミナル",
+            TerminalType.Terminal => L["Root.SessionType.Terminal"],
             TerminalType.ClaudeCode => "Claude Code",
             TerminalType.GeminiCLI => "Gemini CLI",
-            _ => "セッション"
+            _ => L["Root.SessionType.Fallback"]
         };
     }
 
@@ -2141,7 +2143,7 @@
             StateHasChanged();
         }
 
-        toast?.ShowSuccess("セッション設定を保存しました");
+        toast?.ShowSuccess(L["Root.Toast.SessionSettingsSaved"]);
     }
 
     private async Task RefreshGitStatus(Guid sessionId)
@@ -2202,19 +2204,19 @@
                 // forceReinit で強制再初期化（activeSessionId を null にしないので BottomPanel は保持される）
                 await SelectSession(sessionId, forceReinit: true);
                 
-                toast?.ShowInfo("--continueオプションなしでセッションを再作成しました");
+                toast?.ShowInfo(L["Root.Toast.SessionRecreatedWithoutContinue"]);
             }
             else
             {
                 // Session recreation failed
-                toast?.ShowError("セッション再作成に失敗しました");
+                toast?.ShowError(L["Root.Toast.SessionRecreateFailed"]);
             }
         }
         catch (Exception ex)
         {
             // RecreateSessionWithoutContinue error
             Logger.LogError(ex, "Session recreation failed: SessionId={SessionId}", sessionId);
-            toast?.ShowError($"セッション再作成エラー: {ex.Message}");
+            toast?.ShowError(string.Format(L["Root.Toast.SessionRecreateErrorFormat"], ex.Message));
         }
     }
     

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1165,7 +1165,7 @@
             bool confirmed;
             try
             {
-                confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"セッション「{sessionName}」を削除しますか？");
+                confirmed = await JSRuntime.InvokeAsync<bool>("confirm", string.Format(L["Root.Confirm.DeleteSessionFormat"], sessionName));
             }
             catch (JSDisconnectedException)
             {
@@ -1240,7 +1240,7 @@
         bool confirmed;
         try
         {
-            confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"セッション「{sessionName}」をアーカイブしますか？");
+            confirmed = await JSRuntime.InvokeAsync<bool>("confirm", string.Format(L["Root.Confirm.ArchiveSessionFormat"], sessionName));
         }
         catch (JSDisconnectedException)
         {

--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -1,9 +1,11 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
 @using TerminalHub.Components.Shared.BottomPanels
+@using Microsoft.Extensions.Localization
 @inject ISessionMemoRepository MemoRepository
 @inject IJSRuntime JSRuntime
 @inject ILogger<BottomPanel> Logger
+@inject IStringLocalizer<SharedResource> L
 @implements IAsyncDisposable
 
 <!-- タブヘッダー -->
@@ -37,7 +39,7 @@
                     <button type="button" class="btn-close ms-1" style="font-size: 0.6rem; opacity: 0.7;"
                             @onclick:stopPropagation="true"
                             @onclick="async () => await RemoveTab(tab.Id)"
-                            title="タブを閉じる">
+                            title="@L["BottomPanel.CloseTab"]">
                     </button>
                 }
             </button>
@@ -52,19 +54,19 @@
             <li>
                 <button class="dropdown-item" type="button"
                    @onclick="() => AddTab(BottomPanelTabType.CommandPrompt)">
-                    <i class="bi bi-terminal me-2"></i>コマンドプロンプトを追加
+                    <i class="bi bi-terminal me-2"></i>@L["BottomPanel.AddCommandPrompt"]
                 </button>
             </li>
             <li>
                 <button class="dropdown-item" type="button"
                    @onclick="() => AddTab(BottomPanelTabType.PowerShell)">
-                    <i class="bi bi-terminal-fill me-2"></i>PowerShellを追加
+                    <i class="bi bi-terminal-fill me-2"></i>@L["BottomPanel.AddPowerShell"]
                 </button>
             </li>
             <li>
                 <button class="dropdown-item" type="button"
                    @onclick="AddMemoTab">
-                    <i class="bi bi-journal-text me-2"></i>メモを追加
+                    <i class="bi bi-journal-text me-2"></i>@L["BottomPanel.AddMemo"]
                 </button>
             </li>
         </ul>
@@ -151,7 +153,7 @@
     {
         Tabs = new List<BottomPanelTabInfo>
         {
-            new() { Id = "default-text", Type = BottomPanelTabType.TextInput, DisplayName = "テキスト入力", IsDefault = true }
+            new() { Id = "default-text", Type = BottomPanelTabType.TextInput, DisplayName = L["BottomPanel.Tab.TextInputDefault"], IsDefault = true }
         };
         ActiveTabId = "default-text";
     }
@@ -237,10 +239,10 @@
         var count = Tabs.Count(t => t.Type == type);
         var displayName = type switch
         {
-            BottomPanelTabType.TextInput => $"テキスト入力({count + 1})",
-            BottomPanelTabType.CommandPrompt => $"コマンドプロンプト({count + 1})",
-            BottomPanelTabType.PowerShell => $"PowerShell({count + 1})",
-            _ => $"タブ({count + 1})"
+            BottomPanelTabType.TextInput => string.Format(L["BottomPanel.Tab.TextInputFormat"], count + 1),
+            BottomPanelTabType.CommandPrompt => string.Format(L["BottomPanel.Tab.CommandPromptFormat"], count + 1),
+            BottomPanelTabType.PowerShell => string.Format(L["BottomPanel.Tab.PowerShellFormat"], count + 1),
+            _ => string.Format(L["BottomPanel.Tab.GenericFormat"], count + 1)
         };
 
         var newTab = new BottomPanelTabInfo
@@ -266,7 +268,7 @@
         {
             MemoId = Guid.NewGuid(),
             SessionId = sessionId,
-            Title = $"メモ({visibleMemoCount + 1})",
+            Title = string.Format(L["BottomPanel.Tab.MemoFormat"], visibleMemoCount + 1),
             Body = "",
             CreatedAt = DateTime.Now,
             UpdatedAt = DateTime.Now,

--- a/TerminalHub/Components/Shared/BottomPanels/MemoPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/MemoPanel.razor
@@ -1,4 +1,6 @@
 @using TerminalHub.Models
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SharedResource> L
 @implements IAsyncDisposable
 
 <div class="p-3 h-100 d-flex flex-column">
@@ -6,7 +8,7 @@
               class="form-control flex-grow-1"
               @bind="bodyText"
               @bind:event="oninput"
-              placeholder="メモ... (Enter で改行、自動保存)"
+              placeholder="@L["MemoPanel.Placeholder"]"
               style="resize: none; font-family: 'Consolas', 'Monaco', monospace;">
     </textarea>
 </div>

--- a/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
@@ -1,9 +1,11 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
+@using Microsoft.Extensions.Localization
 @inject IInputHistoryService InputHistoryService
 @inject ITextRefineService TextRefine
 @inject ILogger<TextInputPanel> Logger
 @inject IJSRuntime JS
+@inject IStringLocalizer<SharedResource> L
 @implements IAsyncDisposable
 
 <div class="p-3 h-100 d-flex flex-column">
@@ -22,7 +24,7 @@
         <div class="mt-2 d-flex justify-content-between align-items-center">
             <div class="d-none d-md-flex align-items-center gap-3">
                 <div>
-                    <kbd>Enter</kbd> 送信 | <kbd>Shift+Enter</kbd> 改行 | <kbd>Ctrl+↑↓</kbd> 履歴
+                    <kbd>Enter</kbd> @L["TextInput.KeyHints.Send"] | <kbd>Shift+Enter</kbd> @L["TextInput.KeyHints.Newline"] | <kbd>Ctrl+↑↓</kbd> @L["TextInput.KeyHints.History"]
                 </div>
             </div>
             <div class="btn-group">
@@ -64,7 +66,7 @@
                             @ontouchstart="OnVoiceStart"
                             @ontouchstart:preventDefault
                             @ontouchend="OnVoiceStop"
-                            title="音声入力（押している間録音）">
+                            title="@L["TextInput.VoiceInput.Tooltip"]">
                         <i class="bi bi-mic"></i>
                     </button>
                 }
@@ -73,7 +75,7 @@
                     <button class="btn btn-secondary @(isRefining ? "active" : "")"
                             @onclick="OnRefineClick"
                             disabled="@(isRefining || string.IsNullOrWhiteSpace(inputText))"
-                            title="Claude Code で誤字脱字・表現を整える">
+                            title="@L["TextInput.Refine.Tooltip"]">
                         @if (isRefining)
                         {
                             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
@@ -82,11 +84,11 @@
                         {
                             <i class="bi bi-stars"></i>
                         }
-                        <span class="d-none d-md-inline ms-1">事前整形</span>
+                        <span class="d-none d-md-inline ms-1">@L["TextInput.Refine.Label"]</span>
                     </button>
                 }
                 <button class="btn btn-primary" @onclick="OnSendClick">
-                    <i class="bi bi-send d-none d-md-inline"></i> 送信
+                    <i class="bi bi-send d-none d-md-inline"></i> @L["TextInput.Send"]
                 </button>
             </div>
         </div>
@@ -274,11 +276,12 @@
 
     private string GetModeSwitchTooltip()
     {
-        return ClaudeModeSwitchKey switch
+        var keyLabel = ClaudeModeSwitchKey switch
         {
-            "shiftTab" => "モード切替 (Shift+Tab)",
-            _ => "モード切替 (Alt+M)"
+            "shiftTab" => "Shift+Tab",
+            _ => "Alt+M"
         };
+        return string.Format(L["TextInput.ModeSwitch.TooltipFormat"], keyLabel);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/TerminalHub/Components/Shared/Dialogs/ArchivedSessionsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/ArchivedSessionsDialog.razor
@@ -1,11 +1,13 @@
 @using System.IO
 @using TerminalHub.Models
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="@(IsVisible ? "display: block;" : "display: none;")" @onmousedown="OnBackdropMouseDown" @onmouseup="OnBackdropMouseUp">
     <div class="modal-dialog modal-dialog-centered modal-lg" @onclick:stopPropagation="true" @onmousedown:stopPropagation="true" @onmouseup:stopPropagation="true">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title"><i class="bi bi-archive me-2"></i>アーカイブ済みセッション</h5>
+                <h5 class="modal-title"><i class="bi bi-archive me-2"></i>@L["ArchivedSessions.Title"]</h5>
                 <button type="button" class="btn-close" @onclick="Close"></button>
             </div>
             <div class="modal-body" style="max-height: 60vh; overflow-y: auto;">
@@ -14,7 +16,7 @@
                     <div class="mb-3">
                         <div class="input-group input-group-sm">
                             <span class="input-group-text"><i class="bi bi-search"></i></span>
-                            <input type="text" class="form-control" placeholder="アーカイブを検索..."
+                            <input type="text" class="form-control" placeholder="@L["ArchivedSessions.SearchPlaceholder"]"
                                    value="@searchText" @oninput="OnSearchTextChanged" />
                             @if (!string.IsNullOrEmpty(searchText))
                             {
@@ -30,13 +32,13 @@
                             <input type="checkbox" class="form-check-input" id="selectAllArchived"
                                    checked="@IsAllSelected"
                                    @onchange="ToggleSelectAll" />
-                            <label class="form-check-label small" for="selectAllArchived">全選択</label>
+                            <label class="form-check-label small" for="selectAllArchived">@L["ArchivedSessions.SelectAll"]</label>
                         </div>
                         @if (selectedSessionIds.Count > 0)
                         {
-                            <span class="small text-muted me-2">@selectedSessionIds.Count 件選択中</span>
+                            <span class="small text-muted me-2">@string.Format(L["ArchivedSessions.SelectedCountFormat"], selectedSessionIds.Count)</span>
                             <button class="btn btn-outline-danger btn-sm" @onclick="ConfirmDeleteSelected">
-                                <i class="bi bi-trash me-1"></i>選択を削除
+                                <i class="bi bi-trash me-1"></i>@L["ArchivedSessions.DeleteSelected"]
                             </button>
                         }
                     </div>
@@ -56,7 +58,7 @@
                                             @session.GetDisplayName()
                                             @if (!string.IsNullOrEmpty(session.FolderPath) && !Directory.Exists(session.FolderPath))
                                             {
-                                                <span class="text-warning ms-1" title="ディレクトリが見つかりません">
+                                                <span class="text-warning ms-1" title="@L["ArchivedSessions.DirectoryNotFound"]">
                                                     <i class="bi bi-exclamation-triangle-fill" style="font-size: 0.75rem;"></i>
                                                 </span>
                                             }
@@ -71,14 +73,14 @@
                                             </div>
                                         }
                                         <div class="small text-muted mt-1">
-                                            <i class="bi bi-clock me-1"></i>アーカイブ日時: @(session.ArchivedAt?.ToString("yyyy/MM/dd HH:mm") ?? "不明")
+                                            <i class="bi bi-clock me-1"></i>@string.Format(L["ArchivedSessions.ArchivedAtFormat"], session.ArchivedAt?.ToString("yyyy/MM/dd HH:mm") ?? L["ArchivedSessions.DateUnknown"].Value)
                                         </div>
                                     </div>
                                     <div class="btn-group btn-group-sm">
-                                        <button class="btn btn-outline-success" @onclick="() => RestoreSession(session.SessionId)" title="復帰">
+                                        <button class="btn btn-outline-success" @onclick="() => RestoreSession(session.SessionId)" title="@L["ArchivedSessions.Restore"]">
                                             <i class="bi bi-arrow-counterclockwise"></i>
                                         </button>
-                                        <button class="btn btn-outline-danger" @onclick="() => ConfirmDelete(session)" title="完全に削除">
+                                        <button class="btn btn-outline-danger" @onclick="() => ConfirmDelete(session)" title="@L["ArchivedSessions.DeletePermanently"]">
                                             <i class="bi bi-trash"></i>
                                         </button>
                                     </div>
@@ -90,7 +92,7 @@
                     @if (!_cachedFilteredSessions.Any())
                     {
                         <div class="text-center text-muted py-3">
-                            <i class="bi bi-search"></i> 検索結果がありません
+                            <i class="bi bi-search"></i> @L["ArchivedSessions.NoResults"]
                         </div>
                     }
                 }
@@ -98,7 +100,7 @@
                 {
                     <div class="text-center text-muted py-5">
                         <i class="bi bi-archive" style="font-size: 3rem;"></i>
-                        <p class="mt-3">アーカイブ済みのセッションはありません</p>
+                        <p class="mt-3">@L["ArchivedSessions.Empty"]</p>
                     </div>
                 }
             </div>
@@ -106,10 +108,10 @@
                 @if (ArchivedSessions.Any())
                 {
                     <button type="button" class="btn btn-outline-danger" @onclick="ConfirmDeleteAll">
-                        <i class="bi bi-trash me-1"></i>すべて削除
+                        <i class="bi bi-trash me-1"></i>@L["ArchivedSessions.DeleteAll"]
                     </button>
                 }
-                <button type="button" class="btn btn-secondary" @onclick="Close">閉じる</button>
+                <button type="button" class="btn btn-secondary" @onclick="Close">@L["Common.Close"]</button>
             </div>
         </div>
     </div>
@@ -127,26 +129,26 @@
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">削除の確認</h5>
+                    <h5 class="modal-title">@L["ArchivedSessions.DeleteConfirm.Title"]</h5>
                 </div>
                 <div class="modal-body">
                     @if (deleteAllMode)
                     {
-                        <p>すべてのアーカイブ済みセッション（@ArchivedSessions.Count 件）を完全に削除しますか？</p>
+                        <p>@string.Format(L["ArchivedSessions.DeleteConfirm.AllFormat"], ArchivedSessions.Count)</p>
                     }
                     else if (deleteSelectedMode)
                     {
-                        <p>選択した @selectedSessionIds.Count 件のアーカイブ済みセッションを完全に削除しますか？</p>
+                        <p>@string.Format(L["ArchivedSessions.DeleteConfirm.SelectedFormat"], selectedSessionIds.Count)</p>
                     }
                     else
                     {
-                        <p>「@sessionToDelete?.GetDisplayName()」を完全に削除しますか？</p>
+                        <p>@string.Format(L["ArchivedSessions.DeleteConfirm.SingleFormat"], sessionToDelete?.GetDisplayName())</p>
                     }
-                    <p class="text-danger small"><i class="bi bi-exclamation-triangle me-1"></i>この操作は取り消せません。</p>
+                    <p class="text-danger small"><i class="bi bi-exclamation-triangle me-1"></i>@L["ArchivedSessions.DeleteConfirm.Irreversible"]</p>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="CancelDelete">キャンセル</button>
-                    <button type="button" class="btn btn-danger" @onclick="ExecuteDelete">削除する</button>
+                    <button type="button" class="btn btn-secondary" @onclick="CancelDelete">@L["Common.Cancel"]</button>
+                    <button type="button" class="btn btn-danger" @onclick="ExecuteDelete">@L["ArchivedSessions.DeleteConfirm.Execute"]</button>
                 </div>
             </div>
         </div>

--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -1,5 +1,6 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
+@using Microsoft.Extensions.Localization
 @using Microsoft.JSInterop
 @using System.IO
 @inject IJSRuntime JSRuntime
@@ -7,27 +8,28 @@
 @inject ILogger<SessionCreateDialog> Logger
 @inject IAppSettingsService AppSettingsService
 @inject IFolderPickerService FolderPicker
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsVisible && !showCreateFolderDialog ? "show" : "")" tabindex="-1" style="@(IsVisible && !showCreateFolderDialog ? "display: block;" : "display: none;")" @onmousedown="OnBackdropMouseDown" @onmouseup="OnBackdropMouseUp">
     <div class="modal-dialog modal-dialog-centered modal-lg" @onclick:stopPropagation="true" @onmousedown:stopPropagation="true" @onmouseup:stopPropagation="true">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">新しいセッションを作成</h5>
+                <h5 class="modal-title">@L["SessionCreate.Title"]</h5>
                 <button type="button" class="btn-close" @onclick="Cancel"></button>
             </div>
             <div class="modal-body">
                 <div class="mb-3">
-                    <label class="form-label">フォルダを選択</label>
+                    <label class="form-label">@L["SessionCreate.FolderLabel"]</label>
                     <div class="input-group">
-                        <input type="text" class="form-control" @bind="folderPath" placeholder="フォルダパスを入力または選択" />
+                        <input type="text" class="form-control" @bind="folderPath" placeholder="@L["SessionCreate.FolderPlaceholder"]" />
                         <div class="dropdown">
                             <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="bi bi-folder-open"></i> 参照
+                                <i class="bi bi-folder-open"></i> @L["SessionCreate.BrowseButton"]
                             </button>
                             <ul class="dropdown-menu dropdown-menu-end" style="max-height: 300px; overflow-y: auto;">
                                 @if (favoriteFolders.Any())
                                 {
-                                    <li><h6 class="dropdown-header">お気に入りフォルダ</h6></li>
+                                    <li><h6 class="dropdown-header">@L["SessionCreate.FavoriteFolders"]</h6></li>
                                     @foreach (var folder in favoriteFolders)
                                     {
                                         <li>
@@ -51,19 +53,19 @@
                                 {
                                     <li>
                                         <button class="dropdown-item" type="button" @onclick="() => SelectFolder(_cachedDefaultFolderPath)">
-                                            <i class="bi bi-folder-fill text-success me-2"></i>デフォルトフォルダ
+                                            <i class="bi bi-folder-fill text-success me-2"></i>@L["SessionCreate.DefaultFolder"]
                                         </button>
                                     </li>
                                 }
                                 <li>
                                     <button class="dropdown-item" type="button" @onclick="SelectUserHome">
-                                        <i class="bi bi-house-fill text-primary me-2"></i>ユーザーホーム
+                                        <i class="bi bi-house-fill text-primary me-2"></i>@L["SessionCreate.UserHome"]
                                     </button>
                                 </li>
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
                                     <button class="dropdown-item" type="button" @onclick="OpenNativeFolderPicker">
-                                        <i class="bi bi-folder-symlink text-secondary me-2"></i>フォルダを選択...
+                                        <i class="bi bi-folder-symlink text-secondary me-2"></i>@L["SessionCreate.PickFolder"]
                                     </button>
                                 </li>
                             </ul>
@@ -82,9 +84,9 @@
                                       CodexOptions="codexOptions" />
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" @onclick="Cancel">キャンセル</button>
+                <button type="button" class="btn btn-secondary" @onclick="Cancel">@L["Common.Cancel"]</button>
                 <button type="button" class="btn btn-primary" @onclick="CreateSession" disabled="@string.IsNullOrWhiteSpace(folderPath)">
-                    作成
+                    @L["Common.Create"]
                 </button>
             </div>
         </div>
@@ -103,16 +105,16 @@
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">フォルダの作成</h5>
+                    <h5 class="modal-title">@L["SessionCreate.CreateFolder.Title"]</h5>
                 </div>
                 <div class="modal-body">
-                    <p>指定されたフォルダが存在しません。</p>
+                    <p>@L["Settings.Message.FolderNotExists"]</p>
                     <p class="mb-2"><strong>@folderPath</strong></p>
-                    <p>このフォルダを作成しますか？</p>
+                    <p>@L["SessionCreate.CreateFolder.Question"]</p>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="CancelFolderCreation">キャンセル</button>
-                    <button type="button" class="btn btn-primary" @onclick="ConfirmFolderCreation">作成する</button>
+                    <button type="button" class="btn btn-secondary" @onclick="CancelFolderCreation">@L["Common.Cancel"]</button>
+                    <button type="button" class="btn btn-primary" @onclick="ConfirmFolderCreation">@L["SessionCreate.CreateFolder.Confirm"]</button>
                 </div>
             </div>
         </div>

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -1,19 +1,21 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
 @using Microsoft.Extensions.Configuration
+@using Microsoft.Extensions.Localization
 @using Microsoft.JSInterop
 @inject IConfiguration Configuration
 @inject ILocalStorageService LocalStorage
+@inject IStringLocalizer<SharedResource> L
 
 <div class="session-options">
     <div class="mb-3">
-        <label class="form-label d-block">ターミナルタイプ</label>
+        <label class="form-label d-block">@L["SessionOptions.TerminalType.Label"]</label>
         <div class="btn-group d-flex" role="group">
             <input type="radio" class="btn-check" name="@($"terminalType{UniqueId}")" id="@($"terminalType1{UniqueId}")"
                    checked="@(SelectedType == TerminalType.Terminal)"
                    @onchange="() => OnTerminalTypeChanged(TerminalType.Terminal)" autocomplete="off">
             <label class="btn btn-outline-primary" for="@($"terminalType1{UniqueId}")">
-                <i class="bi bi-terminal"></i> ターミナル
+                <i class="bi bi-terminal"></i> @L["SessionOptions.TerminalType.Terminal"]
             </label>
 
             @if (Configuration.GetValue<bool>("ExternalTools:UseClaudeCode", true))
@@ -51,31 +53,31 @@
     @if (SelectedType == TerminalType.ClaudeCode && Configuration.GetValue<bool>("ExternalTools:UseClaudeCode", true))
     {
         <div class="mb-3">
-            <label class="form-label">Claude Code オプション</label>
+            <label class="form-label">@L["SessionOptions.Claude.Header"]</label>
 
             <!-- 権限モード -->
             <div class="mt-2">
-                <label class="form-label small text-muted mb-1">権限モード</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Claude.PermissionMode.Label"]</label>
                 <div class="btn-group d-flex" role="group">
                     <input type="radio" class="btn-check" name="@($"claudePermMode{UniqueId}")" id="@($"claudePermBypass{UniqueId}")"
                            checked="@(ClaudeOptions.PermissionMode == "bypass")"
                            @onchange="@(() => ClaudeOptions.PermissionMode = "bypass")" autocomplete="off">
-                    <label class="btn btn-outline-danger btn-sm" for="@($"claudePermBypass{UniqueId}")" title="全操作を無条件で自動承認します（危険）">
-                        バイパス
+                    <label class="btn btn-outline-danger btn-sm" for="@($"claudePermBypass{UniqueId}")" title="@L["SessionOptions.Claude.PermissionMode.BypassTitle"]">
+                        @L["SessionOptions.Claude.PermissionMode.BypassLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"claudePermMode{UniqueId}")" id="@($"claudePermAuto{UniqueId}")"
                            checked="@(ClaudeOptions.PermissionMode == "auto")"
                            @onchange="@(() => ClaudeOptions.PermissionMode = "auto")" autocomplete="off">
-                    <label class="btn btn-outline-success btn-sm" for="@($"claudePermAuto{UniqueId}")" title="低リスク操作を自動承認し、高リスク操作のみ確認を求めます">
-                        オートモード
+                    <label class="btn btn-outline-success btn-sm" for="@($"claudePermAuto{UniqueId}")" title="@L["SessionOptions.Claude.PermissionMode.AutoTitle"]">
+                        @L["SessionOptions.Claude.PermissionMode.AutoLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"claudePermMode{UniqueId}")" id="@($"claudePermDefault{UniqueId}")"
                            checked="@(ClaudeOptions.PermissionMode == "default")"
                            @onchange="@(() => ClaudeOptions.PermissionMode = "default")" autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"claudePermDefault{UniqueId}")" title="全ての操作で都度確認を求めます">
-                        デフォルト
+                    <label class="btn btn-outline-primary btn-sm" for="@($"claudePermDefault{UniqueId}")" title="@L["SessionOptions.Claude.PermissionMode.DefaultTitle"]">
+                        @L["SessionOptions.Claude.PermissionMode.DefaultLabel"]
                     </label>
                 </div>
                 @if (!string.IsNullOrWhiteSpace(GetPermissionModeHelp()))
@@ -89,51 +91,51 @@
                 <div class="form-check mt-2">
                     <input class="form-check-input" type="checkbox" @bind="ClaudeOptions.Continue" id="@($"claudeContinue{UniqueId}")">
                     <label class="form-check-label" for="@($"claudeContinue{UniqueId}")">
-                        コンティニュー (--continue)
+                        @L["SessionOptions.Claude.Continue"]
                     </label>
                 </div>
             }
             <div class="form-check mt-2">
                 <input class="form-check-input" type="checkbox" @bind="ClaudeOptions.ChromeMode" id="@($"claudeChrome{UniqueId}")">
                 <label class="form-check-label" for="@($"claudeChrome{UniqueId}")">
-                    ブラウザ連携 (--chrome)
+                    @L["SessionOptions.Claude.Chrome"]
                 </label>
             </div>
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">追加引数</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="ClaudeOptions.ExtraArgs"
-                       placeholder="例: --model claude-sonnet-4-20250514 --verbose" />
-                <div class="form-text small">そのままClaude Codeに渡します</div>
+                       placeholder="@L["SessionOptions.Claude.ExtraArgsPlaceholder"]" />
+                <div class="form-text small">@L["SessionOptions.Claude.PassToCli"]</div>
             </div>
         </div>
     }
     else if (SelectedType == TerminalType.GeminiCLI && Configuration.GetValue<bool>("ExternalTools:UseGeminiCli", true))
     {
         <div class="mb-3">
-            <label class="form-label">Gemini CLI オプション</label>
+            <label class="form-label">@L["SessionOptions.Gemini.Header"]</label>
 
             <!-- Approval Mode -->
             <div class="mt-2">
-                <label class="form-label small text-muted mb-1">承認モード</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Gemini.ApprovalMode.Label"]</label>
                 <div class="btn-group d-flex" role="group">
                     <input type="radio" class="btn-check" name="@($"geminiApprovalMode{UniqueId}")" id="@($"geminiModeDefault{UniqueId}")"
                            checked="@(GeminiOptions.ApprovalMode == "default")"
                            @onchange=@(() => GeminiOptions.ApprovalMode = "default") autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"geminiModeDefault{UniqueId}")" title="ツール使用時に都度確認を求めます（デフォルト）">
+                    <label class="btn btn-outline-primary btn-sm" for="@($"geminiModeDefault{UniqueId}")" title="@L["SessionOptions.Gemini.ApprovalMode.DefaultTitle"]">
                         Default
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"geminiApprovalMode{UniqueId}")" id="@($"geminiModeAutoEdit{UniqueId}")"
                            checked="@(GeminiOptions.ApprovalMode == "auto_edit")"
                            @onchange=@(() => GeminiOptions.ApprovalMode = "auto_edit") autocomplete="off">
-                    <label class="btn btn-outline-success btn-sm" for="@($"geminiModeAutoEdit{UniqueId}")" title="ファイル編集など、安全な操作を自動で承認します">
+                    <label class="btn btn-outline-success btn-sm" for="@($"geminiModeAutoEdit{UniqueId}")" title="@L["SessionOptions.Gemini.ApprovalMode.AutoEditTitle"]">
                         Auto-Edit
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"geminiApprovalMode{UniqueId}")" id="@($"geminiModeYolo{UniqueId}")"
                            checked="@(GeminiOptions.ApprovalMode == "yolo")"
                            @onchange=@(() => GeminiOptions.ApprovalMode = "yolo") autocomplete="off">
-                    <label class="btn btn-outline-danger btn-sm" for="@($"geminiModeYolo{UniqueId}")" title="全ての操作を警告なしで自動的に承認します（危険）">
+                    <label class="btn btn-outline-danger btn-sm" for="@($"geminiModeYolo{UniqueId}")" title="@L["SessionOptions.Gemini.ApprovalMode.YoloTitle"]">
                         YOLO
                     </label>
                 </div>
@@ -148,10 +150,10 @@
                 <div class="form-check">
                     <input class="form-check-input" type="checkbox" @bind="GeminiOptions.SandboxMode" id="@($"geminiSandbox{UniqueId}")">
                     <label class="form-check-label" for="@($"geminiSandbox{UniqueId}")">
-                        サンドボックスモード (-s)
+                        @L["SessionOptions.Gemini.Sandbox"]
                     </label>
                     <div class="form-text text-muted small mt-0">
-                        <i class="bi bi-info-circle"></i> この機能を使用するには、Docker Desktopがインストールされている必要があります。
+                        <i class="bi bi-info-circle"></i> @L["SessionOptions.Gemini.SandboxHelp"]
                     </div>
                 </div>
 
@@ -160,7 +162,7 @@
                     <div class="form-check mt-2">
                         <input class="form-check-input" type="checkbox" @bind="GeminiOptions.Continue" id="@($"geminiContinue{UniqueId}")">
                         <label class="form-check-label" for="@($"geminiContinue{UniqueId}")">
-                            コンティニュー (--resume latest)
+                            @L["SessionOptions.Gemini.Continue"]
                         </label>
                     </div>
                 }
@@ -171,7 +173,7 @@
                 <div class="form-check">
                     <input class="form-check-input" type="checkbox" @bind="GeminiOptions.UseCustomModel" id="@($"geminiUseCustomModel{UniqueId}")">
                     <label class="form-check-label" for="@($"geminiUseCustomModel{UniqueId}")">
-                        モデルをカスタマイズ
+                        @L["SessionOptions.Gemini.UseCustomModel"]
                     </label>
                 </div>
 
@@ -179,7 +181,7 @@
                 {
                     <div class="mt-2 ps-4">
                         <div class="mb-2">
-                            <label for="@($"geminiModelSelect{UniqueId}")" class="form-label small text-muted mb-1">使用するモデル</label>
+                            <label for="@($"geminiModelSelect{UniqueId}")" class="form-label small text-muted mb-1">@L["SessionOptions.Gemini.ModelSelectLabel"]</label>
                             <select class="form-select form-select-sm" id="@($"geminiModelSelect{UniqueId}")" @bind="GeminiOptions.Model">
                                 @foreach (var model in geminiModelList)
                                 {
@@ -188,10 +190,10 @@
                             </select>
                         </div>
                         <div>
-                            <label class="form-label small text-muted mb-1">モデルリスト管理</label>
+                            <label class="form-label small text-muted mb-1">@L["SessionOptions.Gemini.ModelManagementLabel"]</label>
                             <div class="input-group input-group-sm">
-                                <input type="text" class="form-control" @bind="newGeminiModelName" placeholder="モデル名を追加..." @onkeydown="OnModelInputKeyDown" />
-                                <button class="btn btn-outline-secondary" type="button" @onclick="AddGeminiModel">追加</button>
+                                <input type="text" class="form-control" @bind="newGeminiModelName" placeholder="@L["SessionOptions.Gemini.ModelAddPlaceholder"]" @onkeydown="OnModelInputKeyDown" />
+                                <button class="btn btn-outline-secondary" type="button" @onclick="AddGeminiModel">@L["Common.Add"]</button>
                             </div>
                             <ul class="list-group mt-2" style="max-height: 150px; overflow-y: auto;">
                                 @foreach (var model in geminiModelList.OrderBy(m => m))
@@ -210,40 +212,40 @@
             </div>
             
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">追加引数</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="GeminiOptions.ExtraArgs"
-                       placeholder="例: --debug --allowed-tools shell,file" />
-                <div class="form-text small">そのままGemini CLIに渡します</div>
+                       placeholder="@L["SessionOptions.Gemini.ExtraArgsPlaceholder"]" />
+                <div class="form-text small">@L["SessionOptions.Gemini.PassToCli"]</div>
             </div>
         </div>
     }
     else if (SelectedType == TerminalType.CodexCLI && Configuration.GetValue<bool>("ExternalTools:UseCodexCli", true))
     {
         <div class="mb-3">
-            <label class="form-label">Codex CLI オプション</label>
+            <label class="form-label">@L["SessionOptions.Codex.Header"]</label>
 
             <div class="mt-2">
-                <label class="form-label small text-muted mb-1">実行モード</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Mode.Label"]</label>
                 <div class="btn-group d-flex" role="group">
                     <input type="radio" class="btn-check" name="@($"codexMode{UniqueId}")" id="@($"codexModeAuto{UniqueId}")"
                            checked="@(CodexOptions.Mode == "auto")"
                            @onchange="() => SetCodexMode(CodexMode.Auto)" autocomplete="off">
-                    <label class="btn btn-outline-success btn-sm" for="@($"codexModeAuto{UniqueId}")" title="編集＋ビルド/テスト等を基本自動化">
-                        Auto (推奨)
+                    <label class="btn btn-outline-success btn-sm" for="@($"codexModeAuto{UniqueId}")" title="@L["SessionOptions.Codex.Mode.AutoTitle"]">
+                        @L["SessionOptions.Codex.Mode.AutoLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"codexMode{UniqueId}")" id="@($"codexModeStandard{UniqueId}")"
                            checked="@(CodexOptions.Mode == "standard")"
                            @onchange="() => SetCodexMode(CodexMode.Standard)" autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"codexModeStandard{UniqueId}")" title="明示的な自動実行フラグを付けず、対話ベースで進行します">
-                        Interactive
+                    <label class="btn btn-outline-primary btn-sm" for="@($"codexModeStandard{UniqueId}")" title="@L["SessionOptions.Codex.Mode.StandardTitle"]">
+                        @L["SessionOptions.Codex.Mode.StandardLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"codexMode{UniqueId}")" id="@($"codexModeYolo{UniqueId}")"
                            checked="@(CodexOptions.Mode == "yolo")"
                            @onchange="() => SetCodexMode(CodexMode.Yolo)" autocomplete="off">
-                    <label class="btn btn-outline-danger btn-sm" for="@($"codexModeYolo{UniqueId}")" title="全自動実行（危険）。隔離環境推奨。">
-                        YOLO (危険)
+                    <label class="btn btn-outline-danger btn-sm" for="@($"codexModeYolo{UniqueId}")" title="@L["SessionOptions.Codex.Mode.YoloTitle"]">
+                        @L["SessionOptions.Codex.Mode.YoloLabel"]
                     </label>
                 </div>
                 @if (!string.IsNullOrWhiteSpace(GetCodexModeHelp()))
@@ -256,49 +258,49 @@
             {
                 <div class="alert alert-danger mt-2 py-2 small">
                     <i class="bi bi-exclamation-triangle-fill me-1"></i>
-                    <strong>警告:</strong> YOLOモードは隔離環境（WSL/Docker/VM/CI）でのみ使用してください。
+                    <strong>@L["SessionOptions.Codex.YoloWarning.Label"]</strong> @L["SessionOptions.Codex.YoloWarning.Message"]
                 </div>
             }
 
             <div class="form-check mt-3">
                 <input class="form-check-input" type="checkbox" @bind="CodexOptions.ResumeLast" id="@($"codexResumeLast{UniqueId}")">
                 <label class="form-check-label" for="@($"codexResumeLast{UniqueId}")">
-                    最新セッションを再開 (resume --last)
+                    @L["SessionOptions.Codex.ResumeLast"]
                 </label>
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">サンドボックスモード</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Sandbox.Label"]</label>
                 <div class="btn-group d-flex" role="group">
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxNone{UniqueId}")"
                            checked="@(string.IsNullOrEmpty(CodexOptions.SandboxMode))"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.Default)" autocomplete="off">
-                    <label class="btn btn-outline-secondary btn-sm" for="@($"codexSandboxNone{UniqueId}")" title="--sandbox を付けず、Codex CLI の既定値に任せます。">
-                        CLI既定
+                    <label class="btn btn-outline-secondary btn-sm" for="@($"codexSandboxNone{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.DefaultTitle"]">
+                        @L["SessionOptions.Codex.Sandbox.DefaultLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxReadOnly{UniqueId}")"
                            checked="@(CodexOptions.SandboxMode == "read-only")"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.ReadOnly)" autocomplete="off">
-                    <label class="btn btn-outline-success btn-sm" for="@($"codexSandboxReadOnly{UniqueId}")" title="読み取り専用。書き込みはブロック。">
-                        読み取り専用
+                    <label class="btn btn-outline-success btn-sm" for="@($"codexSandboxReadOnly{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.ReadOnlyTitle"]">
+                        @L["SessionOptions.Codex.Sandbox.ReadOnlyLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxWorkspace{UniqueId}")"
                            checked="@(CodexOptions.SandboxMode == "workspace-write")"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.WorkspaceWrite)" autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"codexSandboxWorkspace{UniqueId}")" title="ワークスペース内のみ書き込み可能。">
-                        ワークスペース (推奨)
+                    <label class="btn btn-outline-primary btn-sm" for="@($"codexSandboxWorkspace{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.WorkspaceTitle"]">
+                        @L["SessionOptions.Codex.Sandbox.WorkspaceLabel"]
                     </label>
 
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxFull{UniqueId}")"
                            checked="@(CodexOptions.SandboxMode == "danger-full-access")"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.FullAccess)" autocomplete="off">
-                    <label class="btn btn-outline-danger btn-sm" for="@($"codexSandboxFull{UniqueId}")" title="フルアクセス（危険）。">
-                        フルアクセス
+                    <label class="btn btn-outline-danger btn-sm" for="@($"codexSandboxFull{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.FullAccessTitle"]">
+                        @L["SessionOptions.Codex.Sandbox.FullAccessLabel"]
                     </label>
                 </div>
-                <div class="form-text small">外部通信やファイルアクセス範囲を制限</div>
+                <div class="form-text small">@L["SessionOptions.Codex.Sandbox.Help"]</div>
                 @if (!string.IsNullOrWhiteSpace(GetSandboxModeHelp()))
                 {
                     <div class="form-text small">@GetSandboxModeHelp()</div>
@@ -306,14 +308,14 @@
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">承認ポリシー</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.ApprovalPolicy.Label"]</label>
                 <select class="form-select form-select-sm" @bind="CodexOptions.ApprovalPolicy">
-                    <option value="">未指定</option>
+                    <option value="">@L["Common.Unspecified"]</option>
                     <option value="untrusted">untrusted</option>
                     <option value="on-request">on-request</option>
                     <option value="never">never</option>
                 </select>
-                <div class="form-text small">操作の承認レベル（--ask-for-approval）</div>
+                <div class="form-text small">@L["SessionOptions.Codex.ApprovalPolicy.Help"]</div>
                 @if (!string.IsNullOrWhiteSpace(GetApprovalPolicyHelp()))
                 {
                     <div class="form-text small">@GetApprovalPolicyHelp()</div>
@@ -321,13 +323,13 @@
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">ネットワークアクセス</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.NetworkAccess.Label"]</label>
                 <select class="form-select form-select-sm" @bind="CodexOptions.NetworkAccess">
-                    <option value="">未指定</option>
+                    <option value="">@L["Common.Unspecified"]</option>
                     <option value="restricted">restricted</option>
                     <option value="enabled">enabled</option>
                 </select>
-                <div class="form-text small">workspace-write時の通信許可（-c sandbox_workspace_write.network_access）。デフォルトは enabled。</div>
+                <div class="form-text small">@L["SessionOptions.Codex.NetworkAccess.Help"]</div>
                 @if (!string.IsNullOrWhiteSpace(GetNetworkAccessHelp()))
                 {
                     <div class="form-text small">@GetNetworkAccessHelp()</div>
@@ -335,46 +337,46 @@
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">プロファイル</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Profile.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="CodexOptions.Profile"
-                       placeholder="例: trusted" />
-                <div class="form-text small">Codex CLI の `--profile` を指定します</div>
+                       placeholder="@L["SessionOptions.Codex.Profile.Placeholder"]" />
+                <div class="form-text small">@L["SessionOptions.Codex.Profile.Help"]</div>
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">モデル</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Model.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="CodexOptions.Model"
-                       placeholder="例: gpt-5-codex" />
-                <div class="form-text small">Codex CLI の `--model` を指定します</div>
+                       placeholder="@L["SessionOptions.Codex.Model.Placeholder"]" />
+                <div class="form-text small">@L["SessionOptions.Codex.Model.Help"]</div>
             </div>
 
             <div class="form-check mt-3">
                 <input class="form-check-input" type="checkbox" @bind="CodexOptions.SearchEnabled" id="@($"codexSearch{UniqueId}")">
                 <label class="form-check-label" for="@($"codexSearch{UniqueId}")">
-                    Web 検索を有効化 (--search)
+                    @L["SessionOptions.Codex.Search"]
                 </label>
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">追加ディレクトリ</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.AdditionalDirs.Label"]</label>
                 <textarea class="form-control form-control-sm" @bind="CodexOptions.AdditionalDirectories"
-                          rows="3" placeholder="1行に1ディレクトリずつ指定"></textarea>
-                <div class="form-text small">各行を `--add-dir` として渡します</div>
+                          rows="3" placeholder="@L["SessionOptions.Codex.AdditionalDirs.Placeholder"]"></textarea>
+                <div class="form-text small">@L["SessionOptions.Codex.AdditionalDirs.Help"]</div>
             </div>
 
             <div class="mt-3">
-                <label class="form-label small text-muted mb-1">追加引数</label>
+                <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="CodexOptions.ExtraArgs"
-                       placeholder="例: --reasoning-effort high" />
-                <div class="form-text small">そのままCodex CLIに渡します</div>
+                       placeholder="@L["SessionOptions.Codex.ExtraArgsPlaceholder"]" />
+                <div class="form-text small">@L["SessionOptions.Codex.PassToCli"]</div>
             </div>
         </div>
     }
     else
     {
         <div class="mb-3">
-            <label class="form-label">起動コマンド（任意）</label>
-            <input type="text" class="form-control" @bind="StartupCommand" placeholder="例: cmd.exe, powershell.exe" />
+            <label class="form-label">@L["SessionOptions.Terminal.StartupCommand.Label"]</label>
+            <input type="text" class="form-control" @bind="StartupCommand" placeholder="@L["SessionOptions.Terminal.StartupCommand.Placeholder"]" />
         </div>
     }
 </div>
@@ -634,9 +636,9 @@
     {
         return ClaudeOptions.PermissionMode switch
         {
-            "bypass" => "全操作を無条件で自動承認します（--dangerously-skip-permissions）。",
-            "auto" => "低リスク操作を自動承認し、高リスク操作のみ確認を求めます（--enable-auto-mode）。",
-            "default" => "全ての操作で都度確認を求めます。",
+            "bypass" => L["SessionOptions.Claude.PermissionMode.HelpBypass"],
+            "auto" => L["SessionOptions.Claude.PermissionMode.HelpAuto"],
+            "default" => L["SessionOptions.Claude.PermissionMode.HelpDefault"],
             _ => ""
         };
     }
@@ -645,9 +647,9 @@
     {
         return GeminiOptions.ApprovalMode switch
         {
-            "default" => "ツール使用時に都度確認を求めます（デフォルト）。",
-            "auto_edit" => "ファイル編集など、安全な操作を自動で承認します。",
-            "yolo" => "全ての操作を警告なしで自動的に承認します（危険）。",
+            "default" => L["SessionOptions.Gemini.ApprovalMode.HelpDefault"],
+            "auto_edit" => L["SessionOptions.Gemini.ApprovalMode.HelpAutoEdit"],
+            "yolo" => L["SessionOptions.Gemini.ApprovalMode.HelpYolo"],
             _ => ""
         };
     }
@@ -656,9 +658,9 @@
     {
         return CodexOptions.ApprovalPolicy switch
         {
-            "untrusted" => "未信頼扱い。すべての操作で承認を求めます。",
-            "on-request" => "必要なときだけ承認を求めます（デフォルトに近い挙動）。",
-            "never" => "承認を求めません（危険）。",
+            "untrusted" => L["SessionOptions.Codex.ApprovalPolicy.HelpUntrusted"],
+            "on-request" => L["SessionOptions.Codex.ApprovalPolicy.HelpOnRequest"],
+            "never" => L["SessionOptions.Codex.ApprovalPolicy.HelpNever"],
             _ => ""
         };
     }
@@ -667,9 +669,9 @@
     {
         return CodexOptions.Mode switch
         {
-            "auto" => "推奨。`--full-auto` を付けて自動実行寄りに進めます。",
-            "standard" => "明示的な自動実行フラグを付けず、対話ベースで進行します。",
-            "yolo" => "全自動実行（危険）。隔離環境推奨です。",
+            "auto" => L["SessionOptions.Codex.Mode.HelpAuto"],
+            "standard" => L["SessionOptions.Codex.Mode.HelpStandard"],
+            "yolo" => L["SessionOptions.Codex.Mode.HelpYolo"],
             _ => ""
         };
     }
@@ -678,10 +680,10 @@
     {
         return CodexOptions.SandboxMode switch
         {
-            "" => "Codex CLI の既定値に任せます。",
-            "read-only" => "読み取り専用。書き込みはブロック。",
-            "workspace-write" => "ワークスペース内のみ書き込み可能。",
-            "danger-full-access" => "フルアクセス（危険）。",
+            "" => L["SessionOptions.Codex.Sandbox.HelpDefault"],
+            "read-only" => L["SessionOptions.Codex.Sandbox.ReadOnlyTitle"],
+            "workspace-write" => L["SessionOptions.Codex.Sandbox.WorkspaceTitle"],
+            "danger-full-access" => L["SessionOptions.Codex.Sandbox.FullAccessTitle"],
             _ => ""
         };
     }
@@ -690,8 +692,8 @@
     {
         return CodexOptions.NetworkAccess switch
         {
-            "enabled" => "ネットワークアクセスを許可します。",
-            "restricted" => "ネットワークアクセスを制限します。",
+            "enabled" => L["SessionOptions.Codex.NetworkAccess.HelpEnabled"],
+            "restricted" => L["SessionOptions.Codex.NetworkAccess.HelpRestricted"],
             _ => ""
         };
     }

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -1,5 +1,6 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
+@using Microsoft.Extensions.Localization
 @using Microsoft.JSInterop
 @using System.Diagnostics
 @using System.IO
@@ -7,13 +8,14 @@
 @inject IJSRuntime JSRuntime
 @inject ILogger<SessionSettingsDialog> Logger
 @inject ISessionMemoRepository MemoRepository
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
     <div class="modal-dialog modal-dialog-centered modal-lg">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">
-                    <i class="bi bi-gear me-2"></i>セッション設定
+                    <i class="bi bi-gear me-2"></i>@L["SessionSettings.Title"]
                 </h5>
                 <button type="button" class="btn-close" @onclick="OnCancel"></button>
             </div>
@@ -21,24 +23,24 @@
                 @if (sessionInfo != null)
                 {
                     <div class="mb-3">
-                        <h6 class="text-muted">セッション情報</h6>
+                        <h6 class="text-muted">@L["SessionSettings.Info.Header"]</h6>
                         <div class="row">
                             <div class="col-md-6">
-                                <small class="text-muted">セッション名:</small><br/>
+                                <small class="text-muted">@L["SessionSettings.Info.SessionName"]</small><br/>
                                 <strong>@sessionInfo.GetDisplayName()</strong>
                             </div>
                             <div class="col-md-6">
-                                <small class="text-muted">フォルダ:</small><br/>
+                                <small class="text-muted">@L["SessionSettings.Info.Folder"]</small><br/>
                                 <div class="d-flex align-items-start">
                                     <code class="flex-grow-1 me-2 text-break" style="word-wrap: break-word; overflow-wrap: break-word;">@sessionInfo.FolderPath</code>
                                     <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
                                             @onclick="() => CopyToClipboard(sessionInfo.FolderPath)"
-                                            title="フォルダパスをコピー">
+                                            title="@L["SessionSettings.Info.CopyFolderPath"]">
                                         <i class="bi bi-clipboard"></i>
                                     </button>
                                     <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0 ms-1"
                                             @onclick="() => OpenFolder(sessionInfo.FolderPath)"
-                                            title="フォルダを開く">
+                                            title="@L["SessionSettings.Info.OpenFolder"]">
                                         <i class="bi bi-folder2-open"></i>
                                     </button>
                                 </div>
@@ -46,12 +48,12 @@
                         </div>
                         <div class="row mt-2">
                             <div class="col-12">
-                                <small class="text-muted">セッションID:</small>
+                                <small class="text-muted">@L["SessionSettings.Info.SessionId"]</small>
                                 <div class="d-flex align-items-center">
                                     <code class="text-muted small">@sessionInfo.SessionId</code>
-                                    <button type="button" class="btn btn-link btn-sm text-muted ms-2" 
-                                            @onclick="() => CopyToClipboard(sessionInfo.SessionId.ToString())" 
-                                            title="セッションIDをコピー">
+                                    <button type="button" class="btn btn-link btn-sm text-muted ms-2"
+                                            @onclick="() => CopyToClipboard(sessionInfo.SessionId.ToString())"
+                                            title="@L["SessionSettings.Info.CopySessionId"]">
                                         <i class="bi bi-clipboard small"></i>
                                     </button>
                                 </div>
@@ -65,13 +67,13 @@
                             @if (!sessionInfo.ParentSessionId.HasValue)
                             {
                                 <button type="button" class="btn btn-outline-success btn-sm" @onclick="HandleCreateSubSession">
-                                    <i class="bi bi-plus-circle me-1"></i>サブセッションを作成
+                                    <i class="bi bi-plus-circle me-1"></i>@L["SessionSettings.CreateSubSession"]
                                 </button>
                             }
                             @if (anyMemoExists)
                             {
                                 <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="OpenMemoManagement">
-                                    <i class="bi bi-journal-text me-1"></i>メモ管理
+                                    <i class="bi bi-journal-text me-1"></i>@L["SessionSettings.OpenMemoManagement"]
                                 </button>
                             }
                         </div>
@@ -81,10 +83,10 @@
 
                     <!-- セッション名の変更 -->
                     <div class="mb-3">
-                        <label class="form-label">表示名</label>
-                        <input type="text" class="form-control" @bind="displayName" placeholder="セッションの表示名" />
+                        <label class="form-label">@L["SessionSettings.DisplayName.Label"]</label>
+                        <input type="text" class="form-control" @bind="displayName" placeholder="@L["SessionSettings.DisplayName.Placeholder"]" />
                         <small class="form-text text-muted">
-                            空白の場合はフォルダ名が使用されます
+                            @L["SessionSettings.DisplayName.Help"]
                         </small>
                     </div>
 
@@ -95,13 +97,13 @@
                             <div class="form-check d-inline-block">
                                 <input class="form-check-input" type="checkbox" @bind="isPinned" id="isPinnedCheck">
                                 <label class="form-check-label" for="isPinnedCheck">
-                                    <i class="bi bi-pin-fill me-1"></i>セッションをピン留め
+                                    <i class="bi bi-pin-fill me-1"></i>@L["SessionSettings.Pin.Label"]
                                 </label>
                             </div>
                             @if (isPinned)
                             {
                                 <div class="d-inline-block ms-3">
-                                    <label class="form-label mb-0 me-1 small">優先度:</label>
+                                    <label class="form-label mb-0 me-1 small">@L["SessionSettings.Pin.PriorityLabel"]</label>
                                     <input type="number" class="form-control form-control-sm d-inline-block" style="width: 80px;"
                                            @bind="pinPriority" placeholder="--" />
                                 </div>
@@ -111,10 +113,10 @@
 
                     <!-- メモ -->
                     <div class="mb-3">
-                        <label class="form-label">メモ</label>
-                        <textarea class="form-control" @bind="memo" placeholder="セッションに関するメモ" rows="3"></textarea>
+                        <label class="form-label">@L["SessionSettings.Memo.Label"]</label>
+                        <textarea class="form-control" @bind="memo" placeholder="@L["SessionSettings.Memo.Placeholder"]" rows="3"></textarea>
                         <small class="form-text text-muted">
-                            このセッションに関する任意のメモを記入できます
+                            @L["SessionSettings.Memo.Help"]
                         </small>
                     </div>
 
@@ -134,7 +136,7 @@
                 {
                     <div class="text-center">
                         <span class="spinner-border spinner-border-sm" role="status"></span>
-                        セッション情報を読み込み中...
+                        @L["SessionSettings.Loading"]
                     </div>
                 }
             </div>
@@ -142,14 +144,14 @@
                 <div class="form-check me-auto">
                     <input class="form-check-input" type="checkbox" @bind="restartSession" id="restartSessionCheck">
                     <label class="form-check-label" for="restartSessionCheck">
-                        変更を即座に適用（セッションを再起動）
+                        @L["SessionSettings.RestartOnSave"]
                     </label>
                 </div>
                 <button type="button" class="btn btn-secondary" @onclick="OnCancel">
-                    キャンセル
+                    @L["Common.Cancel"]
                 </button>
                 <button type="button" class="btn btn-primary" @onclick="SaveSettings" disabled="@(sessionInfo == null)">
-                    <i class="bi bi-check-circle me-2"></i>保存
+                    <i class="bi bi-check-circle me-2"></i>@L["SessionSettings.Save"]
                 </button>
             </div>
         </div>
@@ -332,7 +334,7 @@
                 var success = await SessionManager.RestartSessionAsync(SessionId.Value);
                 if (!success)
                 {
-                    errorMessage = "設定は保存されましたが、セッションの再起動に失敗しました。";
+                    errorMessage = L["SessionSettings.RestartFailed"];
                 }
             }
 
@@ -344,7 +346,7 @@
         }
         catch (Exception ex)
         {
-            errorMessage = $"設定の保存に失敗しました: {ex.Message}";
+            errorMessage = string.Format(L["SessionSettings.SaveErrorFormat"], ex.Message);
         }
     }
 

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -495,24 +495,24 @@
                         else if (activeTab == "export")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">データのエクスポート/インポート</h6>
+                                <h6 class="mb-3">@L["Settings.Export.Header"]</h6>
 
                                 <!-- エクスポート -->
                                 <div class="mb-4">
-                                    <h6 class="mb-2">エクスポート</h6>
+                                    <h6 class="mb-2">@L["Settings.Export.Export.Header"]</h6>
                                     <p class="text-muted small">
-                                        現在のストレージ（@("SQLite")）からセッション情報をJSONファイルとしてダウンロードします。
+                                        @string.Format(L["Settings.Export.Export.Help"], "SQLite")
                                     </p>
 
                                     <div class="alert alert-secondary mb-3">
                                         <small>
                                             <i class="bi bi-info-circle me-1"></i>
-                                            エクスポート対象: セッション情報（@SessionManager.GetAllSessions().Count() 件）
+                                            @string.Format(L["Settings.Export.Export.TargetInfo"], SessionManager.GetAllSessions().Count())
                                         </small>
                                     </div>
 
                                     <button class="btn btn-primary btn-sm" @onclick="ExportSettings" disabled="@(SessionManager.GetAllSessions().Count() == 0)">
-                                        <i class="bi bi-download me-1"></i>エクスポート
+                                        <i class="bi bi-download me-1"></i>@L["Settings.Export.Export.Button"]
                                     </button>
                                 </div>
 
@@ -520,10 +520,9 @@
 
                                 <!-- インポート -->
                                 <div>
-                                    <h6 class="mb-2">インポート</h6>
+                                    <h6 class="mb-2">@L["Settings.Export.Import.Header"]</h6>
                                     <p class="text-muted small">
-                                        JSONファイルを選択してセッション情報をインポートします。
-                                        現在のストレージ（@("SQLite")）に追加されます。
+                                        @string.Format(L["Settings.Export.Import.Help"], "SQLite")
                                     </p>
 
                                     <div class="mb-3">
@@ -533,14 +532,14 @@
                                     @if (importSessionCount > 0)
                                     {
                                         <div class="alert alert-info">
-                                            <h6 class="alert-heading">インポートプレビュー</h6>
+                                            <h6 class="alert-heading">@L["Settings.Export.Import.PreviewHeader"]</h6>
                                             <small>
-                                                <i class="bi bi-terminal me-1"></i>セッション情報: @importSessionCount 件
+                                                <i class="bi bi-terminal me-1"></i>@string.Format(L["Settings.Export.Import.PreviewSessions"], importSessionCount)
                                             </small>
                                         </div>
 
                                         <button class="btn btn-warning btn-sm" @onclick="ImportSettings">
-                                            <i class="bi bi-upload me-1"></i>インポート実行
+                                            <i class="bi bi-upload me-1"></i>@L["Settings.Export.Import.RunButton"]
                                         </button>
                                     }
                                 </div>
@@ -549,9 +548,9 @@
                         else if (activeTab == "commands")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">カスタムコマンド</h6>
+                                <h6 class="mb-3">@L["Settings.Commands.Header"]</h6>
                                 <small class="text-muted d-block mb-3">
-                                    ターミナル種別ごとにボタンバーに表示するコマンドを登録できます。
+                                    @L["Settings.Commands.Help"]
                                 </small>
 
                                 @foreach (var terminalType in new[] { "Terminal", "ClaudeCode", "GeminiCLI", "CodexCLI" })
@@ -570,12 +569,12 @@
                                         <div class="input-group input-group-sm mb-2">
                                             <select class="form-select" style="max-width: 110px;"
                                                     @bind="newCommandTypes[type]">
-                                                <option value="@CustomCommandType.Text">テキスト</option>
-                                                <option value="@CustomCommandType.KeySequence">キー</option>
+                                                <option value="@CustomCommandType.Text">@L["Settings.Commands.Type.Text"]</option>
+                                                <option value="@CustomCommandType.KeySequence">@L["Settings.Commands.Type.Key"]</option>
                                             </select>
                                             <input type="text" class="form-control"
                                                    @bind="newCommandTitles[type]" @bind:event="oninput"
-                                                   placeholder="タイトル（省略可）" style="max-width: 140px;" />
+                                                   placeholder="@L["Settings.Commands.TitlePlaceholder"]" style="max-width: 140px;" />
                                             @if (newCommandTypes.GetValueOrDefault(type, CustomCommandType.Text) == CustomCommandType.KeySequence)
                                             {
                                                 <select class="form-select" @bind="newCommandKeyNames[type]">
@@ -593,7 +592,7 @@
                                             {
                                                 <input type="text" class="form-control"
                                                        @bind="newCommandTexts[type]" @bind:event="oninput"
-                                                       placeholder="コマンド（例: /plan）" />
+                                                       placeholder="@L["Settings.Commands.CommandPlaceholder"]" />
                                                 <button class="btn btn-outline-primary" type="button"
                                                         @onclick="() => AddCommand(type)"
                                                         disabled="@string.IsNullOrWhiteSpace(newCommandTexts.GetValueOrDefault(type))">
@@ -626,7 +625,7 @@
                                                         <small class="d-flex align-items-center" style="min-width: 0; flex: 1;">
                                                             @if (canReorder)
                                                             {
-                                                                <i class="bi bi-grip-vertical me-2 text-muted drag-handle" title="ドラッグで並び替え"></i>
+                                                                <i class="bi bi-grip-vertical me-2 text-muted drag-handle" title="@L["Settings.Commands.DragToReorder"]"></i>
                                                             }
                                                             @if (isKey)
                                                             {
@@ -658,16 +657,16 @@
                         else if (activeTab == "remoteLaunch")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">リモート起動</h6>
+                                <h6 class="mb-3">@L["Settings.RemoteLaunch.Header"]</h6>
                                 <small class="text-muted d-block mb-3">
-                                    外出先のスマートフォンからClaude Codeセッションを起動し、Remote Control URLを取得できます。
+                                    @L["Settings.RemoteLaunch.Help"]
                                 </small>
 
                                 <div class="mb-3 form-check form-switch">
                                     <input class="form-check-input" type="checkbox" role="switch" @bind="remoteLaunchEnabled"
                                            @bind:after="OnRemoteLaunchEnabledChanged" id="remoteLaunchEnabled">
                                     <label class="form-check-label" for="remoteLaunchEnabled">
-                                        リモート起動を有効にする
+                                        @L["Settings.RemoteLaunch.Enable"]
                                     </label>
                                 </div>
 
@@ -679,13 +678,13 @@
                                                 @if (MqttService.IsBrokerConnected)
                                                 {
                                                     <span class="badge bg-success">
-                                                        <i class="bi bi-check-circle me-1"></i>接続中
+                                                        <i class="bi bi-check-circle me-1"></i>@L["Settings.RemoteLaunch.Connected"]
                                                     </span>
                                                 }
                                                 else
                                                 {
                                                     <span class="badge bg-danger">
-                                                        <i class="bi bi-x-circle me-1"></i>未接続
+                                                        <i class="bi bi-x-circle me-1"></i>@L["Settings.RemoteLaunch.Disconnected"]
                                                     </span>
                                                 }
                                                 @if (MqttService.LastConnectResult is not null)
@@ -700,7 +699,7 @@
                                                 }
                                                 else if (!MqttService.IsBrokerConnected)
                                                 {
-                                                    <small class="text-muted">接続試行中…</small>
+                                                    <small class="text-muted">@L["Settings.RemoteLaunch.Connecting"]</small>
                                                 }
                                             </div>
                                             <button class="btn btn-outline-primary btn-sm" type="button"
@@ -714,7 +713,7 @@
                                                 {
                                                     <i class="bi bi-broadcast me-1"></i>
                                                 }
-                                                疎通確認
+                                                @L["Settings.RemoteLaunch.DiagPing"]
                                             </button>
                                         </div>
                                         @if (!string.IsNullOrEmpty(diagPingMessage))
@@ -732,7 +731,7 @@
                                     @if (!string.IsNullOrEmpty(remoteLaunchTopicGuid))
                                     {
                                         <div class="mb-3">
-                                            <label class="form-label">アクセスURL</label>
+                                            <label class="form-label">@L["Settings.RemoteLaunch.AccessUrl"]</label>
                                             <div class="d-flex align-items-center gap-2">
                                                 <a href="@GetRemoteLaunchAccessUrl()" target="_blank"
                                                    class="text-truncate" title="@GetRemoteLaunchAccessUrl()">
@@ -740,23 +739,23 @@
                                                 </a>
                                                 <button class="btn btn-outline-secondary btn-sm" type="button"
                                                         @onclick="() => CopyToClipboardText(GetRemoteLaunchAccessUrl())"
-                                                        title="URLをコピー">
+                                                        title="@L["Settings.RemoteLaunch.CopyUrlTitle"]">
                                                     <i class="bi bi-clipboard"></i>
                                                 </button>
                                             </div>
                                             <div class="alert alert-warning mt-2 py-2">
                                                 <i class="bi bi-exclamation-triangle me-1"></i>
-                                                <small>このURLは他人に公開しないでください。URLを知っている人がセッションを起動できます。</small>
+                                                <small>@L["Settings.RemoteLaunch.UrlWarning"]</small>
                                             </div>
                                         </div>
                                     }
 
                                     <div class="mb-3">
-                                        <label class="form-label">パスワード（任意）</label>
+                                        <label class="form-label">@L["Settings.RemoteLaunch.PasswordLabel"]</label>
                                         <div class="input-group">
                                             <input type="password" class="form-control" value="@remoteLaunchPassword"
                                                    @oninput="OnRemoteLaunchPasswordInput"
-                                                   placeholder="設定するとアクセス時にパスワードが必要になります" />
+                                                   placeholder="@L["Settings.RemoteLaunch.PasswordPlaceholder"]" />
                                             @if (remoteLaunchPassword == Constants.MqttConstants.PasswordDummy)
                                             {
                                                 <button class="btn btn-outline-danger" type="button"
@@ -766,22 +765,22 @@
                                             }
                                         </div>
                                         <small class="text-muted">
-                                            空欄の場合はURLのみでアクセスできます。
+                                            @L["Settings.RemoteLaunch.PasswordHelp"]
                                         </small>
                                     </div>
 
                                     <div class="mb-3">
-                                        <label class="form-label small text-muted">トピックGUID</label>
+                                        <label class="form-label small text-muted">@L["Settings.RemoteLaunch.TopicGuid"]</label>
                                         <div class="input-group input-group-sm">
                                             <input type="text" class="form-control font-monospace text-muted"
                                                    value="@remoteLaunchTopicGuid" readonly />
                                             <button class="btn btn-outline-warning" type="button"
                                                     @onclick="RegenerateTopicGuid"
-                                                    title="GUIDを再発行（既存のアクセスURLが無効になります）">
+                                                    title="@L["Settings.RemoteLaunch.RegenerateGuidTitle"]">
                                                 <i class="bi bi-arrow-clockwise"></i>
                                             </button>
                                         </div>
-                                        <small class="text-muted">再発行すると既存のアクセスURLが無効になります。</small>
+                                        <small class="text-muted">@L["Settings.RemoteLaunch.RegenerateGuidHelp"]</small>
                                     </div>
                                 }
                             </div>
@@ -1171,20 +1170,20 @@
         if (isDiagPingRunning) return;
         isDiagPingRunning = true;
         diagPingExecutedAt = DateTime.Now;
-        diagPingMessage = "確認中...";
+        diagPingMessage = L["Settings.RemoteLaunch.DiagPingChecking"];
         diagPingSuccess = false;
         try
         {
             var result = await MqttService.DiagPingAsync(TimeSpan.FromSeconds(3));
             diagPingSuccess = result.Success;
             diagPingMessage = result.Success
-                ? $"OK (往復 {result.RoundTrip?.TotalMilliseconds:F0} ms)"
-                : $"NG: {result.FailureReason}";
+                ? string.Format(L["Settings.RemoteLaunch.DiagPingOkFormat"], result.RoundTrip?.TotalMilliseconds.ToString("F0"))
+                : string.Format(L["Settings.RemoteLaunch.DiagPingNgFormat"], result.FailureReason);
         }
         catch (Exception ex)
         {
             diagPingSuccess = false;
-            diagPingMessage = $"NG: {ex.Message}";
+            diagPingMessage = string.Format(L["Settings.RemoteLaunch.DiagPingNgFormat"], ex.Message);
         }
         finally
         {

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -788,11 +788,11 @@
                         else if (activeTab == "special")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">特殊設定</h6>
+                                <h6 class="mb-3">@L["Settings.Special.Header"]</h6>
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">Claude Code モード切替キー</h6>
-                                    <p class="text-muted small">Claude Codeでモード切替に使用するキーボードショートカットを選択します。</p>
+                                    <h6 class="mb-2">@L["Settings.Special.ClaudeModeKey.Header"]</h6>
+                                    <p class="text-muted small">@L["Settings.Special.ClaudeModeKey.Help"]</p>
 
                                     <div class="mb-3">
                                         <div class="form-check">
@@ -800,7 +800,7 @@
                                                    id="keyNone" value="none" checked="@(claudeModeSwitchKey == "none")"
                                                    @onchange="@(() => claudeModeSwitchKey = "none")">
                                             <label class="form-check-label" for="keyNone">
-                                                無し <span class="text-muted">（デフォルト）</span>
+                                                @L["Settings.Special.ClaudeModeKey.None"] <span class="text-muted">@L["Settings.Special.ClaudeModeKey.DefaultNote"]</span>
                                             </label>
                                         </div>
                                         <div class="form-check">
@@ -822,70 +822,68 @@
                                     </div>
                                     <p class="text-muted small mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        環境によってはAlt+Mが他の機能と競合する場合があります。その場合はShift+Tabをお試しください。
+                                        @L["Settings.Special.ClaudeModeKey.ConflictNote"]
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">音声入力</h6>
+                                    <h6 class="mb-2">@L["Settings.Special.VoiceInput.Header"]</h6>
                                     <div class="form-check form-switch">
                                         <input class="form-check-input" type="checkbox" @bind="voiceInputEnabled" id="voiceInputSwitch">
                                         <label class="form-check-label" for="voiceInputSwitch">
-                                            音声入力を有効にする（実験的）
+                                            @L["Settings.Special.VoiceInput.Enable"]
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        有効にすると、テキスト入力パネルにマイクボタンが表示されます。ボタンを押している間だけ音声認識が動作します（Chrome推奨）。
+                                        @L["Settings.Special.VoiceInput.Help"]
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">テキスト事前整形</h6>
+                                    <h6 class="mb-2">@L["Settings.Special.TextRefine.Header"]</h6>
                                     <div class="form-check form-switch">
                                         <input class="form-check-input" type="checkbox" @bind="textRefineEnabled" id="textRefineSwitch">
                                         <label class="form-check-label" for="textRefineSwitch">
-                                            事前整形ボタンを有効にする（実験的）
+                                            @L["Settings.Special.TextRefine.Enable"]
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        有効にすると、テキスト入力パネルに「<i class="bi bi-stars"></i> 事前整形」ボタンが表示されます。
-                                        押すと Claude Code CLI（Haiku モデル）で誤字脱字や表現の揺れを修正します。<br/>
-                                        整形指示は <code>%LOCALAPPDATA%\TerminalHub\refine-workdir\CLAUDE.md</code> を編集してカスタマイズ可能。
+                                        @((MarkupString)L["Settings.Special.TextRefine.HelpHtml"].Value)
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">開発ツール</h6>
+                                    <h6 class="mb-2">@L["Settings.Special.DevTools.Header"]</h6>
                                     <div class="form-check form-switch">
                                         <input class="form-check-input" type="checkbox" @bind="devToolsEnabled" id="devToolsSwitch">
                                         <label class="form-check-label" for="devToolsSwitch">
-                                            開発ツールを有効にする
+                                            @L["Settings.Special.DevTools.Enable"]
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        有効にすると、診断・バッファ・通知テストのタブが表示されます。
+                                        @L["Settings.Special.DevTools.Help"]
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">ログファイル</h6>
+                                    <h6 class="mb-2">@L["Settings.Special.Logs.Header"]</h6>
                                     <button class="btn btn-outline-secondary btn-sm" @onclick="OpenLogFolder">
-                                        <i class="bi bi-folder2-open me-1"></i>ログフォルダを開く
+                                        <i class="bi bi-folder2-open me-1"></i>@L["Settings.Special.Logs.OpenFolder"]
                                     </button>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        アプリケーションのログファイルが保存されているフォルダを開きます。
+                                        @L["Settings.Special.Logs.Help"]
                                     </p>
                                 </div>
                             </div>
@@ -893,25 +891,25 @@
                         else if (activeTab == "devDiagnose")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">診断情報</h6>
+                                <h6 class="mb-3">@L["Settings.DevDiagnose.Header"]</h6>
 
                                 <div class="mb-3">
                                     <button class="btn btn-info btn-sm me-2" @onclick="RefreshDiagnostics">
-                                        <i class="bi bi-arrow-clockwise me-1"></i>診断情報を更新
+                                        <i class="bi bi-arrow-clockwise me-1"></i>@L["Settings.DevDiagnose.Refresh"]
                                     </button>
                                     <button class="btn btn-warning btn-sm" @onclick="RunJSDiagnostics">
-                                        <i class="bi bi-bug me-1"></i>JS診断実行
+                                        <i class="bi bi-bug me-1"></i>@L["Settings.DevDiagnose.RunJs"]
                                     </button>
                                 </div>
 
                                 <div class="mb-3">
-                                    <h6>セッション一覧</h6>
+                                    <h6>@L["Settings.DevDiagnose.SessionList"]</h6>
                                     <div class="table-responsive" style="max-height: 200px; overflow-y: auto;">
                                         <table class="table table-sm table-striped">
                                             <thead>
                                                 <tr>
-                                                    <th>名前</th>
-                                                    <th>状態</th>
+                                                    <th>@L["Settings.DevDiagnose.ColName"]</th>
+                                                    <th>@L["Settings.DevDiagnose.ColStatus"]</th>
                                                     <th>ConPTY</th>
                                                 </tr>
                                             </thead>
@@ -927,7 +925,7 @@
                                                         </td>
                                                         <td>
                                                             <span class="badge @(session.ConPtySession != null ? "bg-primary" : "bg-warning")">
-                                                                @(session.ConPtySession != null ? "有" : "無")
+                                                                @(session.ConPtySession != null ? L["Settings.DevDiagnose.ConPtyPresent"] : L["Settings.DevDiagnose.ConPtyAbsent"])
                                                             </span>
                                                         </td>
                                                     </tr>
@@ -938,22 +936,22 @@
                                 </div>
 
                                 <div class="mb-3">
-                                    <h6>ターミナル情報</h6>
-                                    <p class="mb-1">JavaScript側ターミナル数: <span class="badge bg-info">@jsTerminalCount</span></p>
+                                    <h6>@L["Settings.DevDiagnose.TerminalInfo.Header"]</h6>
+                                    <p class="mb-1">@L["Settings.DevDiagnose.TerminalInfo.JsTerminalCount"] <span class="badge bg-info">@jsTerminalCount</span></p>
                                 </div>
 
                                 <hr />
 
-                                <h6 class="mb-3">ターミナル制御テスト</h6>
+                                <h6 class="mb-3">@L["Settings.DevDiagnose.TerminalTest.Header"]</h6>
                                 <div class="mb-3">
                                     <button class="btn btn-primary btn-sm me-2" @onclick="ScrollToBottom">
-                                        <i class="bi bi-arrow-down me-1"></i>最下部へ
+                                        <i class="bi bi-arrow-down me-1"></i>@L["Settings.DevDiagnose.TerminalTest.ScrollBottom"]
                                     </button>
                                     <button class="btn btn-secondary btn-sm me-2" @onclick="ScrollToTop">
-                                        <i class="bi bi-arrow-up me-1"></i>最上部へ
+                                        <i class="bi bi-arrow-up me-1"></i>@L["Settings.DevDiagnose.TerminalTest.ScrollTop"]
                                     </button>
                                     <button class="btn btn-info btn-sm" @onclick="GetScrollPosition">
-                                        <i class="bi bi-info-circle me-1"></i>位置取得
+                                        <i class="bi bi-info-circle me-1"></i>@L["Settings.DevDiagnose.TerminalTest.GetPosition"]
                                     </button>
                                 </div>
                                 <div class="mb-3">
@@ -964,16 +962,16 @@
                         else if (activeTab == "devBuffer")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">バッファダンプ</h6>
-                                <p class="text-muted small mb-3">セッションの出力バッファ（最大2MB）をファイルにダウンロードします。</p>
+                                <h6 class="mb-3">@L["Settings.DevBuffer.Header"]</h6>
+                                <p class="text-muted small mb-3">@L["Settings.DevBuffer.Help"]</p>
 
                                 <div class="mb-3">
-                                    <label class="form-label">セッション選択</label>
+                                    <label class="form-label">@L["Settings.DevBuffer.SelectLabel"]</label>
                                     <select class="form-select" @bind="selectedSessionForBuffer">
-                                        <option value="">-- セッションを選択 --</option>
+                                        <option value="">@L["Settings.DevBuffer.SelectPlaceholder"]</option>
                                         @foreach (var session in GetAvailableSessions())
                                         {
-                                            var bufferSize = session.TerminalBufferSize > 0 ? $" ({FormatBytes(session.TerminalBufferSize)})" : " (空)";
+                                            var bufferSize = session.TerminalBufferSize > 0 ? $" ({FormatBytes(session.TerminalBufferSize)})" : $" {L["Settings.DevBuffer.Empty"]}";
                                             <option value="@session.SessionId">@session.GetDisplayName()@bufferSize</option>
                                         }
                                     </select>
@@ -982,23 +980,23 @@
                                 @if (GetSelectedBufferSession() is SessionInfo selectedSession)
                                 {
                                     <div class="mb-3">
-                                        <span class="badge bg-info me-2">バッファ: @FormatBytes(selectedSession.TerminalBufferSize)</span>
-                                        <span class="badge bg-secondary">ステータス履歴: @selectedSession.StatusChangeHistoryCount 件</span>
+                                        <span class="badge bg-info me-2">@string.Format(L["Settings.DevBuffer.BufferFormat"], FormatBytes(selectedSession.TerminalBufferSize))</span>
+                                        <span class="badge bg-secondary">@string.Format(L["Settings.DevBuffer.StatusHistoryFormat"], selectedSession.StatusChangeHistoryCount)</span>
                                     </div>
                                 }
 
                                 <div class="mb-3">
                                     <button class="btn btn-primary btn-sm me-2" @onclick="DownloadBuffer"
                                             disabled="@(string.IsNullOrEmpty(selectedSessionForBuffer) || GetSelectedBufferSession()?.TerminalBufferSize == 0)">
-                                        <i class="bi bi-download me-1"></i>バッファ
+                                        <i class="bi bi-download me-1"></i>@L["Settings.DevBuffer.DownloadBuffer"]
                                     </button>
                                     <button class="btn btn-outline-primary btn-sm me-2" @onclick="DownloadBufferClean"
                                             disabled="@(string.IsNullOrEmpty(selectedSessionForBuffer) || GetSelectedBufferSession()?.TerminalBufferSize == 0)">
-                                        <i class="bi bi-file-text me-1"></i>バッファ (ANSI除去)
+                                        <i class="bi bi-file-text me-1"></i>@L["Settings.DevBuffer.DownloadBufferClean"]
                                     </button>
                                     <button class="btn btn-outline-info btn-sm" @onclick="DownloadStatusHistory"
                                             disabled="@(string.IsNullOrEmpty(selectedSessionForBuffer) || GetSelectedBufferSession()?.StatusChangeHistoryCount == 0)">
-                                        <i class="bi bi-clock-history me-1"></i>ステータス履歴 JSON
+                                        <i class="bi bi-clock-history me-1"></i>@L["Settings.DevBuffer.DownloadStatusHistory"]
                                     </button>
                                 </div>
 
@@ -1010,19 +1008,19 @@
                         else if (activeTab == "devNotify")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">通知テスト</h6>
+                                <h6 class="mb-3">@L["Settings.DevNotify.Header"]</h6>
 
                                 <div class="mb-3">
-                                    <label class="form-label">テスト用経過時間（秒）</label>
+                                    <label class="form-label">@L["Settings.DevNotify.TestElapsedLabel"]</label>
                                     <input type="number" class="form-control" @bind="testElapsedSeconds" min="1" max="300" style="max-width: 150px;" />
                                 </div>
 
                                 <div class="mb-3">
                                     <button class="btn btn-warning btn-sm me-2" @onclick="TestBrowserNotification">
-                                        <i class="bi bi-bell me-1"></i>ブラウザ通知テスト
+                                        <i class="bi bi-bell me-1"></i>@L["Settings.DevNotify.TestBrowser"]
                                     </button>
                                     <button class="btn btn-success btn-sm" @onclick="TestWebHookNotification">
-                                        <i class="bi bi-send me-1"></i>WebHook通知テスト
+                                        <i class="bi bi-send me-1"></i>@L["Settings.DevNotify.TestWebhook"]
                                     </button>
                                 </div>
 
@@ -1121,11 +1119,13 @@
     private bool devToolsEnabled = false;
     private List<SessionInfo> diagnosticSessions = new();
     private int jsTerminalCount = 0;
-    private string scrollInfo = "スクロール位置情報が表示されます";
+    // localize 済みの初期メッセージは OnInitialized で設定する (この時点では L インジェクト未完了のため)
+    private string scrollInfo = "";
     private string selectedSessionForBuffer = "";
     private string bufferResult = "";
     private int testElapsedSeconds = 10;
-    private string notificationTestResult = "テスト結果がここに表示されます";
+    // localize 済みの初期メッセージは OnInitialized で設定する (この時点では L インジェクト未完了のため)
+    private string notificationTestResult = "";
 
     [Parameter] public EventCallback<string> OnSessionSortModeChanged { get; set; }
     [Parameter] public string SessionSortMode { get; set; } = "lastAccessed";
@@ -1152,6 +1152,9 @@
         // Blazor Server の初期レンダー時には UseRequestLocalization middleware が
         // 既に CultureInfo.CurrentUICulture を差し替え済みなので、ここで確定値を拾う。
         currentCulture = System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+        // localize 済みの初期値を設定 (field initializer では IStringLocalizer L がまだ inject されていない)
+        scrollInfo = L["Settings.DevDiagnose.ScrollInfo.Initial"];
+        notificationTestResult = L["Settings.DevNotify.Result.Initial"];
     }
 
     public void Dispose()
@@ -1305,12 +1308,12 @@
             versionCheckResult = await VersionCheckService.CheckForUpdatesAsync();
             if (versionCheckResult == null)
             {
-                versionCheckError = "バージョン情報を取得できませんでした";
+                versionCheckError = L["Settings.Message.VersionFetchFailed"];
             }
         }
         catch (Exception ex)
         {
-            versionCheckError = $"チェックに失敗しました: {ex.Message}";
+            versionCheckError = string.Format(L["Settings.Message.VersionCheckErrorFormat"], ex.Message);
         }
         finally
         {
@@ -1347,18 +1350,18 @@
 
             if (granted)
             {
-                saveMessage = "通知が許可されました";
+                saveMessage = L["Settings.Message.PermissionGranted"];
                 saveSuccess = true;
             }
             else
             {
-                saveMessage = "通知が拒否されました";
+                saveMessage = L["Settings.Message.PermissionDenied"];
                 saveSuccess = false;
             }
         }
         catch (Exception ex)
         {
-            saveMessage = $"エラー: {ex.Message}";
+            saveMessage = string.Format(L["Common.ErrorFormat"], ex.Message);
             saveSuccess = false;
         }
     }
@@ -1371,7 +1374,7 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"エラー: {ex.Message}";
+            saveMessage = string.Format(L["Common.ErrorFormat"], ex.Message);
             saveSuccess = false;
         }
     }
@@ -1396,7 +1399,7 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"フォルダを開けませんでした: {ex.Message}";
+            saveMessage = string.Format(L["Settings.Message.OpenFolderErrorFormat"], ex.Message);
             saveSuccess = false;
             StateHasChanged();
         }
@@ -1409,14 +1412,14 @@
             // 設定値の検証
             if (thresholdSeconds < 0)
             {
-                saveMessage = "通知時間は0以上にしてください";
+                saveMessage = L["Settings.Message.ThresholdNegative"];
                 saveSuccess = false;
                 return;
             }
 
             if (webHookEnabled && string.IsNullOrWhiteSpace(webHookUrl))
             {
-                saveMessage = "WebHook URLを入力してください";
+                saveMessage = L["Settings.Message.WebhookUrlRequired"];
                 saveSuccess = false;
                 return;
             }
@@ -1435,7 +1438,7 @@
                 // パスの存在チェック
                 if (!Directory.Exists(defaultFolderPath))
                 {
-                    defaultFolderPathWarning = "指定されたパスが存在しません";
+                    defaultFolderPathWarning = L["Settings.Message.PathNotExists"];
                 }
             }
 
@@ -1536,7 +1539,7 @@
                 await MqttService.ConnectAsync(remoteLaunchTopicGuid);
             }
 
-            saveMessage = "設定を保存しました";
+            saveMessage = L["Settings.Message.SaveSuccess"];
             saveSuccess = true;
 
             // 3秒後にメッセージを消す
@@ -1552,11 +1555,11 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"保存エラー: {ex.Message}";
+            saveMessage = string.Format(L["Settings.Message.SaveErrorFormat"], ex.Message);
             saveSuccess = false;
         }
     }
-    
+
     private void AddFavoriteFolder()
     {
         if (string.IsNullOrWhiteSpace(newFavoriteFolder)) return;
@@ -1568,13 +1571,13 @@
 
         if (!Directory.Exists(folder))
         {
-            favoriteFolderError = "指定されたフォルダが存在しません";
+            favoriteFolderError = L["Settings.Message.FolderNotExists"];
             return;
         }
 
         if (favoriteFolders.Contains(folder))
         {
-            favoriteFolderError = "このフォルダは既に追加されています";
+            favoriteFolderError = L["Settings.Message.FolderDuplicate"];
             return;
         }
 
@@ -1927,16 +1930,16 @@
             await JSRuntime.InvokeVoidAsync("terminalHubHelpers.downloadJson",
                 json, $"terminalhub_sessions_{DateTime.Now:yyyyMMdd_HHmmss}.json");
 
-            saveMessage = $"セッション情報（{sessions.Count}件）をエクスポートしました";
+            saveMessage = string.Format(L["Settings.Message.ExportSuccessFormat"], sessions.Count);
             saveSuccess = true;
         }
         catch (Exception ex)
         {
-            saveMessage = $"エクスポートエラー: {ex.Message}";
+            saveMessage = string.Format(L["Settings.Message.ExportErrorFormat"], ex.Message);
             saveSuccess = false;
         }
     }
-    
+
     private async Task LoadImportFile(InputFileChangeEventArgs e)
     {
         try
@@ -1944,7 +1947,7 @@
             var file = e.File;
             if (file.ContentType != "application/json")
             {
-                saveMessage = "JSONファイルを選択してください";
+                saveMessage = L["Settings.Message.JsonFileRequired"];
                 saveSuccess = false;
                 return;
             }
@@ -1967,7 +1970,7 @@
             }
             else
             {
-                saveMessage = "セッション情報が見つかりませんでした";
+                saveMessage = L["Settings.Message.SessionsNotFound"];
                 saveSuccess = false;
                 importSessions = null;
                 importSessionCount = 0;
@@ -1975,7 +1978,7 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"ファイル読み込みエラー: {ex.Message}";
+            saveMessage = string.Format(L["Settings.Message.FileReadErrorFormat"], ex.Message);
             saveSuccess = false;
             importSessions = null;
             importSessionCount = 0;
@@ -2006,7 +2009,7 @@
                 }
             }
 
-            saveMessage = $"インポートが完了しました（{addedCount}件追加、{importSessions.Count - addedCount}件は重複のためスキップ）。ページを再読み込みしてください。";
+            saveMessage = string.Format(L["Settings.Message.ImportResultFormat"], addedCount, importSessions.Count - addedCount);
             saveSuccess = true;
             importSessions = null;
             importSessionCount = 0;
@@ -2014,7 +2017,7 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"インポートエラー: {ex.Message}";
+            saveMessage = string.Format(L["Settings.Message.ImportErrorFormat"], ex.Message);
             saveSuccess = false;
         }
     }
@@ -2051,11 +2054,11 @@
         try
         {
             await JSRuntime.InvokeVoidAsync("terminalHubHelpers.scrollAllTerminalsToBottom");
-            scrollInfo = $"最下部にスクロールしました - {DateTime.Now:HH:mm:ss}";
+            scrollInfo = string.Format(L["Settings.DevDiagnose.ScrollInfo.BottomFormat"], DateTime.Now.ToString("HH:mm:ss"));
         }
         catch (Exception ex)
         {
-            scrollInfo = $"エラー: {ex.Message}";
+            scrollInfo = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 
@@ -2064,11 +2067,11 @@
         try
         {
             await JSRuntime.InvokeVoidAsync("terminalHubHelpers.scrollAllTerminalsToTop");
-            scrollInfo = $"最上部にスクロールしました - {DateTime.Now:HH:mm:ss}";
+            scrollInfo = string.Format(L["Settings.DevDiagnose.ScrollInfo.TopFormat"], DateTime.Now.ToString("HH:mm:ss"));
         }
         catch (Exception ex)
         {
-            scrollInfo = $"エラー: {ex.Message}";
+            scrollInfo = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 
@@ -2077,11 +2080,12 @@
         try
         {
             var result = await JSRuntime.InvokeAsync<object>("terminalHubHelpers.getAllTerminalScrollPositions");
-            scrollInfo = $"スクロール位置: {System.Text.Json.JsonSerializer.Serialize(result)} - {DateTime.Now:HH:mm:ss}";
+            scrollInfo = string.Format(L["Settings.DevDiagnose.ScrollInfo.PositionFormat"],
+                System.Text.Json.JsonSerializer.Serialize(result), DateTime.Now.ToString("HH:mm:ss"));
         }
         catch (Exception ex)
         {
-            scrollInfo = $"エラー: {ex.Message}";
+            scrollInfo = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 
@@ -2126,7 +2130,9 @@
                 SessionName = sessionInfo.GetDisplayName(),
                 SessionId = sessionInfo.SessionId
             };
-            var header = "--- バッファ情報 ---\n" + System.Text.Json.JsonSerializer.Serialize(bufferInfo, new System.Text.Json.JsonSerializerOptions { WriteIndented = true }) + "\n\n--- バッファ内容 ---\n";
+            var header = $"--- {L["Settings.DevBuffer.HeaderBufferInfo"]} ---\n"
+                + System.Text.Json.JsonSerializer.Serialize(bufferInfo, new System.Text.Json.JsonSerializerOptions { WriteIndented = true })
+                + $"\n\n--- {L["Settings.DevBuffer.HeaderBufferContent"]} ---\n";
 
             return Task.FromResult<(string?, string, string)?>(
                 (header + content, $"buffer_{SanitizeFilename(sessionInfo.GetDisplayName())}_{DateTime.Now:yyyyMMdd_HHmmss}.txt", "text/plain"));
@@ -2191,14 +2197,14 @@
             var sessionInfo = GetSelectedBufferSession();
             if (sessionInfo == null)
             {
-                bufferResult = "セッションを選択してください";
+                bufferResult = L["Settings.DevBuffer.Result.SelectSession"];
                 return;
             }
 
             var result = await contentFactory(sessionInfo);
             if (result == null || result.Value.Content == null)
             {
-                bufferResult = "バッファが空です";
+                bufferResult = L["Settings.DevBuffer.Result.BufferEmpty"];
                 return;
             }
 
@@ -2207,11 +2213,11 @@
             var base64 = Convert.ToBase64String(bytes);
 
             await JSRuntime.InvokeVoidAsync("terminalHubHelpers.downloadBase64File", base64, filename, mimeType);
-            bufferResult = $"ダウンロード完了: {filename} ({FormatBytes(content.Length)})";
+            bufferResult = string.Format(L["Settings.DevBuffer.Result.DownloadedFormat"], filename, FormatBytes(content.Length));
         }
         catch (Exception ex)
         {
-            bufferResult = $"エラー: {ex.Message}";
+            bufferResult = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 
@@ -2241,21 +2247,21 @@
             {
                 SessionId = Guid.NewGuid(),
                 FolderPath = "C:\\TestFolder",
-                DisplayName = "通知テストセッション",
+                DisplayName = L["Settings.DevNotify.SessionName.Browser"],
                 TerminalType = TerminalType.ClaudeCode,
                 ProcessingElapsedSeconds = testElapsedSeconds
             };
 
-            notificationTestResult = $"ブラウザ通知を送信中... ({testElapsedSeconds}秒の処理として)";
+            notificationTestResult = string.Format(L["Settings.DevNotify.Result.BrowserSendingFormat"], testElapsedSeconds);
             StateHasChanged();
 
             await NotificationService.NotifyProcessingCompleteAsync(testSession, testElapsedSeconds);
 
-            notificationTestResult = $"ブラウザ通知を送信しました - {DateTime.Now:HH:mm:ss}";
+            notificationTestResult = string.Format(L["Settings.DevNotify.Result.BrowserSentFormat"], DateTime.Now.ToString("HH:mm:ss"));
         }
         catch (Exception ex)
         {
-            notificationTestResult = $"エラー: {ex.Message}";
+            notificationTestResult = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 
@@ -2267,21 +2273,21 @@
             {
                 SessionId = Guid.NewGuid(),
                 FolderPath = "C:\\TestFolder",
-                DisplayName = "WebHookテストセッション",
+                DisplayName = L["Settings.DevNotify.SessionName.Webhook"],
                 TerminalType = TerminalType.GeminiCLI,
                 ProcessingElapsedSeconds = testElapsedSeconds
             };
 
-            notificationTestResult = $"WebHook通知を送信中... ({testElapsedSeconds}秒の処理として)";
+            notificationTestResult = string.Format(L["Settings.DevNotify.Result.WebhookSendingFormat"], testElapsedSeconds);
             StateHasChanged();
 
             await NotificationService.NotifyProcessingCompleteAsync(testSession, testElapsedSeconds);
 
-            notificationTestResult = $"WebHook通知を送信しました - {DateTime.Now:HH:mm:ss}";
+            notificationTestResult = string.Format(L["Settings.DevNotify.Result.WebhookSentFormat"], DateTime.Now.ToString("HH:mm:ss"));
         }
         catch (Exception ex)
         {
-            notificationTestResult = $"エラー: {ex.Message}";
+            notificationTestResult = string.Format(L["Common.ErrorFormat"], ex.Message);
         }
     }
 

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -2,10 +2,12 @@
 @using TerminalHub.Services
 @using TerminalHub.Models
 @using Microsoft.Extensions.Configuration
+@using Microsoft.Extensions.Localization
 @inject INotificationService NotificationService
 @inject IConfiguration Configuration
 @inject IHostEnvironment HostEnvironment
 @inject IJSRuntime JSRuntime
+@inject IStringLocalizer<SharedResource> L
 @inject ILocalStorageService LocalStorageService
 @inject IAppSettingsService AppSettingsService
 @inject IFolderPickerService FolderPicker
@@ -22,7 +24,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">
-                        <i class="bi bi-gear-fill me-2"></i>設定
+                        <i class="bi bi-gear-fill me-2"></i>@L["Settings.Title"]
                     </h5>
                     <button type="button" class="btn-close" @onclick="SaveAndClose"></button>
                 </div>
@@ -33,56 +35,56 @@
                             <button class="nav-link @(activeTab == "general" ? "active" : "")"
                                     type="button"
                                     @onclick="@(() => activeTab = "general")">
-                                <i class="bi bi-gear me-1"></i>一般
+                                <i class="bi bi-gear me-1"></i>@L["Settings.Tab.General"]
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link @(activeTab == "display" ? "active" : "")"
                                     type="button"
                                     @onclick="@(() => activeTab = "display")">
-                                <i class="bi bi-palette me-1"></i>表示
+                                <i class="bi bi-palette me-1"></i>@L["Settings.Tab.Display"]
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link @(activeTab == "notifications" ? "active" : "")"
                                     type="button"
                                     @onclick="@(() => activeTab = "notifications")">
-                                <i class="bi bi-bell me-1"></i>通知
+                                <i class="bi bi-bell me-1"></i>@L["Settings.Tab.Notifications"]
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link @(activeTab == "sessions" ? "active" : "")"
                                     type="button"
                                     @onclick="@(() => activeTab = "sessions")">
-                                <i class="bi bi-terminal me-1"></i>セッション
+                                <i class="bi bi-terminal me-1"></i>@L["Settings.Tab.Sessions"]
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link @(activeTab == "export" ? "active" : "")"
                                     type="button"
                                     @onclick="@(() => activeTab = "export")">
-                                <i class="bi bi-download me-1"></i>エクスポート/インポート
+                                <i class="bi bi-download me-1"></i>@L["Settings.Tab.ExportImport"]
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link @(activeTab == "commands" ? "active" : "")"
                                     type="button"
                                     @onclick="@(() => activeTab = "commands")">
-                                <i class="bi bi-play-btn me-1"></i>コマンド
+                                <i class="bi bi-play-btn me-1"></i>@L["Settings.Tab.Commands"]
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link @(activeTab == "remoteLaunch" ? "active" : "")"
                                     type="button"
                                     @onclick="@(() => activeTab = "remoteLaunch")">
-                                <i class="bi bi-phone me-1"></i>リモート起動
+                                <i class="bi bi-phone me-1"></i>@L["Settings.Tab.RemoteLaunch"]
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link @(activeTab == "special" ? "active" : "")"
                                     type="button"
                                     @onclick="@(() => activeTab = "special")">
-                                <i class="bi bi-wrench me-1"></i>特殊
+                                <i class="bi bi-wrench me-1"></i>@L["Settings.Tab.Special"]
                             </button>
                         </li>
                         @if (devToolsEnabled)
@@ -91,21 +93,21 @@
                                 <button class="nav-link @(activeTab == "devDiagnose" ? "active" : "")"
                                         type="button"
                                         @onclick="@(() => activeTab = "devDiagnose")">
-                                    <i class="bi bi-bug me-1"></i>診断
+                                    <i class="bi bi-bug me-1"></i>@L["Settings.Tab.DevDiagnose"]
                                 </button>
                             </li>
                             <li class="nav-item" role="presentation">
                                 <button class="nav-link @(activeTab == "devBuffer" ? "active" : "")"
                                         type="button"
                                         @onclick="@(() => activeTab = "devBuffer")">
-                                    <i class="bi bi-hdd me-1"></i>バッファ
+                                    <i class="bi bi-hdd me-1"></i>@L["Settings.Tab.DevBuffer"]
                                 </button>
                             </li>
                             <li class="nav-item" role="presentation">
                                 <button class="nav-link @(activeTab == "devNotify" ? "active" : "")"
                                         type="button"
                                         @onclick="@(() => activeTab = "devNotify")">
-                                    <i class="bi bi-bell-fill me-1"></i>通知テスト
+                                    <i class="bi bi-bell-fill me-1"></i>@L["Settings.Tab.DevNotify"]
                                 </button>
                             </li>
                         }
@@ -116,16 +118,26 @@
                         @if (activeTab == "general")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">一般設定</h6>
+                                <h6 class="mb-3">@L["Settings.General.Header"]</h6>
+
+                                <!-- UI 言語切替 -->
+                                <div class="mb-4">
+                                    <label class="form-label">@L["Settings.General.Language.Label"]</label>
+                                    <select class="form-select" value="@currentCulture" @onchange="ChangeUiCulture">
+                                        <option value="en">English</option>
+                                        <option value="ja">日本語</option>
+                                    </select>
+                                    <small class="text-muted">@L["Settings.General.Language.Help"]</small>
+                                </div>
 
                                 <div class="mb-4">
-                                    <label class="form-label">デフォルトフォルダパス</label>
+                                    <label class="form-label">@L["Settings.General.DefaultFolder.Label"]</label>
                                     <div class="input-group">
                                         <input type="text" class="form-control @(defaultFolderPathWarning != null ? "is-warning" : "")"
                                                @bind="defaultFolderPath"
                                                placeholder="@Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)" />
                                         <button class="btn btn-outline-secondary" type="button" @onclick="BrowseDefaultFolder"
-                                                title="フォルダを選択">
+                                                title="@L["Settings.General.DefaultFolder.PickTitle"]">
                                             <i class="bi bi-folder-symlink"></i>
                                         </button>
                                     </div>
@@ -136,23 +148,23 @@
                                         </div>
                                     }
                                     <small class="text-muted">
-                                        新規セッション作成時のデフォルトパスを設定します。空欄の場合はユーザーフォルダが使用されます。
+                                        @L["Settings.General.DefaultFolder.Help"]
                                     </small>
                                 </div>
 
                                 <div class="mb-4">
-                                    <label class="form-label">お気に入りフォルダ</label>
+                                    <label class="form-label">@L["Settings.General.FavoriteFolders.Label"]</label>
                                     <div class="input-group mb-2">
                                         <input type="text" class="form-control @(favoriteFolderError != null ? "is-invalid" : "")"
                                                @bind="newFavoriteFolder" @bind:event="oninput"
-                                               placeholder="フォルダパスを入力" />
+                                               placeholder="@L["Settings.General.FavoriteFolders.Placeholder"]" />
                                         <button class="btn btn-outline-secondary" type="button" @onclick="BrowseFavoriteFolder"
-                                                title="フォルダを選択">
+                                                title="@L["Settings.General.DefaultFolder.PickTitle"]">
                                             <i class="bi bi-folder-symlink"></i>
                                         </button>
                                         <button class="btn btn-outline-primary" type="button" @onclick="AddFavoriteFolder"
                                                 disabled="@string.IsNullOrWhiteSpace(newFavoriteFolder)">
-                                            <i class="bi bi-plus-lg"></i> 追加
+                                            <i class="bi bi-plus-lg"></i> @L["Common.Add"]
                                         </button>
                                     </div>
                                     @if (favoriteFolderError != null)
@@ -180,14 +192,14 @@
                                         </ul>
                                     }
                                     <small class="text-muted">
-                                        セッション作成時にフォルダ選択の候補として表示されます。
+                                        @L["Settings.General.FavoriteFolders.Help"]
                                     </small>
                                 </div>
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">バージョン情報</h6>
+                                    <h6 class="mb-2">@L["Settings.General.Version.Header"]</h6>
                                     <div class="d-flex align-items-center mb-2">
-                                        <span class="me-2">現在のバージョン:</span>
+                                        <span class="me-2">@L["Settings.General.Version.Current"]</span>
                                         <span class="badge bg-secondary">v@(currentVersion)</span>
                                     </div>
 
@@ -195,23 +207,23 @@
                                     {
                                         <div class="text-muted small">
                                             <span class="spinner-border spinner-border-sm me-1" role="status"></span>
-                                            バージョンを確認中...
+                                            @L["Settings.General.Version.Checking"]
                                         </div>
                                     }
                                     else if (versionCheckResult != null && versionCheckResult.IsNewVersionAvailable)
                                     {
                                         <div class="alert alert-info py-2 mb-0">
                                             <i class="bi bi-info-circle me-1"></i>
-                                            新しいバージョン <strong>v@(versionCheckResult.LatestVersion)</strong> があります
+                                            @((MarkupString)string.Format(L["Settings.General.Version.NewAvailableHtml"], versionCheckResult.LatestVersion))
                                             <a href="@versionCheckResult.ReleaseUrl" target="_blank" class="ms-2">
-                                                <i class="bi bi-box-arrow-up-right me-1"></i>GitHubで確認
+                                                <i class="bi bi-box-arrow-up-right me-1"></i>@L["Settings.General.Version.CheckOnGitHub"]
                                             </a>
                                         </div>
                                     }
                                     else if (versionCheckResult != null && !versionCheckResult.IsNewVersionAvailable)
                                     {
                                         <div class="text-success small">
-                                            <i class="bi bi-check-circle me-1"></i>最新バージョンです
+                                            <i class="bi bi-check-circle me-1"></i>@L["Settings.General.Version.UpToDate"]
                                         </div>
                                     }
                                     else if (versionCheckError != null)
@@ -223,12 +235,12 @@
                                 </div>
 
                                 <div class="mt-4 pt-3 border-top">
-                                    <h6 class="mb-2">コミュニティ</h6>
+                                    <h6 class="mb-2">@L["Settings.General.Community.Header"]</h6>
                                     <a href="https://discord.gg/juCcFNXJg7" target="_blank" class="btn btn-outline-primary btn-sm">
-                                        <i class="bi bi-discord me-1"></i>Discord サーバーに参加
+                                        <i class="bi bi-discord me-1"></i>@L["Settings.General.Community.JoinDiscord"]
                                     </a>
                                     <small class="text-muted d-block mt-1">
-                                        バグ報告、機能リクエスト、質問などはこちらで受け付けています。
+                                        @L["Settings.General.Community.Help"]
                                     </small>
                                 </div>
                             </div>
@@ -1034,7 +1046,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-primary" @onclick="SaveAndClose">
-                        <i class="bi bi-check-circle me-1"></i>閉じる
+                        <i class="bi bi-check-circle me-1"></i>@L["Common.Close"]
                     </button>
                 </div>
             </div>
@@ -1060,6 +1072,11 @@
     private Dictionary<string, CustomCommandType> newCommandTypes = new();
     private Dictionary<string, string> newCommandKeyNames = new();
     private string activeTab = "general";
+
+    // 現在の UI culture (dropdown の選択値)。CultureInfo の two-letter name をそのまま使う (ja / en)。
+    // 実際の値はコンポーネント初期化時 (OnInitialized) に設定する。
+    // RequestLocalization middleware が culture を差し替えた後で確定させるため。
+    private string currentCulture = "en";
     private bool remoteLaunchEnabled = false;
     private string remoteLaunchTopicGuid = "";
     private string remoteLaunchPassword = "";
@@ -1126,6 +1143,9 @@
     protected override void OnInitialized()
     {
         MqttService.StateChanged += OnMqttStateChanged;
+        // Blazor Server の初期レンダー時には UseRequestLocalization middleware が
+        // 既に CultureInfo.CurrentUICulture を差し替え済みなので、ここで確定値を拾う。
+        currentCulture = System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
     }
 
     public void Dispose()
@@ -1844,6 +1864,15 @@
     {
         await SaveSettings();
         await Close();
+    }
+
+    // UI 言語切替: .AspNetCore.Culture cookie を書き換えてからページを reload する。
+    // JS 側 (helpers.js#setUiCulture) で cookie 書き込み → reload をまとめて行う。
+    private async Task ChangeUiCulture(ChangeEventArgs e)
+    {
+        var next = e.Value?.ToString();
+        if (string.IsNullOrWhiteSpace(next) || next == currentCulture) return;
+        await JSRuntime.InvokeVoidAsync("terminalHubHelpers.setUiCulture", next);
     }
     
     private async Task ExportSettings()

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -248,16 +248,16 @@
                         else if (activeTab == "display")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">表示設定</h6>
+                                <h6 class="mb-3">@L["Settings.Display.Header"]</h6>
 
                                 <div class="mb-4">
-                                    <label class="form-label">テーマ</label>
+                                    <label class="form-label">@L["Settings.Display.Theme.Label"]</label>
                                     <div class="form-check">
                                         <input class="form-check-input" type="radio" name="themeMode"
                                                id="themeLight" value="light" checked="@(theme == "light")"
                                                @onchange="@(() => OnThemePreviewChange("light"))">
                                         <label class="form-check-label" for="themeLight">
-                                            <i class="bi bi-sun me-1"></i>ライト
+                                            <i class="bi bi-sun me-1"></i>@L["Settings.Display.Theme.Light"]
                                         </label>
                                     </div>
                                     <div class="form-check">
@@ -265,13 +265,13 @@
                                                id="themeDark" value="dark" checked="@(theme == "dark")"
                                                @onchange="@(() => OnThemePreviewChange("dark"))">
                                         <label class="form-check-label" for="themeDark">
-                                            <i class="bi bi-moon-stars me-1"></i>ダーク
+                                            <i class="bi bi-moon-stars me-1"></i>@L["Settings.Display.Theme.Dark"]
                                         </label>
                                     </div>
                                 </div>
 
                                 <div class="mb-4">
-                                    <label class="form-label">セッションリスト表示倍率</label>
+                                    <label class="form-label">@L["Settings.Display.SessionListScale.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
                                                min="0.5" max="1.5" step="0.05"
@@ -280,12 +280,12 @@
                                         <span class="badge bg-secondary" style="min-width: 50px;">@((sessionListScale * 100).ToString("0"))%</span>
                                     </div>
                                     <small class="text-muted">
-                                        セッションリストの表示倍率を調整します（50%〜150%）。
+                                        @L["Settings.Display.SessionListScale.Help"]
                                     </small>
                                 </div>
 
                                 <div class="mb-4">
-                                    <label class="form-label">ターミナルフォントサイズ</label>
+                                    <label class="form-label">@L["Settings.Display.TerminalFontSize.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
                                                min="8" max="28" step="1"
@@ -294,12 +294,12 @@
                                         <span class="badge bg-secondary" style="min-width: 50px;">@(terminalFontSize)px</span>
                                     </div>
                                     <small class="text-muted">
-                                        ターミナルのフォントサイズを調整します（8px〜28px）。
+                                        @L["Settings.Display.TerminalFontSize.Help"]
                                     </small>
                                 </div>
 
                                 <div class="mb-4">
-                                    <label class="form-label">サイドバー幅</label>
+                                    <label class="form-label">@L["Settings.Display.SidebarWidth.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
                                                min="15" max="40" step="1"
@@ -308,12 +308,12 @@
                                         <span class="badge bg-secondary" style="min-width: 60px;">@(sidebarWidthPercent)%</span>
                                     </div>
                                     <small class="text-muted">
-                                        セッションリストの幅を調整します（15%〜40%）。境界線のドラッグでも変更できます。
+                                        @L["Settings.Display.SidebarWidth.Help"]
                                     </small>
                                 </div>
 
                                 <div class="mb-4">
-                                    <label class="form-label">ターミナル / 入力パネル比率</label>
+                                    <label class="form-label">@L["Settings.Display.TerminalHeightRatio.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
                                                min="20" max="90" step="1"
@@ -322,7 +322,7 @@
                                         <span class="badge bg-secondary" style="min-width: 80px;">@(terminalHeightPercent) / @(100 - terminalHeightPercent)</span>
                                     </div>
                                     <small class="text-muted">
-                                        ターミナルと入力パネルの高さ比率を調整します（50:50〜90:10）。境界線のドラッグでも変更できます。
+                                        @L["Settings.Display.TerminalHeightRatio.Help"]
                                     </small>
                                 </div>
                             </div>
@@ -330,85 +330,83 @@
                         else if (activeTab == "notifications")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">通知設定</h6>
-                    
+                                <h6 class="mb-3">@L["Settings.Notifications.Header"]</h6>
+
                     <div class="mb-4">
                         <div class="d-flex align-items-center justify-content-between mb-2">
-                            <label class="form-label mb-0">ブラウザ通知</label>
-                            <span class="badge @GetNotificationBadgeClass()">@notificationStatus</span>
+                            <label class="form-label mb-0">@L["Settings.Notifications.Browser.Label"]</label>
+                            <span class="badge @GetNotificationBadgeClass()">@GetNotificationStatusText()</span>
                         </div>
-                        @if (notificationStatus == "許可済み")
+                        @if (notificationStatus == NotifStateGranted)
                         {
                             <div class="form-check form-switch mb-2">
                                 <input class="form-check-input" type="checkbox" @bind="browserNotificationEnabled" id="browserNotificationSwitch">
                                 <label class="form-check-label" for="browserNotificationSwitch">
-                                    ブラウザ通知を有効にする
+                                    @L["Settings.Notifications.Browser.Enable"]
                                 </label>
                             </div>
                             <button class="btn btn-outline-secondary btn-sm" @onclick="OpenBrowserNotificationSettings">
-                                <i class="bi bi-gear me-1"></i>通知許可を解除
+                                <i class="bi bi-gear me-1"></i>@L["Settings.Notifications.Browser.Revoke"]
                             </button>
                             <p class="text-muted small mt-2 mb-0">
-                                ブラウザの設定画面で通知許可を解除できます。
+                                @L["Settings.Notifications.Browser.RevokeHelp"]
                             </p>
                         }
-                        else if (notificationStatus == "未許可")
+                        else if (notificationStatus == NotifStateNotRequested)
                         {
                             <button class="btn btn-primary btn-sm" @onclick="RequestNotificationPermission">
-                                <i class="bi bi-bell me-1"></i>通知を許可する
+                                <i class="bi bi-bell me-1"></i>@L["Settings.Notifications.Browser.Request"]
                             </button>
                             <p class="text-muted small mt-2 mb-0">
-                                処理完了時にデスクトップ通知を受け取るには、ブラウザの通知を許可してください。
+                                @L["Settings.Notifications.Browser.RequestHelp"]
                             </p>
                         }
                     </div>
-                    
+
                     <div class="mb-4">
-                        <label class="form-label">通知を送信する処理時間（秒）</label>
+                        <label class="form-label">@L["Settings.Notifications.Threshold.Label"]</label>
                         <input type="number" class="form-control" @bind="thresholdSeconds" min="0" max="3600" />
-                        <small class="text-muted">0に設定すると、すべての処理完了時に通知します</small>
+                        <small class="text-muted">@L["Settings.Notifications.Threshold.Help"]</small>
                     </div>
-                    
+
                     <hr />
-                    
-                    <h6 class="mb-3">WebHook設定</h6>
-                    
+
+                    <h6 class="mb-3">@L["Settings.Notifications.Webhook.Header"]</h6>
+
                     <div class="mb-3">
                         <div class="form-check form-switch">
                             <input class="form-check-input" type="checkbox" @bind="webHookEnabled" id="webHookSwitch">
                             <label class="form-check-label" for="webHookSwitch">
-                                WebHook通知を有効にする
+                                @L["Settings.Notifications.Webhook.Enable"]
                             </label>
                         </div>
                     </div>
-                    
+
                     @if (webHookEnabled)
                     {
                         <div class="mb-3">
-                            <label class="form-label">WebHook URL</label>
+                            <label class="form-label">@L["Settings.Notifications.Webhook.UrlLabel"]</label>
                             <input type="url" class="form-control" @bind="webHookUrl" placeholder="https://example.com/webhook" />
                         </div>
                     }
 
                     <hr />
 
-                    <h6 class="mb-3">Claude Code Hook設定</h6>
+                    <h6 class="mb-3">@L["Settings.Notifications.ClaudeHook.Header"]</h6>
                     <p class="text-muted small mb-3">
-                        Claude Code の hook 機能を使用して、より確実に通知を受け取ることができます。
-                        セッション作成時に自動的に <code>.claude/settings.local.json</code> に設定が追加されます。
+                        @((MarkupString)L["Settings.Notifications.ClaudeHook.HelpHtml"].Value)
                     </p>
 
                     <div class="mb-3">
                         <div class="form-check form-switch">
                             <input class="form-check-input" type="checkbox" @bind="claudeHookEnabled" id="claudeHookSwitch">
                             <label class="form-check-label" for="claudeHookSwitch">
-                                Claude Code Hook を有効にする
+                                @L["Settings.Notifications.ClaudeHook.Enable"]
                             </label>
                         </div>
                         <small class="text-muted d-block mt-1">
                             <i class="bi bi-info-circle me-1"></i>
-                            この設定は各セッションが次に起動／再起動されたタイミングで <code>.claude/settings.local.json</code> に反映されます。
-                            既に起動中のセッションや、TerminalHub 管理外のワークスペースには即時適用されません。
+                            @((MarkupString)L["Settings.Notifications.ClaudeHook.ApplyNoticeHtml"].Value)
                         </small>
                     </div>
 
@@ -417,16 +415,16 @@
                         else if (activeTab == "sessions")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">セッション設定</h6>
+                                <h6 class="mb-3">@L["Settings.Sessions.Header"]</h6>
 
                                 <div class="mb-4">
-                                    <label class="form-label">セッション一覧の並び順</label>
+                                    <label class="form-label">@L["Settings.Sessions.SortOrder.Label"]</label>
                                     <div class="form-check">
                                         <input class="form-check-input" type="radio" name="sessionSortMode"
                                                id="sortByCreatedAt" value="createdAt" checked="@(sessionSortMode == "createdAt")"
                                                @onchange="@(() => sessionSortMode = "createdAt")">
                                         <label class="form-check-label" for="sortByCreatedAt">
-                                            <i class="bi bi-calendar-plus me-1"></i>作成日時順
+                                            <i class="bi bi-calendar-plus me-1"></i>@L["Settings.Sessions.SortOrder.ByCreatedAt"]
                                         </label>
                                     </div>
                                     <div class="form-check">
@@ -434,8 +432,8 @@
                                                id="sortByLastAccessed" value="lastAccessed" checked="@(sessionSortMode == "lastAccessed")"
                                                @onchange="@(() => sessionSortMode = "lastAccessed")">
                                         <label class="form-check-label" for="sortByLastAccessed">
-                                            <i class="bi bi-clock-history me-1"></i>最終利用日時順
-                                            <span class="text-muted small">（最近使用したセッションが上に表示）</span>
+                                            <i class="bi bi-clock-history me-1"></i>@L["Settings.Sessions.SortOrder.ByLastAccessed"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.SortOrder.ByLastAccessedSub"]）</span>
                                         </label>
                                     </div>
                                     <div class="form-check">
@@ -443,53 +441,53 @@
                                                id="sortByName" value="name" checked="@(sessionSortMode == "name")"
                                                @onchange="@(() => sessionSortMode = "name")">
                                         <label class="form-check-label" for="sortByName">
-                                            <i class="bi bi-sort-alpha-down me-1"></i>名前順
+                                            <i class="bi bi-sort-alpha-down me-1"></i>@L["Settings.Sessions.SortOrder.ByName"]
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        「最終利用日時順」では、子セッション（Worktree）の利用も親セッションの順序に反映されます。
+                                        @L["Settings.Sessions.SortOrder.Help"]
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <label class="form-label">セッション一覧の表示設定</label>
+                                    <label class="form-label">@L["Settings.Sessions.Display.Label"]</label>
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" @bind="showTerminalType" id="showTerminalType">
                                         <label class="form-check-label" for="showTerminalType">
-                                            <i class="bi bi-tag me-1"></i>ターミナル種別を表示
-                                            <span class="text-muted small">（Claude/Gemini/Codexバッジ）</span>
+                                            <i class="bi bi-tag me-1"></i>@L["Settings.Sessions.Display.ShowTerminalType"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.Display.ShowTerminalTypeSub"]）</span>
                                         </label>
                                     </div>
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" @bind="showGitInfo" id="showGitInfo">
                                         <label class="form-check-label" for="showGitInfo">
-                                            <i class="bi bi-git me-1"></i>Git情報を表示
-                                            <span class="text-muted small">（ブランチ名バッジ）</span>
+                                            <i class="bi bi-git me-1"></i>@L["Settings.Sessions.Display.ShowGitInfo"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.Display.ShowGitInfoSub"]）</span>
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        セッション一覧に表示する追加情報を選択できます。
+                                        @L["Settings.Sessions.Display.Help"]
                                     </p>
                                 </div>
 
                                 <hr />
 
                                 <div class="mb-4">
-                                    <label class="form-label">入力パネル設定</label>
+                                    <label class="form-label">@L["Settings.Sessions.InputPanel.Label"]</label>
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" @bind="hideInputPanel" id="hideInputPanel">
                                         <label class="form-check-label" for="hideInputPanel">
-                                            <i class="bi bi-textarea me-1"></i>入力パネルを非表示
-                                            <span class="text-muted small">（ターミナルのみ表示）</span>
+                                            <i class="bi bi-textarea me-1"></i>@L["Settings.Sessions.InputPanel.Hide"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.InputPanel.HideSub"]）</span>
                                         </label>
                                     </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
-                                        下部の入力パネルを非表示にして、ターミナル領域を広く使えます。
+                                        @L["Settings.Sessions.InputPanel.HideHelp"]
                                     </p>
                                 </div>
                             </div>
@@ -1058,7 +1056,16 @@
     [Parameter] public bool IsVisible { get; set; }
     [Parameter] public EventCallback<bool> IsVisibleChanged { get; set; }
 
-    private string notificationStatus = "確認中...";
+    // notificationStatus はブラウザの Notification API の permission 値 ("granted"/"denied"/"default")
+    // に、アプリ側の擬似状態 ("checking"/"error"/"unknown") を追加した state key を保持する。
+    // UI 表示文字列は GetNotificationStatusText() / GetNotificationBadgeClass() で解決する。
+    private const string NotifStateChecking = "checking";
+    private const string NotifStateGranted = "granted";
+    private const string NotifStateDenied = "denied";
+    private const string NotifStateNotRequested = "default"; // JS permission "default" = 未許可
+    private const string NotifStateError = "error";
+    private const string NotifStateUnknown = "unknown";
+    private string notificationStatus = NotifStateChecking;
     private int thresholdSeconds = 60;
     private bool browserNotificationEnabled = true;
     private bool webHookEnabled = false;
@@ -1320,15 +1327,15 @@
             var permission = await JSRuntime.InvokeAsync<string>("terminalHubHelpers.checkNotificationPermission");
             notificationStatus = permission switch
             {
-                "granted" => "許可済み",
-                "denied" => "拒否",
-                "default" => "未許可",
-                _ => "不明"
+                "granted" => NotifStateGranted,
+                "denied" => NotifStateDenied,
+                "default" => NotifStateNotRequested,
+                _ => NotifStateUnknown
             };
         }
         catch
         {
-            notificationStatus = "確認エラー";
+            notificationStatus = NotifStateError;
         }
     }
     
@@ -1848,11 +1855,26 @@
     {
         return notificationStatus switch
         {
-            "許可済み" => "bg-success",
-            "拒否" => "bg-danger",
-            "未許可" => "bg-warning",
+            NotifStateGranted => "bg-success",
+            NotifStateDenied => "bg-danger",
+            NotifStateNotRequested => "bg-warning",
             _ => "bg-secondary"
         };
+    }
+
+    // notificationStatus (state key) に対応する localized 表示文字列を返す
+    private string GetNotificationStatusText()
+    {
+        var key = notificationStatus switch
+        {
+            NotifStateGranted => "Granted",
+            NotifStateDenied => "Denied",
+            NotifStateNotRequested => "NotRequested",
+            NotifStateChecking => "Checking",
+            NotifStateError => "CheckError",
+            _ => "Unknown"
+        };
+        return L[$"Settings.Notifications.Status.{key}"];
     }
     
     private async Task Close()

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -1,13 +1,15 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
+@using Microsoft.Extensions.Localization
 @inject IGitService GitService
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
     <div class="modal-dialog modal-dialog-centered modal-lg">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">
-                    <i class="bi bi-diagram-3 me-2"></i>サブセッション作成
+                    <i class="bi bi-diagram-3 me-2"></i>@L["SubSession.Title"]
                 </h5>
                 <button type="button" class="btn-close" @onclick="OnCancel"></button>
             </div>
@@ -15,37 +17,37 @@
                 @if (!string.IsNullOrEmpty(ParentSessionName))
                 {
                     <div class="mb-3">
-                        <small class="text-muted">親セッション: @ParentSessionName</small>
+                        <small class="text-muted">@string.Format(L["SubSession.ParentSessionFormat"], ParentSessionName)</small>
                     </div>
                 }
-                
+
                 <!-- タブナビゲーション -->
                 <ul class="nav nav-tabs mb-3">
                     @if (IsGitRepository)
                     {
                         <li class="nav-item">
-                            <button class="nav-link @(activeTab == TabType.Create ? "active" : "")" 
+                            <button class="nav-link @(activeTab == TabType.Create ? "active" : "")"
                                     @onclick="@(() => activeTab = TabType.Create)">
-                                <i class="bi bi-plus-circle me-1"></i>Worktree新規作成
+                                <i class="bi bi-plus-circle me-1"></i>@L["SubSession.Tab.CreateWorktree"]
                             </button>
                         </li>
                         <li class="nav-item">
-                            <button class="nav-link @(activeTab == TabType.Existing ? "active" : "")" 
+                            <button class="nav-link @(activeTab == TabType.Existing ? "active" : "")"
                                     @onclick="@(() => activeTab = TabType.Existing)">
-                                <i class="bi bi-folder-plus me-1"></i>既存Worktree追加
+                                <i class="bi bi-folder-plus me-1"></i>@L["SubSession.Tab.ExistingWorktree"]
                             </button>
                         </li>
                     }
                     <li class="nav-item">
-                        <button class="nav-link @(activeTab == TabType.SamePath ? "active" : "")" 
+                        <button class="nav-link @(activeTab == TabType.SamePath ? "active" : "")"
                                 @onclick="@(() => activeTab = TabType.SamePath)">
-                            <i class="bi bi-folder me-1"></i>同じフォルダで開く
+                            <i class="bi bi-folder me-1"></i>@L["SubSession.Tab.SamePath"]
                         </button>
                     </li>
                     <li class="nav-item">
-                        <button class="nav-link @(activeTab == TabType.NewFolder ? "active" : "")" 
+                        <button class="nav-link @(activeTab == TabType.NewFolder ? "active" : "")"
                                 @onclick="@(() => activeTab = TabType.NewFolder)">
-                            <i class="bi bi-folder-plus me-1"></i>新しいフォルダで開く
+                            <i class="bi bi-folder-plus me-1"></i>@L["SubSession.Tab.NewFolder"]
                         </button>
                     </li>
                 </ul>
@@ -60,64 +62,64 @@
                             {
                                 <div class="alert alert-warning">
                                     <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                                    <strong>Git管理が必要です</strong><br/>
-                                    Worktreeの作成にはGitリポジトリが必要です。
+                                    <strong>@L["SubSession.GitRequired.Title"]</strong><br/>
+                                    @L["SubSession.GitRequired.CreateWorktree"]
                                 </div>
                             }
                             else
                             {
                             <div class="mb-3">
-                                <label class="form-label">ブランチ選択方法</label>
+                                <label class="form-label">@L["SubSession.BranchSelection.Label"]</label>
                                 <div class="btn-group d-flex mb-2" role="group">
-                                    <input type="radio" class="btn-check" name="branchOption" id="newBranch" 
+                                    <input type="radio" class="btn-check" name="branchOption" id="newBranch"
                                            checked="@(branchSelectionMode == BranchSelectionMode.NewBranch)"
                                            @onclick="@(() => branchSelectionMode = BranchSelectionMode.NewBranch)">
-                                    <label class="btn btn-outline-secondary" for="newBranch">新規ブランチ</label>
-                                    
-                                    <input type="radio" class="btn-check" name="branchOption" id="existingBranch" 
+                                    <label class="btn btn-outline-secondary" for="newBranch">@L["SubSession.BranchSelection.New"]</label>
+
+                                    <input type="radio" class="btn-check" name="branchOption" id="existingBranch"
                                            checked="@(branchSelectionMode == BranchSelectionMode.ExistingBranch)"
                                            @onclick="@(() => branchSelectionMode = BranchSelectionMode.ExistingBranch)">
-                                    <label class="btn btn-outline-secondary" for="existingBranch">既存ブランチ</label>
+                                    <label class="btn btn-outline-secondary" for="existingBranch">@L["SubSession.BranchSelection.Existing"]</label>
                                 </div>
                             </div>
-                            
+
                             @if (branchSelectionMode == BranchSelectionMode.NewBranch)
                             {
                                 <div class="mb-3">
-                                    <label for="branchName" class="form-label">新しいブランチ名</label>
-                                    <input type="text" class="form-control" id="branchName" 
-                                           @bind="branchName" 
+                                    <label for="branchName" class="form-label">@L["SubSession.NewBranch.Label"]</label>
+                                    <input type="text" class="form-control" id="branchName"
+                                           @bind="branchName"
                                            @bind:event="oninput"
                                            @onkeydown="OnKeyDown"
-                                           placeholder="feature/new-feature" 
+                                           placeholder="feature/new-feature"
                                            autofocus>
                                     <small class="form-text text-muted">
-                                        このブランチ名で新しいWorktreeが作成されます
+                                        @L["SubSession.NewBranch.Help"]
                                     </small>
                                 </div>
                             }
                             else
                             {
                                 <div class="mb-3">
-                                    <label for="existingBranchSelect" class="form-label">既存のブランチを選択</label>
+                                    <label for="existingBranchSelect" class="form-label">@L["SubSession.ExistingBranch.Label"]</label>
                                     @if (availableBranches == null)
                                     {
                                         <div class="text-center">
                                             <span class="spinner-border spinner-border-sm" role="status"></span>
-                                            ブランチ一覧を読み込み中...
+                                            @L["SubSession.ExistingBranch.Loading"]
                                         </div>
                                     }
                                     else if (availableBranches.Count == 0)
                                     {
                                         <div class="alert alert-warning">
-                                            利用可能なブランチがありません
+                                            @L["SubSession.ExistingBranch.Empty"]
                                         </div>
                                     }
                                     else
                                     {
-                                        <select class="form-select" id="existingBranchSelect" 
+                                        <select class="form-select" id="existingBranchSelect"
                                                 @onchange="OnExistingBranchSelected">
-                                            <option value="">ブランチを選択してください</option>
+                                            <option value="">@L["SubSession.ExistingBranch.Placeholder"]</option>
                                             @foreach (var branch in availableBranches)
                                             {
                                                 <option value="@branch">@branch</option>
@@ -125,14 +127,14 @@
                                         </select>
                                     }
                                 </div>
-                                
+
                                 @if (!string.IsNullOrEmpty(selectedExistingBranch) && branchWorktreeInfo != null)
                                 {
                                     <div class="alert alert-warning">
                                         <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                                        <strong>このブランチには既にWorktreeが存在します</strong><br/>
-                                        <span>パス: @branchWorktreeInfo.Path</span><br/>
-                                        <small>「既存Worktree追加」タブから追加してください</small>
+                                        <strong>@L["SubSession.BranchExistingWorktree.Title"]</strong><br/>
+                                        <span>@string.Format(L["SubSession.BranchExistingWorktree.PathFormat"], branchWorktreeInfo.Path)</span><br/>
+                                        <small>@L["SubSession.BranchExistingWorktree.Help"]</small>
                                     </div>
                                 }
                             }
@@ -157,41 +159,41 @@
                             {
                                 <div class="alert alert-warning">
                                     <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                                    <strong>Git管理が必要です</strong><br/>
-                                    既存のWorktreeを追加するにはGitリポジトリが必要です。
+                                    <strong>@L["SubSession.GitRequired.Title"]</strong><br/>
+                                    @L["SubSession.GitRequired.ExistingWorktree"]
                                 </div>
                             }
                             else
                             {
                             <div class="mb-3">
-                                <label for="worktreePath" class="form-label">既存のWorktreeを選択</label>
+                                <label for="worktreePath" class="form-label">@L["SubSession.ExistingWorktree.Label"]</label>
                                 @if (availableWorktrees == null)
                                 {
                                     <div class="text-center">
                                         <span class="spinner-border spinner-border-sm" role="status"></span>
-                                        Worktree一覧を読み込み中...
+                                        @L["SubSession.ExistingWorktree.Loading"]
                                     </div>
                                 }
                                 else if (availableWorktrees.Count == 0)
                                 {
                                     <div class="alert alert-warning">
                                         <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                                        利用可能なWorktreeがありません
+                                        @L["SubSession.ExistingWorktree.Empty"]
                                     </div>
                                 }
                                 else
                                 {
-                                    <select class="form-select" id="worktreeSelect" 
+                                    <select class="form-select" id="worktreeSelect"
                                             value="@selectedWorktreePath"
                                             @onchange="OnWorktreeSelected">
-                                        <option value="">Worktreeを選択してください</option>
+                                        <option value="">@L["SubSession.ExistingWorktree.Placeholder"]</option>
                                         @foreach (var worktree in availableWorktrees)
                                         {
                                             <option value="@worktree.Path">
                                                 (@worktree.BranchName)
                                                 @if (worktree.IsMain)
                                                 {
-                                                    <text> - メイン</text>
+                                                    <text> @L["SubSession.WorktreeMainSuffix"]</text>
                                                 }
                                             </option>
                                         }
@@ -232,7 +234,7 @@
                             {
                                 <div class="alert alert-info">
                                     <i class="bi bi-info-circle me-2"></i>
-                                    親セッション "@ParentSessionName" と同じフォルダで開きます
+                                    @string.Format(L["SubSession.SamePath.InfoFormat"], ParentSessionName)
                                 </div>
                             }
                         </div>
@@ -242,20 +244,20 @@
                         <!-- 新しいフォルダで開く -->
                         <div class="tab-pane active">
                             <div class="mb-3">
-                                <label for="newFolderPath" class="form-label">新しいフォルダのパス</label>
+                                <label for="newFolderPath" class="form-label">@L["SubSession.NewFolder.Label"]</label>
                                 <div class="input-group">
-                                    <input type="text" class="form-control" id="newFolderPath" 
-                                           @bind="newFolderPath" 
+                                    <input type="text" class="form-control" id="newFolderPath"
+                                           @bind="newFolderPath"
                                            @bind:event="oninput"
                                            @onkeydown="OnKeyDown"
-                                           placeholder="C:\path\to\new\folder または相対パス" 
+                                           placeholder="@L["SubSession.NewFolder.Placeholder"]"
                                            autofocus>
                                     <button class="btn btn-outline-secondary" type="button" @onclick="SelectFolderDialog">
                                         <i class="bi bi-folder2-open"></i>
                                     </button>
                                 </div>
                                 <small class="form-text text-muted">
-                                    フォルダが存在しない場合は自動的に作成されます
+                                    @L["SubSession.NewFolder.Help"]
                                 </small>
                             </div>
                             
@@ -274,7 +276,7 @@
                                 
                                 <div class="alert alert-info mt-3">
                                     <i class="bi bi-info-circle me-2"></i>
-                                    新しいフォルダ "@newFolderPath" でセッションを開始します
+                                    @string.Format(L["SubSession.NewFolder.InfoFormat"], newFolderPath)
                                 </div>
                             }
                         </div>
@@ -285,7 +287,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" @onclick="OnCancel" disabled="@isProcessing">
-                    キャンセル
+                    @L["Common.Cancel"]
                 </button>
                 <button type="button" class="btn btn-success" @onclick="ProcessOperation" 
                         disabled="@(!CanProcess || isProcessing)">
@@ -437,7 +439,7 @@
         }
         catch (Exception ex)
         {
-            errorMessage = $"操作中にエラーが発生しました: {ex.Message}";
+            errorMessage = string.Format(L["SubSession.ErrorFormat"], ex.Message);
             isProcessing = false;
         }
     }
@@ -566,11 +568,11 @@
     {
         return activeTab switch
         {
-            TabType.Create => "Worktree作成",
-            TabType.Existing => "Worktree追加",
-            TabType.SamePath => "セッション作成",
-            TabType.NewFolder => "フォルダ作成",
-            _ => "作成"
+            TabType.Create => L["SubSession.Button.Create"],
+            TabType.Existing => L["SubSession.Button.Existing"],
+            TabType.SamePath => L["SubSession.Button.SamePath"],
+            TabType.NewFolder => L["SubSession.Button.NewFolder"],
+            _ => L["Common.Create"]
         };
     }
     

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -1,6 +1,8 @@
 @using System.IO
 @using TerminalHub.Models
 @using TerminalHub.Constants
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SharedResource> L
 
 <style>
     @@keyframes bell-ring {
@@ -29,21 +31,21 @@
 
     <div class="mb-2">
         <button class="btn btn-primary w-100" @onclick="() => OnAddSession.InvokeAsync()" disabled="@IsAddingSession">
-            <i class="bi bi-plus-circle"></i> 新しいセッションを作成
+            <i class="bi bi-plus-circle"></i> @L["SessionList.CreateSession"]
         </button>
     </div>
 
     @if (!Sessions.Any())
     {
         <div class="alert alert-info py-2 px-3 mb-2 small">
-            <i class="bi bi-arrow-up"></i> 上のボタンからセッションを作成してください
+            <i class="bi bi-arrow-up"></i> @L["SessionList.EmptyHint"]
         </div>
     }
 
     <div class="mb-2">
         <div class="input-group input-group-sm">
             <span class="input-group-text"><i class="bi bi-search"></i></span>
-            <input type="text" class="form-control" placeholder="セッションを検索..."
+            <input type="text" class="form-control" placeholder="@L["SessionList.SearchPlaceholder"]"
                    @bind="filterText" @bind:event="oninput" />
             @if (!string.IsNullOrEmpty(filterText))
             {
@@ -52,7 +54,7 @@
                 </button>
             }
             <button class="btn btn-outline-secondary" type="button" @onclick="() => OnShowArchivedSessions.InvokeAsync()"
-                    title="アーカイブ済みセッション">
+                    title="@L["SessionList.ArchivedTooltip"]">
                 <i class="bi bi-archive"></i>
                 @{
                     var archivedCount = Sessions.Count(s => s.IsArchived);
@@ -90,20 +92,20 @@
                                 }
                             @if (session.IsPinned)
                             {
-                                <span class="text-muted me-1" title="ピン留め">
+                                <span class="text-muted me-1" title="@L["SessionList.Badge.Pinned"]">
                                     <i class="bi bi-pin-fill"></i>
                                 </span>
                             }
                             @if (NotificationPendingSessions.Contains(session.SessionId))
                             {
-                                <span class="text-danger me-1" title="処理が完了しました">
+                                <span class="text-danger me-1" title="@L["SessionList.Badge.Notification"]">
                                     <i class="bi bi-bell-fill"></i>
                                 </span>
                             }
                             <span class="@GetConnectionOpacityClass(session)">@session.GetDisplayName()</span>
                             @if (!string.IsNullOrEmpty(session.FolderPath) && !Directory.Exists(session.FolderPath))
                             {
-                                <span class="text-warning ms-1" title="ディレクトリが見つかりません: @session.FolderPath">
+                                <span class="text-warning ms-1" title="@string.Format(L["SessionList.Badge.DirectoryNotFoundFormat"], session.FolderPath)">
                                     <i class="bi bi-exclamation-triangle-fill" style="font-size: 0.75rem;"></i>
                                 </span>
                             }
@@ -113,24 +115,24 @@
                             }
                             @if (ShowGitInfo && session.IsGitRepository && !string.IsNullOrEmpty(session.GitBranch))
                             {
-                                <span class="badge @(session.IsWorktree ? "bg-warning" : "bg-success") ms-1" title="@(session.IsWorktree ? "Worktree" : "Git ブランチ")">
+                                <span class="badge @(session.IsWorktree ? "bg-warning" : "bg-success") ms-1" title="@(session.IsWorktree ? "Worktree" : L["SessionList.Badge.GitBranch"].Value)">
                                     <i class="bi @(session.IsWorktree ? "bi-git" : "bi-git") me-1"></i>@session.GitBranch
                                     @if (session.HasUncommittedChanges)
                                     {
-                                        <i class="bi bi-circle-fill text-danger git-status-indicator" title="未コミットの変更があります"></i>
+                                        <i class="bi bi-circle-fill text-danger git-status-indicator" title="@L["SessionList.Badge.UncommittedChanges"]"></i>
                                     }
                                 </span>
                             }
                             @if (!string.IsNullOrEmpty(session.RemoteControlUrl))
                             {
-                                <span class="badge bg-info ms-1" title="リモートコントロール接続中">
+                                <span class="badge bg-info ms-1" title="@L["SessionList.Badge.RemoteControl"]">
                                     <i class="bi bi-phone-fill"></i>
                                 </span>
                             }
                             @if (!session.ParentSessionId.HasValue && HasChildren(session) && !session.IsExpanded)
                             {
                                 <span class="badge bg-secondary ms-1" style="font-size: 0.7rem;">
-                                    @GetChildrenCount(session) 件
+                                    @string.Format(L["SessionList.Badge.ChildrenCountFormat"], GetChildrenCount(session))
                                 </span>
                             }
                         </h6>
@@ -155,15 +157,15 @@
                         }
                     </div>
                     <div class="d-flex align-items-center">
-                        <button class="btn btn-outline-secondary btn-sm border-0 opacity-50" @onclick:stopPropagation="true" 
+                        <button class="btn btn-outline-secondary btn-sm border-0 opacity-50" @onclick:stopPropagation="true"
                                 @onclick="() => OnSessionSettings.InvokeAsync(session.SessionId)"
-                                title="セッション設定"
+                                title="@L["SessionList.Tooltip.Settings"]"
                                 style="font-size: 0.75rem; padding: 0.25rem 0.5rem;">
                             <i class="bi bi-gear"></i>
                         </button>
-                        <button class="btn btn-outline-secondary btn-sm border-0 opacity-50" @onclick:stopPropagation="true" 
+                        <button class="btn btn-outline-secondary btn-sm border-0 opacity-50" @onclick:stopPropagation="true"
                                 @onclick="() => OnSessionRemove.InvokeAsync(session.SessionId)"
-                                title="セッション削除"
+                                title="@L["SessionList.Tooltip.Delete"]"
                                 style="font-size: 0.75rem; padding: 0.25rem 0.5rem;">
                             <i class="bi bi-x-lg"></i>
                         </button>
@@ -188,7 +190,7 @@
     <div class="mt-auto border-top sidebar-footer">
         <div class="p-2">
             <button class="btn btn-outline-secondary btn-sm w-100" @onclick="OnSettingsClick">
-                <i class="bi bi-gear me-1"></i>設定
+                <i class="bi bi-gear me-1"></i>@L["Settings.Title"]
             </button>
         </div>
     </div>

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -105,7 +105,7 @@
                             <span class="@GetConnectionOpacityClass(session)">@session.GetDisplayName()</span>
                             @if (!string.IsNullOrEmpty(session.FolderPath) && !Directory.Exists(session.FolderPath))
                             {
-                                <span class="text-warning ms-1" title="@string.Format(L["SessionList.Badge.DirectoryNotFoundFormat"], session.FolderPath)">
+                                <span class="text-warning ms-1" title="@string.Format(L["Common.DirectoryNotFoundFormat"], session.FolderPath)">
                                     <i class="bi bi-exclamation-triangle-fill" style="font-size: 0.75rem;"></i>
                                 </span>
                             }

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -39,6 +39,27 @@ builder.Host.UseSerilog((context, configuration) =>
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
+// ローカライゼーション設定
+// - リソース配置: TerminalHub/Resources/SharedResource.{en,ja}.resx
+// - 言語判定: Cookie (.AspNetCore.Culture) → Accept-Language → デフォルト "en"
+// - 対応外言語は "en" にフォールバック (英語を canonical として統一)
+//
+// 注意: ResourcesPath は敢えて指定しない。
+// .NET SDK のビルドが resx を埋め込む際、観測された実名は
+//   TerminalHub.SharedResource.{culture}.resources
+// となっていて "Resources." フォルダ prefix が付与されていない。
+// ResourcesPath を指定すると localizer は "TerminalHub.Resources.SharedResource..." を
+// 探しに行って見つけられずキー文字列がそのまま返ってしまう。
+// 空のまま = typeInfo.FullName (TerminalHub.SharedResource) をそのまま prefix として使うので一致する。
+builder.Services.AddLocalization();
+builder.Services.Configure<Microsoft.AspNetCore.Builder.RequestLocalizationOptions>(options =>
+{
+    var supported = new[] { "en", "ja" };
+    options.SetDefaultCulture("en");
+    options.AddSupportedCultures(supported);
+    options.AddSupportedUICultures(supported);
+});
+
 // SignalRのメッセージサイズ制限を増加（デフォルト32KBでは不足）
 builder.Services.AddSignalR(options =>
 {
@@ -137,6 +158,44 @@ if (!app.Environment.IsDevelopment())
 // app.UseHttpsRedirection();
 
 app.UseAntiforgery();
+
+// リクエストローカライゼーション
+// Program.cs 先頭で登録した RequestLocalizationOptions を適用する。
+// Cookie (.AspNetCore.Culture) → Accept-Language の順で culture を判定、対応外は "en" へフォールバック。
+app.UseRequestLocalization();
+
+// Cookie スライディング更新: culture cookie の有効期限を毎リクエスト 1 年先へ延長する。
+// これでユーザーが最後にアクセスしてから 1 年放置しない限り言語選択は永続化される。
+//
+// 実装注意: await next() の後に Response.Cookies.Append を呼ぶと、静的ファイル配信や
+// SignalR ストリーミング応答では既にヘッダーが送信済みで "Headers are read-only" 例外になる。
+// OnStarting コールバックはヘッダー送信「直前」に一度だけ呼ばれるのでここで cookie を追記する。
+app.Use((context, next) =>
+{
+    context.Response.OnStarting(() =>
+    {
+        // 実リクエストで解決された culture を IRequestCultureFeature から取得する。
+        // CurrentUICulture は AsyncLocal で OnStarting 発火時に壊れているケースがあるので、
+        // より信頼できる Feature 経由で取り直す。
+        var feature = context.Features.Get<Microsoft.AspNetCore.Localization.IRequestCultureFeature>();
+        var culture = feature?.RequestCulture ??
+                      new Microsoft.AspNetCore.Localization.RequestCulture(System.Globalization.CultureInfo.CurrentUICulture);
+        var cookieValue = Microsoft.AspNetCore.Localization.CookieRequestCultureProvider.MakeCookieValue(culture);
+        context.Response.Cookies.Append(
+            Microsoft.AspNetCore.Localization.CookieRequestCultureProvider.DefaultCookieName,
+            cookieValue,
+            new Microsoft.AspNetCore.Http.CookieOptions
+            {
+                Expires = DateTimeOffset.UtcNow.AddYears(1),
+                IsEssential = true,
+                SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax,
+                HttpOnly = false, // 言語切替のため JS からも読み書き可能にする
+                Path = "/"
+            });
+        return Task.CompletedTask;
+    });
+    return next();
+});
 
 app.MapStaticAssets();
 app.MapRazorComponents<App>()

--- a/TerminalHub/Resources/SharedResource.cs
+++ b/TerminalHub/Resources/SharedResource.cs
@@ -1,0 +1,22 @@
+// 注意: namespace はあえてアセンブリルート (TerminalHub) 直下に置いている。
+// IStringLocalizer<T> の resx 解決規則は {baseNamespace}.{ResourcesPath}.{RelativeTypeName} を
+// embedded resource 名として要求する。クラスを TerminalHub.Resources に置くと
+// RelativeTypeName が "Resources.SharedResource" となり、ResourcesPath="Resources" と
+// 組み合わさって "TerminalHub.Resources.Resources.SharedResource" を探しに行ってしまう
+// (実際の埋め込みリソース名は "TerminalHub.Resources.SharedResource")。
+// 結果としてリソース解決に失敗しキー文字列がそのまま返ってしまうため、ルート namespace に置く。
+namespace TerminalHub
+{
+    /// <summary>
+    /// 共有リソースのマーカークラス。
+    /// IStringLocalizer&lt;SharedResource&gt; として注入することで、
+    /// Resources/SharedResource.{culture}.resx から文字列を引ける。
+    ///
+    /// 使用例:
+    ///   @inject IStringLocalizer&lt;SharedResource&gt; L
+    ///   &lt;h1&gt;@L["Settings.Title"]&lt;/h1&gt;
+    /// </summary>
+    public class SharedResource
+    {
+    }
+}

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -58,6 +58,7 @@
   <!-- Common -->
   <data name="Common.Close" xml:space="preserve"><value>Close</value></data>
   <data name="Common.Add" xml:space="preserve"><value>Add</value></data>
+  <data name="Common.ErrorFormat" xml:space="preserve"><value>Error: {0}</value></data>
 
   <!-- Settings Dialog -->
   <data name="Settings.Title" xml:space="preserve"><value>Settings</value></data>
@@ -156,7 +157,7 @@
   <data name="Settings.Export.Header" xml:space="preserve"><value>Export / Import Data</value></data>
   <data name="Settings.Export.Export.Header" xml:space="preserve"><value>Export</value></data>
   <data name="Settings.Export.Export.Help" xml:space="preserve"><value>Downloads session data from the current storage ({0}) as a JSON file.</value></data>
-  <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>Export target: sessions ({0})</value></data>
+  <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>Export target: {0} sessions</value></data>
   <data name="Settings.Export.Export.Button" xml:space="preserve"><value>Export</value></data>
   <data name="Settings.Export.Import.Header" xml:space="preserve"><value>Import</value></data>
   <data name="Settings.Export.Import.Help" xml:space="preserve"><value>Select a JSON file to import session data. It will be added to the current storage ({0}).</value></data>
@@ -193,4 +194,95 @@
   <data name="Settings.RemoteLaunch.TopicGuid" xml:space="preserve"><value>Topic GUID</value></data>
   <data name="Settings.RemoteLaunch.RegenerateGuidTitle" xml:space="preserve"><value>Regenerate GUID (existing access URL will be invalidated)</value></data>
   <data name="Settings.RemoteLaunch.RegenerateGuidHelp" xml:space="preserve"><value>Regenerating invalidates the existing access URL.</value></data>
+
+  <!-- Settings: Special Tab -->
+  <data name="Settings.Special.Header" xml:space="preserve"><value>Special Settings</value></data>
+  <data name="Settings.Special.ClaudeModeKey.Header" xml:space="preserve"><value>Claude Code mode switch key</value></data>
+  <data name="Settings.Special.ClaudeModeKey.Help" xml:space="preserve"><value>Select the keyboard shortcut used for mode switching in Claude Code.</value></data>
+  <data name="Settings.Special.ClaudeModeKey.None" xml:space="preserve"><value>None</value></data>
+  <data name="Settings.Special.ClaudeModeKey.DefaultNote" xml:space="preserve"><value>(default)</value></data>
+  <data name="Settings.Special.ClaudeModeKey.ConflictNote" xml:space="preserve"><value>Alt+M can conflict with other functions in some environments. If that happens, try Shift+Tab instead.</value></data>
+  <data name="Settings.Special.VoiceInput.Header" xml:space="preserve"><value>Voice input</value></data>
+  <data name="Settings.Special.VoiceInput.Enable" xml:space="preserve"><value>Enable voice input (experimental)</value></data>
+  <data name="Settings.Special.VoiceInput.Help" xml:space="preserve"><value>When enabled, a microphone button appears in the text input panel. Speech recognition only runs while the button is held down (Chrome recommended).</value></data>
+  <data name="Settings.Special.TextRefine.Header" xml:space="preserve"><value>Text pre-refinement</value></data>
+  <data name="Settings.Special.TextRefine.Enable" xml:space="preserve"><value>Enable pre-refinement button (experimental)</value></data>
+  <data name="Settings.Special.TextRefine.HelpHtml" xml:space="preserve"><value>When enabled, a &lt;i class="bi bi-stars"&gt;&lt;/i&gt; Refine button appears in the text input panel. Pressing it uses Claude Code CLI (Haiku model) to fix typos and inconsistencies.&lt;br/&gt;The refinement instructions can be customized by editing &lt;code&gt;%LOCALAPPDATA%\TerminalHub\refine-workdir\CLAUDE.md&lt;/code&gt;.</value></data>
+  <data name="Settings.Special.DevTools.Header" xml:space="preserve"><value>Developer tools</value></data>
+  <data name="Settings.Special.DevTools.Enable" xml:space="preserve"><value>Enable developer tools</value></data>
+  <data name="Settings.Special.DevTools.Help" xml:space="preserve"><value>When enabled, the Diagnostics, Buffer, and Notification Test tabs are shown.</value></data>
+  <data name="Settings.Special.Logs.Header" xml:space="preserve"><value>Log files</value></data>
+  <data name="Settings.Special.Logs.OpenFolder" xml:space="preserve"><value>Open log folder</value></data>
+  <data name="Settings.Special.Logs.Help" xml:space="preserve"><value>Opens the folder where application log files are stored.</value></data>
+
+  <!-- Settings: Dev Diagnose Tab -->
+  <data name="Settings.DevDiagnose.Header" xml:space="preserve"><value>Diagnostics</value></data>
+  <data name="Settings.DevDiagnose.Refresh" xml:space="preserve"><value>Refresh diagnostics</value></data>
+  <data name="Settings.DevDiagnose.RunJs" xml:space="preserve"><value>Run JS diagnostics</value></data>
+  <data name="Settings.DevDiagnose.SessionList" xml:space="preserve"><value>Session list</value></data>
+  <data name="Settings.DevDiagnose.ColName" xml:space="preserve"><value>Name</value></data>
+  <data name="Settings.DevDiagnose.ColStatus" xml:space="preserve"><value>Status</value></data>
+  <data name="Settings.DevDiagnose.ConPtyPresent" xml:space="preserve"><value>Yes</value></data>
+  <data name="Settings.DevDiagnose.ConPtyAbsent" xml:space="preserve"><value>No</value></data>
+  <data name="Settings.DevDiagnose.TerminalInfo.Header" xml:space="preserve"><value>Terminal info</value></data>
+  <data name="Settings.DevDiagnose.TerminalInfo.JsTerminalCount" xml:space="preserve"><value>JavaScript terminal count:</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.Header" xml:space="preserve"><value>Terminal control test</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.ScrollBottom" xml:space="preserve"><value>Scroll to bottom</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.ScrollTop" xml:space="preserve"><value>Scroll to top</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.GetPosition" xml:space="preserve"><value>Get position</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.Initial" xml:space="preserve"><value>Scroll position info will appear here</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.BottomFormat" xml:space="preserve"><value>Scrolled to bottom - {0}</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.TopFormat" xml:space="preserve"><value>Scrolled to top - {0}</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.PositionFormat" xml:space="preserve"><value>Scroll position: {0} - {1}</value></data>
+
+  <!-- Settings: Dev Buffer Tab -->
+  <data name="Settings.DevBuffer.Header" xml:space="preserve"><value>Buffer Dump</value></data>
+  <data name="Settings.DevBuffer.Help" xml:space="preserve"><value>Downloads the session's output buffer (up to 2MB) as a file.</value></data>
+  <data name="Settings.DevBuffer.SelectLabel" xml:space="preserve"><value>Select session</value></data>
+  <data name="Settings.DevBuffer.SelectPlaceholder" xml:space="preserve"><value>-- Select a session --</value></data>
+  <data name="Settings.DevBuffer.Empty" xml:space="preserve"><value>(empty)</value></data>
+  <data name="Settings.DevBuffer.BufferFormat" xml:space="preserve"><value>Buffer: {0}</value></data>
+  <data name="Settings.DevBuffer.StatusHistoryFormat" xml:space="preserve"><value>Status history: {0}</value></data>
+  <data name="Settings.DevBuffer.DownloadBuffer" xml:space="preserve"><value>Buffer</value></data>
+  <data name="Settings.DevBuffer.DownloadBufferClean" xml:space="preserve"><value>Buffer (ANSI stripped)</value></data>
+  <data name="Settings.DevBuffer.DownloadStatusHistory" xml:space="preserve"><value>Status history JSON</value></data>
+  <data name="Settings.DevBuffer.Result.SelectSession" xml:space="preserve"><value>Please select a session</value></data>
+  <data name="Settings.DevBuffer.Result.BufferEmpty" xml:space="preserve"><value>Buffer is empty</value></data>
+  <data name="Settings.DevBuffer.Result.DownloadedFormat" xml:space="preserve"><value>Download complete: {0} ({1})</value></data>
+  <data name="Settings.DevBuffer.HeaderBufferInfo" xml:space="preserve"><value>Buffer Info</value></data>
+  <data name="Settings.DevBuffer.HeaderBufferContent" xml:space="preserve"><value>Buffer Content</value></data>
+
+  <!-- Settings: Dev Notify Tab -->
+  <data name="Settings.DevNotify.Header" xml:space="preserve"><value>Notification Test</value></data>
+  <data name="Settings.DevNotify.TestElapsedLabel" xml:space="preserve"><value>Test elapsed time (seconds)</value></data>
+  <data name="Settings.DevNotify.TestBrowser" xml:space="preserve"><value>Test browser notification</value></data>
+  <data name="Settings.DevNotify.TestWebhook" xml:space="preserve"><value>Test webhook notification</value></data>
+  <data name="Settings.DevNotify.Result.Initial" xml:space="preserve"><value>Test results will appear here</value></data>
+  <data name="Settings.DevNotify.Result.BrowserSendingFormat" xml:space="preserve"><value>Sending browser notification... (as {0}s process)</value></data>
+  <data name="Settings.DevNotify.Result.BrowserSentFormat" xml:space="preserve"><value>Browser notification sent - {0}</value></data>
+  <data name="Settings.DevNotify.Result.WebhookSendingFormat" xml:space="preserve"><value>Sending webhook notification... (as {0}s process)</value></data>
+  <data name="Settings.DevNotify.Result.WebhookSentFormat" xml:space="preserve"><value>Webhook notification sent - {0}</value></data>
+  <data name="Settings.DevNotify.SessionName.Browser" xml:space="preserve"><value>Browser notification test</value></data>
+  <data name="Settings.DevNotify.SessionName.Webhook" xml:space="preserve"><value>Webhook notification test</value></data>
+
+  <!-- Settings: Cross-tab messages (saveMessage / validation / version / export / import) -->
+  <data name="Settings.Message.PermissionGranted" xml:space="preserve"><value>Notifications allowed</value></data>
+  <data name="Settings.Message.PermissionDenied" xml:space="preserve"><value>Notifications denied</value></data>
+  <data name="Settings.Message.OpenFolderErrorFormat" xml:space="preserve"><value>Could not open folder: {0}</value></data>
+  <data name="Settings.Message.ThresholdNegative" xml:space="preserve"><value>Notification threshold must be 0 or greater</value></data>
+  <data name="Settings.Message.WebhookUrlRequired" xml:space="preserve"><value>Please enter a Webhook URL</value></data>
+  <data name="Settings.Message.PathNotExists" xml:space="preserve"><value>The specified path does not exist</value></data>
+  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>The specified folder does not exist</value></data>
+  <data name="Settings.Message.FolderDuplicate" xml:space="preserve"><value>This folder has already been added</value></data>
+  <data name="Settings.Message.SaveSuccess" xml:space="preserve"><value>Settings saved</value></data>
+  <data name="Settings.Message.SaveErrorFormat" xml:space="preserve"><value>Save error: {0}</value></data>
+  <data name="Settings.Message.VersionFetchFailed" xml:space="preserve"><value>Could not retrieve version information</value></data>
+  <data name="Settings.Message.VersionCheckErrorFormat" xml:space="preserve"><value>Check failed: {0}</value></data>
+  <data name="Settings.Message.ExportSuccessFormat" xml:space="preserve"><value>Exported {0} sessions</value></data>
+  <data name="Settings.Message.ExportErrorFormat" xml:space="preserve"><value>Export error: {0}</value></data>
+  <data name="Settings.Message.JsonFileRequired" xml:space="preserve"><value>Please select a JSON file</value></data>
+  <data name="Settings.Message.SessionsNotFound" xml:space="preserve"><value>No sessions found</value></data>
+  <data name="Settings.Message.FileReadErrorFormat" xml:space="preserve"><value>File read error: {0}</value></data>
+  <data name="Settings.Message.ImportResultFormat" xml:space="preserve"><value>Import complete ({0} added, {1} skipped as duplicates). Please reload the page.</value></data>
+  <data name="Settings.Message.ImportErrorFormat" xml:space="preserve"><value>Import error: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -457,4 +457,40 @@
   <data name="SubSession.Button.SamePath" xml:space="preserve"><value>Create session</value></data>
   <data name="SubSession.Button.NewFolder" xml:space="preserve"><value>Create folder</value></data>
   <data name="SubSession.ErrorFormat" xml:space="preserve"><value>An error occurred during the operation: {0}</value></data>
+
+  <!-- SessionList (left sidebar) -->
+  <data name="SessionList.CreateSession" xml:space="preserve"><value>New Session</value></data>
+  <data name="SessionList.EmptyHint" xml:space="preserve"><value>Use the button above to create a session</value></data>
+  <data name="SessionList.SearchPlaceholder" xml:space="preserve"><value>Search sessions...</value></data>
+  <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>Archived sessions</value></data>
+  <data name="SessionList.Badge.Pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="SessionList.Badge.Notification" xml:space="preserve"><value>Processing completed</value></data>
+  <data name="SessionList.Badge.DirectoryNotFoundFormat" xml:space="preserve"><value>Directory not found: {0}</value></data>
+  <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git branch</value></data>
+  <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>Uncommitted changes</value></data>
+  <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>Remote control connected</value></data>
+  <data name="SessionList.Badge.ChildrenCountFormat" xml:space="preserve"><value>{0} children</value></data>
+  <data name="SessionList.Tooltip.Settings" xml:space="preserve"><value>Session settings</value></data>
+  <data name="SessionList.Tooltip.Delete" xml:space="preserve"><value>Delete session</value></data>
+
+  <!-- ArchivedSessions Dialog -->
+  <data name="ArchivedSessions.Title" xml:space="preserve"><value>Archived Sessions</value></data>
+  <data name="ArchivedSessions.SearchPlaceholder" xml:space="preserve"><value>Search archives...</value></data>
+  <data name="ArchivedSessions.SelectAll" xml:space="preserve"><value>Select all</value></data>
+  <data name="ArchivedSessions.SelectedCountFormat" xml:space="preserve"><value>{0} selected</value></data>
+  <data name="ArchivedSessions.DeleteSelected" xml:space="preserve"><value>Delete selected</value></data>
+  <data name="ArchivedSessions.DirectoryNotFound" xml:space="preserve"><value>Directory not found</value></data>
+  <data name="ArchivedSessions.ArchivedAtFormat" xml:space="preserve"><value>Archived at: {0}</value></data>
+  <data name="ArchivedSessions.DateUnknown" xml:space="preserve"><value>Unknown</value></data>
+  <data name="ArchivedSessions.Restore" xml:space="preserve"><value>Restore</value></data>
+  <data name="ArchivedSessions.DeletePermanently" xml:space="preserve"><value>Delete permanently</value></data>
+  <data name="ArchivedSessions.NoResults" xml:space="preserve"><value>No search results</value></data>
+  <data name="ArchivedSessions.Empty" xml:space="preserve"><value>No archived sessions</value></data>
+  <data name="ArchivedSessions.DeleteAll" xml:space="preserve"><value>Delete all</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Title" xml:space="preserve"><value>Confirm deletion</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.AllFormat" xml:space="preserve"><value>Permanently delete all {0} archived sessions?</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.SelectedFormat" xml:space="preserve"><value>Permanently delete {0} selected archived sessions?</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.SingleFormat" xml:space="preserve"><value>Permanently delete "{0}"?</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Irreversible" xml:space="preserve"><value>This action cannot be undone.</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Execute" xml:space="preserve"><value>Delete</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -545,4 +545,6 @@
   <data name="Root.Toast.SessionRecreatedWithoutContinue" xml:space="preserve"><value>Session recreated without --continue option</value></data>
   <data name="Root.Toast.SessionRecreateFailed" xml:space="preserve"><value>Failed to recreate session</value></data>
   <data name="Root.Toast.SessionRecreateErrorFormat" xml:space="preserve"><value>Session recreate error: {0}</value></data>
+  <data name="Root.Confirm.DeleteSessionFormat" xml:space="preserve"><value>Delete session "{0}"?</value></data>
+  <data name="Root.Confirm.ArchiveSessionFormat" xml:space="preserve"><value>Archive session "{0}"?</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -493,4 +493,29 @@
   <data name="ArchivedSessions.DeleteConfirm.SingleFormat" xml:space="preserve"><value>Permanently delete "{0}"?</value></data>
   <data name="ArchivedSessions.DeleteConfirm.Irreversible" xml:space="preserve"><value>This action cannot be undone.</value></data>
   <data name="ArchivedSessions.DeleteConfirm.Execute" xml:space="preserve"><value>Delete</value></data>
+
+  <!-- BottomPanels: TextInputPanel -->
+  <data name="TextInput.KeyHints.Send" xml:space="preserve"><value>Send</value></data>
+  <data name="TextInput.KeyHints.Newline" xml:space="preserve"><value>Newline</value></data>
+  <data name="TextInput.KeyHints.History" xml:space="preserve"><value>History</value></data>
+  <data name="TextInput.VoiceInput.Tooltip" xml:space="preserve"><value>Voice input (hold to record)</value></data>
+  <data name="TextInput.Refine.Tooltip" xml:space="preserve"><value>Clean up typos and phrasing with Claude Code</value></data>
+  <data name="TextInput.Refine.Label" xml:space="preserve"><value>Refine</value></data>
+  <data name="TextInput.Send" xml:space="preserve"><value>Send</value></data>
+  <data name="TextInput.ModeSwitch.TooltipFormat" xml:space="preserve"><value>Mode switch ({0})</value></data>
+
+  <!-- BottomPanels: MemoPanel -->
+  <data name="MemoPanel.Placeholder" xml:space="preserve"><value>Memo... (Enter for newline, auto-saved)</value></data>
+
+  <!-- BottomPanel (tab host) -->
+  <data name="BottomPanel.CloseTab" xml:space="preserve"><value>Close tab</value></data>
+  <data name="BottomPanel.AddCommandPrompt" xml:space="preserve"><value>Add Command Prompt</value></data>
+  <data name="BottomPanel.AddPowerShell" xml:space="preserve"><value>Add PowerShell</value></data>
+  <data name="BottomPanel.AddMemo" xml:space="preserve"><value>Add memo</value></data>
+  <data name="BottomPanel.Tab.TextInputDefault" xml:space="preserve"><value>Text input</value></data>
+  <data name="BottomPanel.Tab.TextInputFormat" xml:space="preserve"><value>Text input ({0})</value></data>
+  <data name="BottomPanel.Tab.CommandPromptFormat" xml:space="preserve"><value>Command Prompt ({0})</value></data>
+  <data name="BottomPanel.Tab.PowerShellFormat" xml:space="preserve"><value>PowerShell ({0})</value></data>
+  <data name="BottomPanel.Tab.GenericFormat" xml:space="preserve"><value>Tab ({0})</value></data>
+  <data name="BottomPanel.Tab.MemoFormat" xml:space="preserve"><value>Memo ({0})</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -151,4 +151,46 @@
   <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>Hide input panel</value></data>
   <data name="Settings.Sessions.InputPanel.HideSub" xml:space="preserve"><value>Terminal only</value></data>
   <data name="Settings.Sessions.InputPanel.HideHelp" xml:space="preserve"><value>Hide the bottom input panel to use more space for the terminal.</value></data>
+
+  <!-- Settings: Export/Import Tab -->
+  <data name="Settings.Export.Header" xml:space="preserve"><value>Export / Import Data</value></data>
+  <data name="Settings.Export.Export.Header" xml:space="preserve"><value>Export</value></data>
+  <data name="Settings.Export.Export.Help" xml:space="preserve"><value>Downloads session data from the current storage ({0}) as a JSON file.</value></data>
+  <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>Export target: sessions ({0})</value></data>
+  <data name="Settings.Export.Export.Button" xml:space="preserve"><value>Export</value></data>
+  <data name="Settings.Export.Import.Header" xml:space="preserve"><value>Import</value></data>
+  <data name="Settings.Export.Import.Help" xml:space="preserve"><value>Select a JSON file to import session data. It will be added to the current storage ({0}).</value></data>
+  <data name="Settings.Export.Import.PreviewHeader" xml:space="preserve"><value>Import preview</value></data>
+  <data name="Settings.Export.Import.PreviewSessions" xml:space="preserve"><value>Sessions: {0}</value></data>
+  <data name="Settings.Export.Import.RunButton" xml:space="preserve"><value>Run import</value></data>
+
+  <!-- Settings: Commands Tab -->
+  <data name="Settings.Commands.Header" xml:space="preserve"><value>Custom Commands</value></data>
+  <data name="Settings.Commands.Help" xml:space="preserve"><value>Register commands shown in the button bar for each terminal type.</value></data>
+  <data name="Settings.Commands.Type.Text" xml:space="preserve"><value>Text</value></data>
+  <data name="Settings.Commands.Type.Key" xml:space="preserve"><value>Key</value></data>
+  <data name="Settings.Commands.TitlePlaceholder" xml:space="preserve"><value>Title (optional)</value></data>
+  <data name="Settings.Commands.CommandPlaceholder" xml:space="preserve"><value>Command (e.g., /plan)</value></data>
+  <data name="Settings.Commands.DragToReorder" xml:space="preserve"><value>Drag to reorder</value></data>
+
+  <!-- Settings: Remote Launch Tab -->
+  <data name="Settings.RemoteLaunch.Header" xml:space="preserve"><value>Remote Launch</value></data>
+  <data name="Settings.RemoteLaunch.Help" xml:space="preserve"><value>Launch Claude Code sessions from your phone while away and obtain a Remote Control URL.</value></data>
+  <data name="Settings.RemoteLaunch.Enable" xml:space="preserve"><value>Enable remote launch</value></data>
+  <data name="Settings.RemoteLaunch.Connected" xml:space="preserve"><value>Connected</value></data>
+  <data name="Settings.RemoteLaunch.Disconnected" xml:space="preserve"><value>Disconnected</value></data>
+  <data name="Settings.RemoteLaunch.Connecting" xml:space="preserve"><value>Connecting...</value></data>
+  <data name="Settings.RemoteLaunch.DiagPing" xml:space="preserve"><value>Test connection</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingChecking" xml:space="preserve"><value>Checking...</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingOkFormat" xml:space="preserve"><value>OK (round-trip {0} ms)</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingNgFormat" xml:space="preserve"><value>Failed: {0}</value></data>
+  <data name="Settings.RemoteLaunch.AccessUrl" xml:space="preserve"><value>Access URL</value></data>
+  <data name="Settings.RemoteLaunch.CopyUrlTitle" xml:space="preserve"><value>Copy URL</value></data>
+  <data name="Settings.RemoteLaunch.UrlWarning" xml:space="preserve"><value>Do not share this URL. Anyone who knows it can launch sessions.</value></data>
+  <data name="Settings.RemoteLaunch.PasswordLabel" xml:space="preserve"><value>Password (optional)</value></data>
+  <data name="Settings.RemoteLaunch.PasswordPlaceholder" xml:space="preserve"><value>When set, a password will be required at access time</value></data>
+  <data name="Settings.RemoteLaunch.PasswordHelp" xml:space="preserve"><value>If empty, the URL alone grants access.</value></data>
+  <data name="Settings.RemoteLaunch.TopicGuid" xml:space="preserve"><value>Topic GUID</value></data>
+  <data name="Settings.RemoteLaunch.RegenerateGuidTitle" xml:space="preserve"><value>Regenerate GUID (existing access URL will be invalidated)</value></data>
+  <data name="Settings.RemoteLaunch.RegenerateGuidHelp" xml:space="preserve"><value>Regenerating invalidates the existing access URL.</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -58,6 +58,8 @@
   <!-- Common -->
   <data name="Common.Close" xml:space="preserve"><value>Close</value></data>
   <data name="Common.Add" xml:space="preserve"><value>Add</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Common.Create" xml:space="preserve"><value>Create</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>Error: {0}</value></data>
 
   <!-- Settings Dialog -->
@@ -272,7 +274,7 @@
   <data name="Settings.Message.ThresholdNegative" xml:space="preserve"><value>Notification threshold must be 0 or greater</value></data>
   <data name="Settings.Message.WebhookUrlRequired" xml:space="preserve"><value>Please enter a Webhook URL</value></data>
   <data name="Settings.Message.PathNotExists" xml:space="preserve"><value>The specified path does not exist</value></data>
-  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>The specified folder does not exist</value></data>
+  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>The specified folder does not exist.</value></data>
   <data name="Settings.Message.FolderDuplicate" xml:space="preserve"><value>This folder has already been added</value></data>
   <data name="Settings.Message.SaveSuccess" xml:space="preserve"><value>Settings saved</value></data>
   <data name="Settings.Message.SaveErrorFormat" xml:space="preserve"><value>Save error: {0}</value></data>
@@ -285,4 +287,17 @@
   <data name="Settings.Message.FileReadErrorFormat" xml:space="preserve"><value>File read error: {0}</value></data>
   <data name="Settings.Message.ImportResultFormat" xml:space="preserve"><value>Import complete ({0} added, {1} skipped as duplicates). Please reload the page.</value></data>
   <data name="Settings.Message.ImportErrorFormat" xml:space="preserve"><value>Import error: {0}</value></data>
+
+  <!-- SessionCreate Dialog -->
+  <data name="SessionCreate.Title" xml:space="preserve"><value>New Session</value></data>
+  <data name="SessionCreate.FolderLabel" xml:space="preserve"><value>Select folder</value></data>
+  <data name="SessionCreate.FolderPlaceholder" xml:space="preserve"><value>Enter or select a folder path</value></data>
+  <data name="SessionCreate.BrowseButton" xml:space="preserve"><value>Browse</value></data>
+  <data name="SessionCreate.FavoriteFolders" xml:space="preserve"><value>Favorite folders</value></data>
+  <data name="SessionCreate.DefaultFolder" xml:space="preserve"><value>Default folder</value></data>
+  <data name="SessionCreate.UserHome" xml:space="preserve"><value>User home</value></data>
+  <data name="SessionCreate.PickFolder" xml:space="preserve"><value>Pick folder...</value></data>
+  <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>Create Folder</value></data>
+  <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>Create this folder?</value></data>
+  <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>Create</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -62,6 +62,7 @@
   <data name="Common.Create" xml:space="preserve"><value>Create</value></data>
   <data name="Common.Unspecified" xml:space="preserve"><value>Unspecified</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>Error: {0}</value></data>
+  <data name="Common.DirectoryNotFoundFormat" xml:space="preserve"><value>Directory not found: {0}</value></data>
 
   <!-- Settings Dialog -->
   <data name="Settings.Title" xml:space="preserve"><value>Settings</value></data>
@@ -465,7 +466,6 @@
   <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>Archived sessions</value></data>
   <data name="SessionList.Badge.Pinned" xml:space="preserve"><value>Pinned</value></data>
   <data name="SessionList.Badge.Notification" xml:space="preserve"><value>Processing completed</value></data>
-  <data name="SessionList.Badge.DirectoryNotFoundFormat" xml:space="preserve"><value>Directory not found: {0}</value></data>
   <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git branch</value></data>
   <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>Uncommitted changes</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>Remote control connected</value></data>
@@ -518,4 +518,31 @@
   <data name="BottomPanel.Tab.PowerShellFormat" xml:space="preserve"><value>PowerShell ({0})</value></data>
   <data name="BottomPanel.Tab.GenericFormat" xml:space="preserve"><value>Tab ({0})</value></data>
   <data name="BottomPanel.Tab.MemoFormat" xml:space="preserve"><value>Memo ({0})</value></data>
+
+  <!-- Root page -->
+  <data name="Root.NoSessionSelected" xml:space="preserve"><value>Select a session from the left sidebar</value></data>
+  <data name="Root.Placeholder.ClaudeCode" xml:space="preserve"><value>Type a message for Claude Code...</value></data>
+  <data name="Root.Placeholder.GeminiCLI" xml:space="preserve"><value>Type a message for Gemini CLI...</value></data>
+  <data name="Root.Placeholder.Terminal" xml:space="preserve"><value>Enter a command...</value></data>
+  <data name="Root.SessionType.Terminal" xml:space="preserve"><value>Terminal</value></data>
+  <data name="Root.SessionType.Fallback" xml:space="preserve"><value>Session</value></data>
+
+  <!-- Root: Toast messages -->
+  <data name="Root.Toast.SessionCreateErrorFormat" xml:space="preserve"><value>Session creation error: {0}</value></data>
+  <data name="Root.Toast.SessionInitErrorFormat" xml:space="preserve"><value>Session initialization error: {0}</value></data>
+  <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>Terminal disposed</value></data>
+  <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>Terminal dispose error: {0}</value></data>
+  <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>Terminal recreated</value></data>
+  <data name="Root.Toast.SelectSessionFirst" xml:space="preserve"><value>Please select this session first, then recreate the terminal</value></data>
+  <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>Terminal recreate error: {0}</value></data>
+  <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' created</value></data>
+  <data name="Root.Toast.WorktreeAddedFormat" xml:space="preserve"><value>Existing worktree '{0}' added</value></data>
+  <data name="Root.Toast.SamePathSessionCreatedFormat" xml:space="preserve"><value>New {0} session created</value></data>
+  <data name="Root.Toast.NewFolderSessionCreatedFormat" xml:space="preserve"><value>New session created in folder '{0}'</value></data>
+  <data name="Root.Toast.SessionCreated" xml:space="preserve"><value>Session created</value></data>
+  <data name="Root.Toast.SessionCreateFailed" xml:space="preserve"><value>Failed to create session</value></data>
+  <data name="Root.Toast.SessionSettingsSaved" xml:space="preserve"><value>Session settings saved</value></data>
+  <data name="Root.Toast.SessionRecreatedWithoutContinue" xml:space="preserve"><value>Session recreated without --continue option</value></data>
+  <data name="Root.Toast.SessionRecreateFailed" xml:space="preserve"><value>Failed to recreate session</value></data>
+  <data name="Root.Toast.SessionRecreateErrorFormat" xml:space="preserve"><value>Session recreate error: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    i18n shared resources (English - canonical)
+    Keys use dotted "Area.Element" hierarchy. Must match SharedResource.ja.resx.
+  -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+
+  <!-- Common -->
+  <data name="Common.Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Common.Add" xml:space="preserve"><value>Add</value></data>
+
+  <!-- Settings Dialog -->
+  <data name="Settings.Title" xml:space="preserve"><value>Settings</value></data>
+
+  <!-- Settings Tabs -->
+  <data name="Settings.Tab.General" xml:space="preserve"><value>General</value></data>
+  <data name="Settings.Tab.Display" xml:space="preserve"><value>Display</value></data>
+  <data name="Settings.Tab.Notifications" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Settings.Tab.Sessions" xml:space="preserve"><value>Sessions</value></data>
+  <data name="Settings.Tab.ExportImport" xml:space="preserve"><value>Export / Import</value></data>
+  <data name="Settings.Tab.Commands" xml:space="preserve"><value>Commands</value></data>
+  <data name="Settings.Tab.RemoteLaunch" xml:space="preserve"><value>Remote Launch</value></data>
+  <data name="Settings.Tab.Special" xml:space="preserve"><value>Special</value></data>
+  <data name="Settings.Tab.DevDiagnose" xml:space="preserve"><value>Diagnostics</value></data>
+  <data name="Settings.Tab.DevBuffer" xml:space="preserve"><value>Buffer</value></data>
+  <data name="Settings.Tab.DevNotify" xml:space="preserve"><value>Notification Test</value></data>
+
+  <!-- Settings: General Tab -->
+  <data name="Settings.General.Header" xml:space="preserve"><value>General</value></data>
+  <data name="Settings.General.Language.Label" xml:space="preserve"><value>Language</value></data>
+  <data name="Settings.General.Language.Help" xml:space="preserve"><value>Switch the UI language. Selecting a value reloads the page.</value></data>
+  <data name="Settings.General.DefaultFolder.Label" xml:space="preserve"><value>Default folder path</value></data>
+  <data name="Settings.General.DefaultFolder.PickTitle" xml:space="preserve"><value>Choose a folder</value></data>
+  <data name="Settings.General.DefaultFolder.Help" xml:space="preserve"><value>Sets the default path for new sessions. When empty, the user home folder is used.</value></data>
+  <data name="Settings.General.FavoriteFolders.Label" xml:space="preserve"><value>Favorite folders</value></data>
+  <data name="Settings.General.FavoriteFolders.Placeholder" xml:space="preserve"><value>Enter a folder path</value></data>
+  <data name="Settings.General.FavoriteFolders.Help" xml:space="preserve"><value>Shown as suggestions when creating a new session.</value></data>
+  <data name="Settings.General.Version.Header" xml:space="preserve"><value>Version</value></data>
+  <data name="Settings.General.Version.Current" xml:space="preserve"><value>Current version:</value></data>
+  <data name="Settings.General.Version.Checking" xml:space="preserve"><value>Checking for updates...</value></data>
+  <data name="Settings.General.Version.NewAvailableHtml" xml:space="preserve"><value>A new version &lt;strong&gt;v{0}&lt;/strong&gt; is available</value></data>
+  <data name="Settings.General.Version.CheckOnGitHub" xml:space="preserve"><value>Check on GitHub</value></data>
+  <data name="Settings.General.Version.UpToDate" xml:space="preserve"><value>You're on the latest version</value></data>
+  <data name="Settings.General.Community.Header" xml:space="preserve"><value>Community</value></data>
+  <data name="Settings.General.Community.JoinDiscord" xml:space="preserve"><value>Join the Discord server</value></data>
+  <data name="Settings.General.Community.Help" xml:space="preserve"><value>Bug reports, feature requests, and questions are welcome there.</value></data>
+</root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -394,4 +394,67 @@
   <data name="SessionOptions.Codex.AdditionalDirs.Help" xml:space="preserve"><value>Each line is passed as --add-dir</value></data>
   <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --reasoning-effort high</value></data>
   <data name="SessionOptions.Codex.PassToCli" xml:space="preserve"><value>Passed as-is to Codex CLI</value></data>
+
+  <!-- SessionSettings Dialog -->
+  <data name="SessionSettings.Title" xml:space="preserve"><value>Session Settings</value></data>
+  <data name="SessionSettings.Info.Header" xml:space="preserve"><value>Session info</value></data>
+  <data name="SessionSettings.Info.SessionName" xml:space="preserve"><value>Session name:</value></data>
+  <data name="SessionSettings.Info.Folder" xml:space="preserve"><value>Folder:</value></data>
+  <data name="SessionSettings.Info.CopyFolderPath" xml:space="preserve"><value>Copy folder path</value></data>
+  <data name="SessionSettings.Info.OpenFolder" xml:space="preserve"><value>Open folder</value></data>
+  <data name="SessionSettings.Info.SessionId" xml:space="preserve"><value>Session ID:</value></data>
+  <data name="SessionSettings.Info.CopySessionId" xml:space="preserve"><value>Copy session ID</value></data>
+  <data name="SessionSettings.CreateSubSession" xml:space="preserve"><value>Create sub-session</value></data>
+  <data name="SessionSettings.OpenMemoManagement" xml:space="preserve"><value>Manage memos</value></data>
+  <data name="SessionSettings.DisplayName.Label" xml:space="preserve"><value>Display name</value></data>
+  <data name="SessionSettings.DisplayName.Placeholder" xml:space="preserve"><value>Session display name</value></data>
+  <data name="SessionSettings.DisplayName.Help" xml:space="preserve"><value>If blank, the folder name will be used</value></data>
+  <data name="SessionSettings.Pin.Label" xml:space="preserve"><value>Pin this session</value></data>
+  <data name="SessionSettings.Pin.PriorityLabel" xml:space="preserve"><value>Priority:</value></data>
+  <data name="SessionSettings.Memo.Label" xml:space="preserve"><value>Memo</value></data>
+  <data name="SessionSettings.Memo.Placeholder" xml:space="preserve"><value>Memo for this session</value></data>
+  <data name="SessionSettings.Memo.Help" xml:space="preserve"><value>Write any notes about this session here</value></data>
+  <data name="SessionSettings.Loading" xml:space="preserve"><value>Loading session info...</value></data>
+  <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>Apply changes immediately (restart session)</value></data>
+  <data name="SessionSettings.Save" xml:space="preserve"><value>Save</value></data>
+  <data name="SessionSettings.SaveErrorFormat" xml:space="preserve"><value>Failed to save settings: {0}</value></data>
+  <data name="SessionSettings.RestartFailed" xml:space="preserve"><value>Settings were saved, but session restart failed.</value></data>
+
+  <!-- SubSession Dialog -->
+  <data name="SubSession.Title" xml:space="preserve"><value>Create Sub-session</value></data>
+  <data name="SubSession.ParentSessionFormat" xml:space="preserve"><value>Parent session: {0}</value></data>
+  <data name="SubSession.Tab.CreateWorktree" xml:space="preserve"><value>New worktree</value></data>
+  <data name="SubSession.Tab.ExistingWorktree" xml:space="preserve"><value>Existing worktree</value></data>
+  <data name="SubSession.Tab.SamePath" xml:space="preserve"><value>Same folder</value></data>
+  <data name="SubSession.Tab.NewFolder" xml:space="preserve"><value>New folder</value></data>
+  <data name="SubSession.GitRequired.Title" xml:space="preserve"><value>Git repository required</value></data>
+  <data name="SubSession.GitRequired.CreateWorktree" xml:space="preserve"><value>A Git repository is required to create a worktree.</value></data>
+  <data name="SubSession.GitRequired.ExistingWorktree" xml:space="preserve"><value>A Git repository is required to add an existing worktree.</value></data>
+  <data name="SubSession.BranchSelection.Label" xml:space="preserve"><value>Branch selection</value></data>
+  <data name="SubSession.BranchSelection.New" xml:space="preserve"><value>New branch</value></data>
+  <data name="SubSession.BranchSelection.Existing" xml:space="preserve"><value>Existing branch</value></data>
+  <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>New branch name</value></data>
+  <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>A new worktree will be created for this branch</value></data>
+  <data name="SubSession.ExistingBranch.Label" xml:space="preserve"><value>Select an existing branch</value></data>
+  <data name="SubSession.ExistingBranch.Loading" xml:space="preserve"><value>Loading branch list...</value></data>
+  <data name="SubSession.ExistingBranch.Empty" xml:space="preserve"><value>No branches available</value></data>
+  <data name="SubSession.ExistingBranch.Placeholder" xml:space="preserve"><value>Please select a branch</value></data>
+  <data name="SubSession.BranchExistingWorktree.Title" xml:space="preserve"><value>A worktree already exists for this branch</value></data>
+  <data name="SubSession.BranchExistingWorktree.PathFormat" xml:space="preserve"><value>Path: {0}</value></data>
+  <data name="SubSession.BranchExistingWorktree.Help" xml:space="preserve"><value>Please use the "Existing worktree" tab to add it</value></data>
+  <data name="SubSession.ExistingWorktree.Label" xml:space="preserve"><value>Select an existing worktree</value></data>
+  <data name="SubSession.ExistingWorktree.Loading" xml:space="preserve"><value>Loading worktree list...</value></data>
+  <data name="SubSession.ExistingWorktree.Empty" xml:space="preserve"><value>No worktrees available</value></data>
+  <data name="SubSession.ExistingWorktree.Placeholder" xml:space="preserve"><value>Please select a worktree</value></data>
+  <data name="SubSession.WorktreeMainSuffix" xml:space="preserve"><value>- main</value></data>
+  <data name="SubSession.SamePath.InfoFormat" xml:space="preserve"><value>Opens in the same folder as parent session "{0}"</value></data>
+  <data name="SubSession.NewFolder.Label" xml:space="preserve"><value>New folder path</value></data>
+  <data name="SubSession.NewFolder.Placeholder" xml:space="preserve"><value>C:\path\to\new\folder or relative path</value></data>
+  <data name="SubSession.NewFolder.Help" xml:space="preserve"><value>The folder will be created automatically if it doesn't exist</value></data>
+  <data name="SubSession.NewFolder.InfoFormat" xml:space="preserve"><value>Starts a session in the new folder "{0}"</value></data>
+  <data name="SubSession.Button.Create" xml:space="preserve"><value>Create worktree</value></data>
+  <data name="SubSession.Button.Existing" xml:space="preserve"><value>Add worktree</value></data>
+  <data name="SubSession.Button.SamePath" xml:space="preserve"><value>Create session</value></data>
+  <data name="SubSession.Button.NewFolder" xml:space="preserve"><value>Create folder</value></data>
+  <data name="SubSession.ErrorFormat" xml:space="preserve"><value>An error occurred during the operation: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -60,6 +60,7 @@
   <data name="Common.Add" xml:space="preserve"><value>Add</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
   <data name="Common.Create" xml:space="preserve"><value>Create</value></data>
+  <data name="Common.Unspecified" xml:space="preserve"><value>Unspecified</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>Error: {0}</value></data>
 
   <!-- Settings Dialog -->
@@ -300,4 +301,97 @@
   <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>Create Folder</value></data>
   <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>Create this folder?</value></data>
   <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>Create</value></data>
+
+  <!-- SessionOptionsSelector: common -->
+  <data name="SessionOptions.TerminalType.Label" xml:space="preserve"><value>Terminal type</value></data>
+  <data name="SessionOptions.TerminalType.Terminal" xml:space="preserve"><value>Terminal</value></data>
+  <data name="SessionOptions.ExtraArgs.Label" xml:space="preserve"><value>Additional arguments</value></data>
+
+  <!-- SessionOptionsSelector: Terminal (default startup command) -->
+  <data name="SessionOptions.Terminal.StartupCommand.Label" xml:space="preserve"><value>Startup command (optional)</value></data>
+  <data name="SessionOptions.Terminal.StartupCommand.Placeholder" xml:space="preserve"><value>e.g., cmd.exe, powershell.exe</value></data>
+
+  <!-- SessionOptionsSelector: Claude Code -->
+  <data name="SessionOptions.Claude.Header" xml:space="preserve"><value>Claude Code Options</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.Label" xml:space="preserve"><value>Permission mode</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.BypassLabel" xml:space="preserve"><value>Bypass</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.BypassTitle" xml:space="preserve"><value>Auto-approves all operations unconditionally (dangerous)</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoLabel" xml:space="preserve"><value>Auto mode</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoTitle" xml:space="preserve"><value>Auto-approves low-risk operations and prompts only for high-risk ones</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.DefaultLabel" xml:space="preserve"><value>Default</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.DefaultTitle" xml:space="preserve"><value>Prompts for confirmation on every operation</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpBypass" xml:space="preserve"><value>Auto-approves all operations unconditionally (--dangerously-skip-permissions).</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpAuto" xml:space="preserve"><value>Auto-approves low-risk operations and prompts only for high-risk ones (--enable-auto-mode).</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpDefault" xml:space="preserve"><value>Prompts for confirmation on every operation.</value></data>
+  <data name="SessionOptions.Claude.Continue" xml:space="preserve"><value>Continue (--continue)</value></data>
+  <data name="SessionOptions.Claude.Chrome" xml:space="preserve"><value>Browser integration (--chrome)</value></data>
+  <data name="SessionOptions.Claude.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --model claude-sonnet-4-20250514 --verbose</value></data>
+  <data name="SessionOptions.Claude.PassToCli" xml:space="preserve"><value>Passed as-is to Claude Code</value></data>
+
+  <!-- SessionOptionsSelector: Gemini CLI -->
+  <data name="SessionOptions.Gemini.Header" xml:space="preserve"><value>Gemini CLI Options</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.Label" xml:space="preserve"><value>Approval mode</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.DefaultTitle" xml:space="preserve"><value>Prompts for confirmation on every tool use (default)</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.AutoEditTitle" xml:space="preserve"><value>Auto-approves safe operations like file edits</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.YoloTitle" xml:space="preserve"><value>Auto-approves all operations without warning (dangerous)</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpDefault" xml:space="preserve"><value>Prompts for confirmation on every tool use (default).</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpAutoEdit" xml:space="preserve"><value>Auto-approves safe operations like file edits.</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpYolo" xml:space="preserve"><value>Auto-approves all operations without warning (dangerous).</value></data>
+  <data name="SessionOptions.Gemini.Sandbox" xml:space="preserve"><value>Sandbox mode (-s)</value></data>
+  <data name="SessionOptions.Gemini.SandboxHelp" xml:space="preserve"><value>Docker Desktop must be installed to use this feature.</value></data>
+  <data name="SessionOptions.Gemini.Continue" xml:space="preserve"><value>Continue (--resume latest)</value></data>
+  <data name="SessionOptions.Gemini.UseCustomModel" xml:space="preserve"><value>Customize model</value></data>
+  <data name="SessionOptions.Gemini.ModelSelectLabel" xml:space="preserve"><value>Model to use</value></data>
+  <data name="SessionOptions.Gemini.ModelManagementLabel" xml:space="preserve"><value>Model list management</value></data>
+  <data name="SessionOptions.Gemini.ModelAddPlaceholder" xml:space="preserve"><value>Add a model name...</value></data>
+  <data name="SessionOptions.Gemini.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --debug --allowed-tools shell,file</value></data>
+  <data name="SessionOptions.Gemini.PassToCli" xml:space="preserve"><value>Passed as-is to Gemini CLI</value></data>
+
+  <!-- SessionOptionsSelector: Codex CLI -->
+  <data name="SessionOptions.Codex.Header" xml:space="preserve"><value>Codex CLI Options</value></data>
+  <data name="SessionOptions.Codex.Mode.Label" xml:space="preserve"><value>Execution mode</value></data>
+  <data name="SessionOptions.Codex.Mode.AutoLabel" xml:space="preserve"><value>Auto (recommended)</value></data>
+  <data name="SessionOptions.Codex.Mode.AutoTitle" xml:space="preserve"><value>Mostly automates edits, builds, and tests</value></data>
+  <data name="SessionOptions.Codex.Mode.StandardLabel" xml:space="preserve"><value>Interactive</value></data>
+  <data name="SessionOptions.Codex.Mode.StandardTitle" xml:space="preserve"><value>No explicit auto-run flags; proceeds interactively</value></data>
+  <data name="SessionOptions.Codex.Mode.YoloLabel" xml:space="preserve"><value>YOLO (dangerous)</value></data>
+  <data name="SessionOptions.Codex.Mode.YoloTitle" xml:space="preserve"><value>Fully automatic execution (dangerous). Isolated environment recommended.</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpAuto" xml:space="preserve"><value>Recommended. Adds `--full-auto` for mostly automatic execution.</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpStandard" xml:space="preserve"><value>No explicit auto-run flags; proceeds interactively.</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpYolo" xml:space="preserve"><value>Fully automatic execution (dangerous). Isolated environment recommended.</value></data>
+  <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>Warning:</value></data>
+  <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO mode should only be used in isolated environments (WSL/Docker/VM/CI).</value></data>
+  <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>Resume last session (resume --last)</value></data>
+  <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>Sandbox mode</value></data>
+  <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI default</value></data>
+  <data name="SessionOptions.Codex.Sandbox.DefaultTitle" xml:space="preserve"><value>Do not add --sandbox; use the Codex CLI default.</value></data>
+  <data name="SessionOptions.Codex.Sandbox.ReadOnlyLabel" xml:space="preserve"><value>Read-only</value></data>
+  <data name="SessionOptions.Codex.Sandbox.ReadOnlyTitle" xml:space="preserve"><value>Read-only. Writes are blocked.</value></data>
+  <data name="SessionOptions.Codex.Sandbox.WorkspaceLabel" xml:space="preserve"><value>Workspace (recommended)</value></data>
+  <data name="SessionOptions.Codex.Sandbox.WorkspaceTitle" xml:space="preserve"><value>Writable only within the workspace.</value></data>
+  <data name="SessionOptions.Codex.Sandbox.FullAccessLabel" xml:space="preserve"><value>Full access</value></data>
+  <data name="SessionOptions.Codex.Sandbox.FullAccessTitle" xml:space="preserve"><value>Full access (dangerous).</value></data>
+  <data name="SessionOptions.Codex.Sandbox.Help" xml:space="preserve"><value>Limits external communication and file access.</value></data>
+  <data name="SessionOptions.Codex.Sandbox.HelpDefault" xml:space="preserve"><value>Uses the Codex CLI default.</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Label" xml:space="preserve"><value>Approval policy</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Help" xml:space="preserve"><value>Operation approval level (--ask-for-approval)</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>Treat as untrusted. Prompts for every operation.</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>Prompts only when needed (near-default behavior).</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpNever" xml:space="preserve"><value>Never prompts (dangerous).</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.Label" xml:space="preserve"><value>Network access</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.Help" xml:space="preserve"><value>Network permission for workspace-write (-c sandbox_workspace_write.network_access). Default is enabled.</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.HelpEnabled" xml:space="preserve"><value>Allows network access.</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.HelpRestricted" xml:space="preserve"><value>Restricts network access.</value></data>
+  <data name="SessionOptions.Codex.Profile.Label" xml:space="preserve"><value>Profile</value></data>
+  <data name="SessionOptions.Codex.Profile.Placeholder" xml:space="preserve"><value>e.g., trusted</value></data>
+  <data name="SessionOptions.Codex.Profile.Help" xml:space="preserve"><value>Specifies --profile for Codex CLI</value></data>
+  <data name="SessionOptions.Codex.Model.Label" xml:space="preserve"><value>Model</value></data>
+  <data name="SessionOptions.Codex.Model.Placeholder" xml:space="preserve"><value>e.g., gpt-5-codex</value></data>
+  <data name="SessionOptions.Codex.Model.Help" xml:space="preserve"><value>Specifies --model for Codex CLI</value></data>
+  <data name="SessionOptions.Codex.Search" xml:space="preserve"><value>Enable web search (--search)</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Label" xml:space="preserve"><value>Additional directories</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Placeholder" xml:space="preserve"><value>One directory per line</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Help" xml:space="preserve"><value>Each line is passed as --add-dir</value></data>
+  <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --reasoning-effort high</value></data>
+  <data name="SessionOptions.Codex.PassToCli" xml:space="preserve"><value>Passed as-is to Codex CLI</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -94,4 +94,61 @@
   <data name="Settings.General.Community.Header" xml:space="preserve"><value>Community</value></data>
   <data name="Settings.General.Community.JoinDiscord" xml:space="preserve"><value>Join the Discord server</value></data>
   <data name="Settings.General.Community.Help" xml:space="preserve"><value>Bug reports, feature requests, and questions are welcome there.</value></data>
+
+  <!-- Settings: Display Tab -->
+  <data name="Settings.Display.Header" xml:space="preserve"><value>Display</value></data>
+  <data name="Settings.Display.Theme.Label" xml:space="preserve"><value>Theme</value></data>
+  <data name="Settings.Display.Theme.Light" xml:space="preserve"><value>Light</value></data>
+  <data name="Settings.Display.Theme.Dark" xml:space="preserve"><value>Dark</value></data>
+  <data name="Settings.Display.SessionListScale.Label" xml:space="preserve"><value>Session list scale</value></data>
+  <data name="Settings.Display.SessionListScale.Help" xml:space="preserve"><value>Adjust the session list display scale (50%–150%).</value></data>
+  <data name="Settings.Display.TerminalFontSize.Label" xml:space="preserve"><value>Terminal font size</value></data>
+  <data name="Settings.Display.TerminalFontSize.Help" xml:space="preserve"><value>Adjust the terminal font size (8px–28px).</value></data>
+  <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>Sidebar width</value></data>
+  <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>Adjust the session list width (15%–40%). You can also drag the border.</value></data>
+  <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>Terminal / input panel ratio</value></data>
+  <data name="Settings.Display.TerminalHeightRatio.Help" xml:space="preserve"><value>Adjust the height ratio between the terminal and input panel (50:50–90:10). You can also drag the border.</value></data>
+
+  <!-- Settings: Notifications Tab -->
+  <data name="Settings.Notifications.Header" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Settings.Notifications.Browser.Label" xml:space="preserve"><value>Browser notifications</value></data>
+  <data name="Settings.Notifications.Status.Granted" xml:space="preserve"><value>Allowed</value></data>
+  <data name="Settings.Notifications.Status.Denied" xml:space="preserve"><value>Denied</value></data>
+  <data name="Settings.Notifications.Status.NotRequested" xml:space="preserve"><value>Not requested</value></data>
+  <data name="Settings.Notifications.Status.Checking" xml:space="preserve"><value>Checking...</value></data>
+  <data name="Settings.Notifications.Status.CheckError" xml:space="preserve"><value>Check failed</value></data>
+  <data name="Settings.Notifications.Status.Unknown" xml:space="preserve"><value>Unknown</value></data>
+  <data name="Settings.Notifications.Browser.Enable" xml:space="preserve"><value>Enable browser notifications</value></data>
+  <data name="Settings.Notifications.Browser.Revoke" xml:space="preserve"><value>Revoke notification permission</value></data>
+  <data name="Settings.Notifications.Browser.RevokeHelp" xml:space="preserve"><value>You can revoke the notification permission from your browser's settings.</value></data>
+  <data name="Settings.Notifications.Browser.Request" xml:space="preserve"><value>Allow notifications</value></data>
+  <data name="Settings.Notifications.Browser.RequestHelp" xml:space="preserve"><value>To receive desktop notifications when processing completes, please allow browser notifications.</value></data>
+  <data name="Settings.Notifications.Threshold.Label" xml:space="preserve"><value>Notify after processing time (seconds)</value></data>
+  <data name="Settings.Notifications.Threshold.Help" xml:space="preserve"><value>Set to 0 to notify on every completion</value></data>
+  <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>Webhook</value></data>
+  <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>Enable webhook notifications</value></data>
+  <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>Webhook URL</value></data>
+  <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>Claude Code Hook</value></data>
+  <data name="Settings.Notifications.ClaudeHook.HelpHtml" xml:space="preserve"><value>Use Claude Code's hook feature to receive notifications more reliably. Settings are automatically added to &lt;code&gt;.claude/settings.local.json&lt;/code&gt; when a session is created.</value></data>
+  <data name="Settings.Notifications.ClaudeHook.Enable" xml:space="preserve"><value>Enable Claude Code Hook</value></data>
+  <data name="Settings.Notifications.ClaudeHook.ApplyNoticeHtml" xml:space="preserve"><value>This setting is applied to &lt;code&gt;.claude/settings.local.json&lt;/code&gt; the next time each session is started/restarted. It is not applied immediately to running sessions or workspaces outside TerminalHub's management.</value></data>
+
+  <!-- Settings: Sessions Tab -->
+  <data name="Settings.Sessions.Header" xml:space="preserve"><value>Sessions</value></data>
+  <data name="Settings.Sessions.SortOrder.Label" xml:space="preserve"><value>Session list sort order</value></data>
+  <data name="Settings.Sessions.SortOrder.ByCreatedAt" xml:space="preserve"><value>By creation date</value></data>
+  <data name="Settings.Sessions.SortOrder.ByLastAccessed" xml:space="preserve"><value>By last used</value></data>
+  <data name="Settings.Sessions.SortOrder.ByLastAccessedSub" xml:space="preserve"><value>Most recently used sessions appear at the top</value></data>
+  <data name="Settings.Sessions.SortOrder.ByName" xml:space="preserve"><value>By name</value></data>
+  <data name="Settings.Sessions.SortOrder.Help" xml:space="preserve"><value>In "By last accessed" order, usage of child (worktree) sessions is reflected in the parent's position.</value></data>
+  <data name="Settings.Sessions.Display.Label" xml:space="preserve"><value>Session list display settings</value></data>
+  <data name="Settings.Sessions.Display.ShowTerminalType" xml:space="preserve"><value>Show terminal type</value></data>
+  <data name="Settings.Sessions.Display.ShowTerminalTypeSub" xml:space="preserve"><value>Claude / Gemini / Codex badges</value></data>
+  <data name="Settings.Sessions.Display.ShowGitInfo" xml:space="preserve"><value>Show Git info</value></data>
+  <data name="Settings.Sessions.Display.ShowGitInfoSub" xml:space="preserve"><value>Branch name badge</value></data>
+  <data name="Settings.Sessions.Display.Help" xml:space="preserve"><value>Choose which additional info to display in the session list.</value></data>
+  <data name="Settings.Sessions.InputPanel.Label" xml:space="preserve"><value>Input panel settings</value></data>
+  <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>Hide input panel</value></data>
+  <data name="Settings.Sessions.InputPanel.HideSub" xml:space="preserve"><value>Terminal only</value></data>
+  <data name="Settings.Sessions.InputPanel.HideHelp" xml:space="preserve"><value>Hide the bottom input panel to use more space for the terminal.</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -87,7 +87,7 @@
   <data name="Settings.General.FavoriteFolders.Help" xml:space="preserve"><value>セッション作成時にフォルダ選択の候補として表示されます。</value></data>
   <data name="Settings.General.Version.Header" xml:space="preserve"><value>バージョン情報</value></data>
   <data name="Settings.General.Version.Current" xml:space="preserve"><value>現在のバージョン:</value></data>
-  <data name="Settings.General.Version.Checking" xml:space="preserve"><value>バージョンを確認中...</value></data>
+  <data name="Settings.General.Version.Checking" xml:space="preserve"><value>バージョンを確認中…</value></data>
   <data name="Settings.General.Version.NewAvailableHtml" xml:space="preserve"><value>新しいバージョン &lt;strong&gt;v{0}&lt;/strong&gt; があります</value></data>
   <data name="Settings.General.Version.CheckOnGitHub" xml:space="preserve"><value>GitHubで確認</value></data>
   <data name="Settings.General.Version.UpToDate" xml:space="preserve"><value>最新バージョンです</value></data>
@@ -115,7 +115,7 @@
   <data name="Settings.Notifications.Status.Granted" xml:space="preserve"><value>許可済み</value></data>
   <data name="Settings.Notifications.Status.Denied" xml:space="preserve"><value>拒否</value></data>
   <data name="Settings.Notifications.Status.NotRequested" xml:space="preserve"><value>未許可</value></data>
-  <data name="Settings.Notifications.Status.Checking" xml:space="preserve"><value>確認中...</value></data>
+  <data name="Settings.Notifications.Status.Checking" xml:space="preserve"><value>確認中…</value></data>
   <data name="Settings.Notifications.Status.CheckError" xml:space="preserve"><value>確認エラー</value></data>
   <data name="Settings.Notifications.Status.Unknown" xml:space="preserve"><value>不明</value></data>
   <data name="Settings.Notifications.Browser.Enable" xml:space="preserve"><value>ブラウザ通知を有効にする</value></data>
@@ -151,4 +151,46 @@
   <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>入力パネルを非表示</value></data>
   <data name="Settings.Sessions.InputPanel.HideSub" xml:space="preserve"><value>ターミナルのみ表示</value></data>
   <data name="Settings.Sessions.InputPanel.HideHelp" xml:space="preserve"><value>下部の入力パネルを非表示にして、ターミナル領域を広く使えます。</value></data>
+
+  <!-- Settings: Export/Import Tab -->
+  <data name="Settings.Export.Header" xml:space="preserve"><value>データのエクスポート/インポート</value></data>
+  <data name="Settings.Export.Export.Header" xml:space="preserve"><value>エクスポート</value></data>
+  <data name="Settings.Export.Export.Help" xml:space="preserve"><value>現在のストレージ（{0}）からセッション情報をJSONファイルとしてダウンロードします。</value></data>
+  <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>エクスポート対象: セッション情報（{0} 件）</value></data>
+  <data name="Settings.Export.Export.Button" xml:space="preserve"><value>エクスポート</value></data>
+  <data name="Settings.Export.Import.Header" xml:space="preserve"><value>インポート</value></data>
+  <data name="Settings.Export.Import.Help" xml:space="preserve"><value>JSONファイルを選択してセッション情報をインポートします。現在のストレージ（{0}）に追加されます。</value></data>
+  <data name="Settings.Export.Import.PreviewHeader" xml:space="preserve"><value>インポートプレビュー</value></data>
+  <data name="Settings.Export.Import.PreviewSessions" xml:space="preserve"><value>セッション情報: {0} 件</value></data>
+  <data name="Settings.Export.Import.RunButton" xml:space="preserve"><value>インポート実行</value></data>
+
+  <!-- Settings: Commands Tab -->
+  <data name="Settings.Commands.Header" xml:space="preserve"><value>カスタムコマンド</value></data>
+  <data name="Settings.Commands.Help" xml:space="preserve"><value>ターミナル種別ごとにボタンバーに表示するコマンドを登録できます。</value></data>
+  <data name="Settings.Commands.Type.Text" xml:space="preserve"><value>テキスト</value></data>
+  <data name="Settings.Commands.Type.Key" xml:space="preserve"><value>キー</value></data>
+  <data name="Settings.Commands.TitlePlaceholder" xml:space="preserve"><value>タイトル（省略可）</value></data>
+  <data name="Settings.Commands.CommandPlaceholder" xml:space="preserve"><value>コマンド（例: /plan）</value></data>
+  <data name="Settings.Commands.DragToReorder" xml:space="preserve"><value>ドラッグで並び替え</value></data>
+
+  <!-- Settings: Remote Launch Tab -->
+  <data name="Settings.RemoteLaunch.Header" xml:space="preserve"><value>リモート起動</value></data>
+  <data name="Settings.RemoteLaunch.Help" xml:space="preserve"><value>外出先のスマートフォンから Claude Code セッションを起動し、Remote Control URL を取得できます。</value></data>
+  <data name="Settings.RemoteLaunch.Enable" xml:space="preserve"><value>リモート起動を有効にする</value></data>
+  <data name="Settings.RemoteLaunch.Connected" xml:space="preserve"><value>接続中</value></data>
+  <data name="Settings.RemoteLaunch.Disconnected" xml:space="preserve"><value>未接続</value></data>
+  <data name="Settings.RemoteLaunch.Connecting" xml:space="preserve"><value>接続試行中…</value></data>
+  <data name="Settings.RemoteLaunch.DiagPing" xml:space="preserve"><value>疎通確認</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingChecking" xml:space="preserve"><value>確認中…</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingOkFormat" xml:space="preserve"><value>OK (往復 {0} ms)</value></data>
+  <data name="Settings.RemoteLaunch.DiagPingNgFormat" xml:space="preserve"><value>NG: {0}</value></data>
+  <data name="Settings.RemoteLaunch.AccessUrl" xml:space="preserve"><value>アクセスURL</value></data>
+  <data name="Settings.RemoteLaunch.CopyUrlTitle" xml:space="preserve"><value>URLをコピー</value></data>
+  <data name="Settings.RemoteLaunch.UrlWarning" xml:space="preserve"><value>このURLは他人に公開しないでください。URLを知っている人がセッションを起動できます。</value></data>
+  <data name="Settings.RemoteLaunch.PasswordLabel" xml:space="preserve"><value>パスワード（任意）</value></data>
+  <data name="Settings.RemoteLaunch.PasswordPlaceholder" xml:space="preserve"><value>設定するとアクセス時にパスワードが必要になります</value></data>
+  <data name="Settings.RemoteLaunch.PasswordHelp" xml:space="preserve"><value>空欄の場合はURLのみでアクセスできます。</value></data>
+  <data name="Settings.RemoteLaunch.TopicGuid" xml:space="preserve"><value>トピックGUID</value></data>
+  <data name="Settings.RemoteLaunch.RegenerateGuidTitle" xml:space="preserve"><value>GUIDを再発行（既存のアクセスURLが無効になります）</value></data>
+  <data name="Settings.RemoteLaunch.RegenerateGuidHelp" xml:space="preserve"><value>再発行すると既存のアクセスURLが無効になります。</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -58,6 +58,8 @@
   <!-- Common -->
   <data name="Common.Close" xml:space="preserve"><value>閉じる</value></data>
   <data name="Common.Add" xml:space="preserve"><value>追加</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>キャンセル</value></data>
+  <data name="Common.Create" xml:space="preserve"><value>作成</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>エラー: {0}</value></data>
 
   <!-- Settings Dialog -->
@@ -272,7 +274,7 @@
   <data name="Settings.Message.ThresholdNegative" xml:space="preserve"><value>通知時間は 0 以上にしてください</value></data>
   <data name="Settings.Message.WebhookUrlRequired" xml:space="preserve"><value>Webhook URL を入力してください</value></data>
   <data name="Settings.Message.PathNotExists" xml:space="preserve"><value>指定されたパスが存在しません</value></data>
-  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>指定されたフォルダが存在しません</value></data>
+  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>指定されたフォルダが存在しません。</value></data>
   <data name="Settings.Message.FolderDuplicate" xml:space="preserve"><value>このフォルダは既に追加されています</value></data>
   <data name="Settings.Message.SaveSuccess" xml:space="preserve"><value>設定を保存しました</value></data>
   <data name="Settings.Message.SaveErrorFormat" xml:space="preserve"><value>保存エラー: {0}</value></data>
@@ -285,4 +287,17 @@
   <data name="Settings.Message.FileReadErrorFormat" xml:space="preserve"><value>ファイル読み込みエラー: {0}</value></data>
   <data name="Settings.Message.ImportResultFormat" xml:space="preserve"><value>インポートが完了しました（{0} 件追加、{1} 件は重複のためスキップ）。ページを再読み込みしてください。</value></data>
   <data name="Settings.Message.ImportErrorFormat" xml:space="preserve"><value>インポートエラー: {0}</value></data>
+
+  <!-- SessionCreate Dialog -->
+  <data name="SessionCreate.Title" xml:space="preserve"><value>新しいセッションを作成</value></data>
+  <data name="SessionCreate.FolderLabel" xml:space="preserve"><value>フォルダを選択</value></data>
+  <data name="SessionCreate.FolderPlaceholder" xml:space="preserve"><value>フォルダパスを入力または選択</value></data>
+  <data name="SessionCreate.BrowseButton" xml:space="preserve"><value>参照</value></data>
+  <data name="SessionCreate.FavoriteFolders" xml:space="preserve"><value>お気に入りフォルダ</value></data>
+  <data name="SessionCreate.DefaultFolder" xml:space="preserve"><value>デフォルトフォルダ</value></data>
+  <data name="SessionCreate.UserHome" xml:space="preserve"><value>ユーザーホーム</value></data>
+  <data name="SessionCreate.PickFolder" xml:space="preserve"><value>フォルダを選択...</value></data>
+  <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>フォルダの作成</value></data>
+  <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>このフォルダを作成しますか？</value></data>
+  <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>作成する</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -457,4 +457,40 @@
   <data name="SubSession.Button.SamePath" xml:space="preserve"><value>セッション作成</value></data>
   <data name="SubSession.Button.NewFolder" xml:space="preserve"><value>フォルダ作成</value></data>
   <data name="SubSession.ErrorFormat" xml:space="preserve"><value>操作中にエラーが発生しました: {0}</value></data>
+
+  <!-- SessionList (left sidebar) -->
+  <data name="SessionList.CreateSession" xml:space="preserve"><value>新しいセッションを作成</value></data>
+  <data name="SessionList.EmptyHint" xml:space="preserve"><value>上のボタンからセッションを作成してください</value></data>
+  <data name="SessionList.SearchPlaceholder" xml:space="preserve"><value>セッションを検索…</value></data>
+  <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>アーカイブ済みセッション</value></data>
+  <data name="SessionList.Badge.Pinned" xml:space="preserve"><value>ピン留め</value></data>
+  <data name="SessionList.Badge.Notification" xml:space="preserve"><value>処理が完了しました</value></data>
+  <data name="SessionList.Badge.DirectoryNotFoundFormat" xml:space="preserve"><value>ディレクトリが見つかりません: {0}</value></data>
+  <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git ブランチ</value></data>
+  <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>未コミットの変更があります</value></data>
+  <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>リモートコントロール接続中</value></data>
+  <data name="SessionList.Badge.ChildrenCountFormat" xml:space="preserve"><value>{0} 件</value></data>
+  <data name="SessionList.Tooltip.Settings" xml:space="preserve"><value>セッション設定</value></data>
+  <data name="SessionList.Tooltip.Delete" xml:space="preserve"><value>セッション削除</value></data>
+
+  <!-- ArchivedSessions Dialog -->
+  <data name="ArchivedSessions.Title" xml:space="preserve"><value>アーカイブ済みセッション</value></data>
+  <data name="ArchivedSessions.SearchPlaceholder" xml:space="preserve"><value>アーカイブを検索…</value></data>
+  <data name="ArchivedSessions.SelectAll" xml:space="preserve"><value>全選択</value></data>
+  <data name="ArchivedSessions.SelectedCountFormat" xml:space="preserve"><value>{0} 件選択中</value></data>
+  <data name="ArchivedSessions.DeleteSelected" xml:space="preserve"><value>選択を削除</value></data>
+  <data name="ArchivedSessions.DirectoryNotFound" xml:space="preserve"><value>ディレクトリが見つかりません</value></data>
+  <data name="ArchivedSessions.ArchivedAtFormat" xml:space="preserve"><value>アーカイブ日時: {0}</value></data>
+  <data name="ArchivedSessions.DateUnknown" xml:space="preserve"><value>不明</value></data>
+  <data name="ArchivedSessions.Restore" xml:space="preserve"><value>復帰</value></data>
+  <data name="ArchivedSessions.DeletePermanently" xml:space="preserve"><value>完全に削除</value></data>
+  <data name="ArchivedSessions.NoResults" xml:space="preserve"><value>検索結果がありません</value></data>
+  <data name="ArchivedSessions.Empty" xml:space="preserve"><value>アーカイブ済みのセッションはありません</value></data>
+  <data name="ArchivedSessions.DeleteAll" xml:space="preserve"><value>すべて削除</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Title" xml:space="preserve"><value>削除の確認</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.AllFormat" xml:space="preserve"><value>すべてのアーカイブ済みセッション（{0} 件）を完全に削除しますか？</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.SelectedFormat" xml:space="preserve"><value>選択した {0} 件のアーカイブ済みセッションを完全に削除しますか？</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.SingleFormat" xml:space="preserve"><value>「{0}」を完全に削除しますか？</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Irreversible" xml:space="preserve"><value>この操作は取り消せません。</value></data>
+  <data name="ArchivedSessions.DeleteConfirm.Execute" xml:space="preserve"><value>削除する</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -394,4 +394,67 @@
   <data name="SessionOptions.Codex.AdditionalDirs.Help" xml:space="preserve"><value>各行を `--add-dir` として渡します</value></data>
   <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --reasoning-effort high</value></data>
   <data name="SessionOptions.Codex.PassToCli" xml:space="preserve"><value>そのまま Codex CLI に渡します</value></data>
+
+  <!-- SessionSettings Dialog -->
+  <data name="SessionSettings.Title" xml:space="preserve"><value>セッション設定</value></data>
+  <data name="SessionSettings.Info.Header" xml:space="preserve"><value>セッション情報</value></data>
+  <data name="SessionSettings.Info.SessionName" xml:space="preserve"><value>セッション名:</value></data>
+  <data name="SessionSettings.Info.Folder" xml:space="preserve"><value>フォルダ:</value></data>
+  <data name="SessionSettings.Info.CopyFolderPath" xml:space="preserve"><value>フォルダパスをコピー</value></data>
+  <data name="SessionSettings.Info.OpenFolder" xml:space="preserve"><value>フォルダを開く</value></data>
+  <data name="SessionSettings.Info.SessionId" xml:space="preserve"><value>セッションID:</value></data>
+  <data name="SessionSettings.Info.CopySessionId" xml:space="preserve"><value>セッションIDをコピー</value></data>
+  <data name="SessionSettings.CreateSubSession" xml:space="preserve"><value>サブセッションを作成</value></data>
+  <data name="SessionSettings.OpenMemoManagement" xml:space="preserve"><value>メモ管理</value></data>
+  <data name="SessionSettings.DisplayName.Label" xml:space="preserve"><value>表示名</value></data>
+  <data name="SessionSettings.DisplayName.Placeholder" xml:space="preserve"><value>セッションの表示名</value></data>
+  <data name="SessionSettings.DisplayName.Help" xml:space="preserve"><value>空白の場合はフォルダ名が使用されます</value></data>
+  <data name="SessionSettings.Pin.Label" xml:space="preserve"><value>セッションをピン留め</value></data>
+  <data name="SessionSettings.Pin.PriorityLabel" xml:space="preserve"><value>優先度:</value></data>
+  <data name="SessionSettings.Memo.Label" xml:space="preserve"><value>メモ</value></data>
+  <data name="SessionSettings.Memo.Placeholder" xml:space="preserve"><value>セッションに関するメモ</value></data>
+  <data name="SessionSettings.Memo.Help" xml:space="preserve"><value>このセッションに関する任意のメモを記入できます</value></data>
+  <data name="SessionSettings.Loading" xml:space="preserve"><value>セッション情報を読み込み中…</value></data>
+  <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>変更を即座に適用（セッションを再起動）</value></data>
+  <data name="SessionSettings.Save" xml:space="preserve"><value>保存</value></data>
+  <data name="SessionSettings.SaveErrorFormat" xml:space="preserve"><value>設定の保存に失敗しました: {0}</value></data>
+  <data name="SessionSettings.RestartFailed" xml:space="preserve"><value>設定は保存されましたが、セッションの再起動に失敗しました。</value></data>
+
+  <!-- SubSession Dialog -->
+  <data name="SubSession.Title" xml:space="preserve"><value>サブセッション作成</value></data>
+  <data name="SubSession.ParentSessionFormat" xml:space="preserve"><value>親セッション: {0}</value></data>
+  <data name="SubSession.Tab.CreateWorktree" xml:space="preserve"><value>Worktree 新規作成</value></data>
+  <data name="SubSession.Tab.ExistingWorktree" xml:space="preserve"><value>既存 Worktree 追加</value></data>
+  <data name="SubSession.Tab.SamePath" xml:space="preserve"><value>同じフォルダで開く</value></data>
+  <data name="SubSession.Tab.NewFolder" xml:space="preserve"><value>新しいフォルダで開く</value></data>
+  <data name="SubSession.GitRequired.Title" xml:space="preserve"><value>Git 管理が必要です</value></data>
+  <data name="SubSession.GitRequired.CreateWorktree" xml:space="preserve"><value>Worktree の作成には Git リポジトリが必要です。</value></data>
+  <data name="SubSession.GitRequired.ExistingWorktree" xml:space="preserve"><value>既存の Worktree を追加するには Git リポジトリが必要です。</value></data>
+  <data name="SubSession.BranchSelection.Label" xml:space="preserve"><value>ブランチ選択方法</value></data>
+  <data name="SubSession.BranchSelection.New" xml:space="preserve"><value>新規ブランチ</value></data>
+  <data name="SubSession.BranchSelection.Existing" xml:space="preserve"><value>既存ブランチ</value></data>
+  <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>新しいブランチ名</value></data>
+  <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>このブランチ名で新しい Worktree が作成されます</value></data>
+  <data name="SubSession.ExistingBranch.Label" xml:space="preserve"><value>既存のブランチを選択</value></data>
+  <data name="SubSession.ExistingBranch.Loading" xml:space="preserve"><value>ブランチ一覧を読み込み中…</value></data>
+  <data name="SubSession.ExistingBranch.Empty" xml:space="preserve"><value>利用可能なブランチがありません</value></data>
+  <data name="SubSession.ExistingBranch.Placeholder" xml:space="preserve"><value>ブランチを選択してください</value></data>
+  <data name="SubSession.BranchExistingWorktree.Title" xml:space="preserve"><value>このブランチには既に Worktree が存在します</value></data>
+  <data name="SubSession.BranchExistingWorktree.PathFormat" xml:space="preserve"><value>パス: {0}</value></data>
+  <data name="SubSession.BranchExistingWorktree.Help" xml:space="preserve"><value>「既存 Worktree 追加」タブから追加してください</value></data>
+  <data name="SubSession.ExistingWorktree.Label" xml:space="preserve"><value>既存の Worktree を選択</value></data>
+  <data name="SubSession.ExistingWorktree.Loading" xml:space="preserve"><value>Worktree 一覧を読み込み中…</value></data>
+  <data name="SubSession.ExistingWorktree.Empty" xml:space="preserve"><value>利用可能な Worktree がありません</value></data>
+  <data name="SubSession.ExistingWorktree.Placeholder" xml:space="preserve"><value>Worktree を選択してください</value></data>
+  <data name="SubSession.WorktreeMainSuffix" xml:space="preserve"><value>- メイン</value></data>
+  <data name="SubSession.SamePath.InfoFormat" xml:space="preserve"><value>親セッション "{0}" と同じフォルダで開きます</value></data>
+  <data name="SubSession.NewFolder.Label" xml:space="preserve"><value>新しいフォルダのパス</value></data>
+  <data name="SubSession.NewFolder.Placeholder" xml:space="preserve"><value>C:\path\to\new\folder または相対パス</value></data>
+  <data name="SubSession.NewFolder.Help" xml:space="preserve"><value>フォルダが存在しない場合は自動的に作成されます</value></data>
+  <data name="SubSession.NewFolder.InfoFormat" xml:space="preserve"><value>新しいフォルダ "{0}" でセッションを開始します</value></data>
+  <data name="SubSession.Button.Create" xml:space="preserve"><value>Worktree 作成</value></data>
+  <data name="SubSession.Button.Existing" xml:space="preserve"><value>Worktree 追加</value></data>
+  <data name="SubSession.Button.SamePath" xml:space="preserve"><value>セッション作成</value></data>
+  <data name="SubSession.Button.NewFolder" xml:space="preserve"><value>フォルダ作成</value></data>
+  <data name="SubSession.ErrorFormat" xml:space="preserve"><value>操作中にエラーが発生しました: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -62,6 +62,7 @@
   <data name="Common.Create" xml:space="preserve"><value>作成</value></data>
   <data name="Common.Unspecified" xml:space="preserve"><value>未指定</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>エラー: {0}</value></data>
+  <data name="Common.DirectoryNotFoundFormat" xml:space="preserve"><value>ディレクトリが見つかりません: {0}</value></data>
 
   <!-- Settings Dialog -->
   <data name="Settings.Title" xml:space="preserve"><value>設定</value></data>
@@ -465,7 +466,6 @@
   <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>アーカイブ済みセッション</value></data>
   <data name="SessionList.Badge.Pinned" xml:space="preserve"><value>ピン留め</value></data>
   <data name="SessionList.Badge.Notification" xml:space="preserve"><value>処理が完了しました</value></data>
-  <data name="SessionList.Badge.DirectoryNotFoundFormat" xml:space="preserve"><value>ディレクトリが見つかりません: {0}</value></data>
   <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git ブランチ</value></data>
   <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>未コミットの変更があります</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>リモートコントロール接続中</value></data>
@@ -518,4 +518,31 @@
   <data name="BottomPanel.Tab.PowerShellFormat" xml:space="preserve"><value>PowerShell({0})</value></data>
   <data name="BottomPanel.Tab.GenericFormat" xml:space="preserve"><value>タブ({0})</value></data>
   <data name="BottomPanel.Tab.MemoFormat" xml:space="preserve"><value>メモ({0})</value></data>
+
+  <!-- Root page -->
+  <data name="Root.NoSessionSelected" xml:space="preserve"><value>左側からセッションを選択してください</value></data>
+  <data name="Root.Placeholder.ClaudeCode" xml:space="preserve"><value>Claude Code へのメッセージを入力…</value></data>
+  <data name="Root.Placeholder.GeminiCLI" xml:space="preserve"><value>Gemini CLI へのメッセージを入力…</value></data>
+  <data name="Root.Placeholder.Terminal" xml:space="preserve"><value>コマンドを入力…</value></data>
+  <data name="Root.SessionType.Terminal" xml:space="preserve"><value>ターミナル</value></data>
+  <data name="Root.SessionType.Fallback" xml:space="preserve"><value>セッション</value></data>
+
+  <!-- Root: Toast messages -->
+  <data name="Root.Toast.SessionCreateErrorFormat" xml:space="preserve"><value>セッション作成エラー: {0}</value></data>
+  <data name="Root.Toast.SessionInitErrorFormat" xml:space="preserve"><value>セッション初期化エラー: {0}</value></data>
+  <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>ターミナルを破棄しました</value></data>
+  <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>ターミナル破棄エラー: {0}</value></data>
+  <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>ターミナルを再作成しました</value></data>
+  <data name="Root.Toast.SelectSessionFirst" xml:space="preserve"><value>このセッションを選択してからターミナルを再作成してください</value></data>
+  <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>ターミナル再作成エラー: {0}</value></data>
+  <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' を作成しました</value></data>
+  <data name="Root.Toast.WorktreeAddedFormat" xml:space="preserve"><value>既存の Worktree '{0}' を追加しました</value></data>
+  <data name="Root.Toast.SamePathSessionCreatedFormat" xml:space="preserve"><value>新しい{0}セッションを作成しました</value></data>
+  <data name="Root.Toast.NewFolderSessionCreatedFormat" xml:space="preserve"><value>新しいフォルダ '{0}' でセッションを作成しました</value></data>
+  <data name="Root.Toast.SessionCreated" xml:space="preserve"><value>セッションを作成しました</value></data>
+  <data name="Root.Toast.SessionCreateFailed" xml:space="preserve"><value>セッション作成に失敗しました</value></data>
+  <data name="Root.Toast.SessionSettingsSaved" xml:space="preserve"><value>セッション設定を保存しました</value></data>
+  <data name="Root.Toast.SessionRecreatedWithoutContinue" xml:space="preserve"><value>--continue オプションなしでセッションを再作成しました</value></data>
+  <data name="Root.Toast.SessionRecreateFailed" xml:space="preserve"><value>セッション再作成に失敗しました</value></data>
+  <data name="Root.Toast.SessionRecreateErrorFormat" xml:space="preserve"><value>セッション再作成エラー: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -58,6 +58,7 @@
   <!-- Common -->
   <data name="Common.Close" xml:space="preserve"><value>閉じる</value></data>
   <data name="Common.Add" xml:space="preserve"><value>追加</value></data>
+  <data name="Common.ErrorFormat" xml:space="preserve"><value>エラー: {0}</value></data>
 
   <!-- Settings Dialog -->
   <data name="Settings.Title" xml:space="preserve"><value>設定</value></data>
@@ -193,4 +194,95 @@
   <data name="Settings.RemoteLaunch.TopicGuid" xml:space="preserve"><value>トピックGUID</value></data>
   <data name="Settings.RemoteLaunch.RegenerateGuidTitle" xml:space="preserve"><value>GUIDを再発行（既存のアクセスURLが無効になります）</value></data>
   <data name="Settings.RemoteLaunch.RegenerateGuidHelp" xml:space="preserve"><value>再発行すると既存のアクセスURLが無効になります。</value></data>
+
+  <!-- Settings: Special Tab -->
+  <data name="Settings.Special.Header" xml:space="preserve"><value>特殊設定</value></data>
+  <data name="Settings.Special.ClaudeModeKey.Header" xml:space="preserve"><value>Claude Code モード切替キー</value></data>
+  <data name="Settings.Special.ClaudeModeKey.Help" xml:space="preserve"><value>Claude Code でモード切替に使用するキーボードショートカットを選択します。</value></data>
+  <data name="Settings.Special.ClaudeModeKey.None" xml:space="preserve"><value>無し</value></data>
+  <data name="Settings.Special.ClaudeModeKey.DefaultNote" xml:space="preserve"><value>（デフォルト）</value></data>
+  <data name="Settings.Special.ClaudeModeKey.ConflictNote" xml:space="preserve"><value>環境によっては Alt+M が他の機能と競合する場合があります。その場合は Shift+Tab をお試しください。</value></data>
+  <data name="Settings.Special.VoiceInput.Header" xml:space="preserve"><value>音声入力</value></data>
+  <data name="Settings.Special.VoiceInput.Enable" xml:space="preserve"><value>音声入力を有効にする（実験的）</value></data>
+  <data name="Settings.Special.VoiceInput.Help" xml:space="preserve"><value>有効にすると、テキスト入力パネルにマイクボタンが表示されます。ボタンを押している間だけ音声認識が動作します（Chrome 推奨）。</value></data>
+  <data name="Settings.Special.TextRefine.Header" xml:space="preserve"><value>テキスト事前整形</value></data>
+  <data name="Settings.Special.TextRefine.Enable" xml:space="preserve"><value>事前整形ボタンを有効にする（実験的）</value></data>
+  <data name="Settings.Special.TextRefine.HelpHtml" xml:space="preserve"><value>有効にすると、テキスト入力パネルに「&lt;i class="bi bi-stars"&gt;&lt;/i&gt; 事前整形」ボタンが表示されます。押すと Claude Code CLI（Haiku モデル）で誤字脱字や表現の揺れを修正します。&lt;br/&gt;整形指示は &lt;code&gt;%LOCALAPPDATA%\TerminalHub\refine-workdir\CLAUDE.md&lt;/code&gt; を編集してカスタマイズ可能。</value></data>
+  <data name="Settings.Special.DevTools.Header" xml:space="preserve"><value>開発ツール</value></data>
+  <data name="Settings.Special.DevTools.Enable" xml:space="preserve"><value>開発ツールを有効にする</value></data>
+  <data name="Settings.Special.DevTools.Help" xml:space="preserve"><value>有効にすると、診断・バッファ・通知テストのタブが表示されます。</value></data>
+  <data name="Settings.Special.Logs.Header" xml:space="preserve"><value>ログファイル</value></data>
+  <data name="Settings.Special.Logs.OpenFolder" xml:space="preserve"><value>ログフォルダを開く</value></data>
+  <data name="Settings.Special.Logs.Help" xml:space="preserve"><value>アプリケーションのログファイルが保存されているフォルダを開きます。</value></data>
+
+  <!-- Settings: Dev Diagnose Tab -->
+  <data name="Settings.DevDiagnose.Header" xml:space="preserve"><value>診断情報</value></data>
+  <data name="Settings.DevDiagnose.Refresh" xml:space="preserve"><value>診断情報を更新</value></data>
+  <data name="Settings.DevDiagnose.RunJs" xml:space="preserve"><value>JS 診断実行</value></data>
+  <data name="Settings.DevDiagnose.SessionList" xml:space="preserve"><value>セッション一覧</value></data>
+  <data name="Settings.DevDiagnose.ColName" xml:space="preserve"><value>名前</value></data>
+  <data name="Settings.DevDiagnose.ColStatus" xml:space="preserve"><value>状態</value></data>
+  <data name="Settings.DevDiagnose.ConPtyPresent" xml:space="preserve"><value>有</value></data>
+  <data name="Settings.DevDiagnose.ConPtyAbsent" xml:space="preserve"><value>無</value></data>
+  <data name="Settings.DevDiagnose.TerminalInfo.Header" xml:space="preserve"><value>ターミナル情報</value></data>
+  <data name="Settings.DevDiagnose.TerminalInfo.JsTerminalCount" xml:space="preserve"><value>JavaScript 側ターミナル数:</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.Header" xml:space="preserve"><value>ターミナル制御テスト</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.ScrollBottom" xml:space="preserve"><value>最下部へ</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.ScrollTop" xml:space="preserve"><value>最上部へ</value></data>
+  <data name="Settings.DevDiagnose.TerminalTest.GetPosition" xml:space="preserve"><value>位置取得</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.Initial" xml:space="preserve"><value>スクロール位置情報が表示されます</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.BottomFormat" xml:space="preserve"><value>最下部にスクロールしました - {0}</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.TopFormat" xml:space="preserve"><value>最上部にスクロールしました - {0}</value></data>
+  <data name="Settings.DevDiagnose.ScrollInfo.PositionFormat" xml:space="preserve"><value>スクロール位置: {0} - {1}</value></data>
+
+  <!-- Settings: Dev Buffer Tab -->
+  <data name="Settings.DevBuffer.Header" xml:space="preserve"><value>バッファダンプ</value></data>
+  <data name="Settings.DevBuffer.Help" xml:space="preserve"><value>セッションの出力バッファ（最大2MB）をファイルにダウンロードします。</value></data>
+  <data name="Settings.DevBuffer.SelectLabel" xml:space="preserve"><value>セッション選択</value></data>
+  <data name="Settings.DevBuffer.SelectPlaceholder" xml:space="preserve"><value>-- セッションを選択 --</value></data>
+  <data name="Settings.DevBuffer.Empty" xml:space="preserve"><value>(空)</value></data>
+  <data name="Settings.DevBuffer.BufferFormat" xml:space="preserve"><value>バッファ: {0}</value></data>
+  <data name="Settings.DevBuffer.StatusHistoryFormat" xml:space="preserve"><value>ステータス履歴: {0} 件</value></data>
+  <data name="Settings.DevBuffer.DownloadBuffer" xml:space="preserve"><value>バッファ</value></data>
+  <data name="Settings.DevBuffer.DownloadBufferClean" xml:space="preserve"><value>バッファ (ANSI 除去)</value></data>
+  <data name="Settings.DevBuffer.DownloadStatusHistory" xml:space="preserve"><value>ステータス履歴 JSON</value></data>
+  <data name="Settings.DevBuffer.Result.SelectSession" xml:space="preserve"><value>セッションを選択してください</value></data>
+  <data name="Settings.DevBuffer.Result.BufferEmpty" xml:space="preserve"><value>バッファが空です</value></data>
+  <data name="Settings.DevBuffer.Result.DownloadedFormat" xml:space="preserve"><value>ダウンロード完了: {0} ({1})</value></data>
+  <data name="Settings.DevBuffer.HeaderBufferInfo" xml:space="preserve"><value>バッファ情報</value></data>
+  <data name="Settings.DevBuffer.HeaderBufferContent" xml:space="preserve"><value>バッファ内容</value></data>
+
+  <!-- Settings: Dev Notify Tab -->
+  <data name="Settings.DevNotify.Header" xml:space="preserve"><value>通知テスト</value></data>
+  <data name="Settings.DevNotify.TestElapsedLabel" xml:space="preserve"><value>テスト用経過時間（秒）</value></data>
+  <data name="Settings.DevNotify.TestBrowser" xml:space="preserve"><value>ブラウザ通知テスト</value></data>
+  <data name="Settings.DevNotify.TestWebhook" xml:space="preserve"><value>Webhook 通知テスト</value></data>
+  <data name="Settings.DevNotify.Result.Initial" xml:space="preserve"><value>テスト結果がここに表示されます</value></data>
+  <data name="Settings.DevNotify.Result.BrowserSendingFormat" xml:space="preserve"><value>ブラウザ通知を送信中… ({0} 秒の処理として)</value></data>
+  <data name="Settings.DevNotify.Result.BrowserSentFormat" xml:space="preserve"><value>ブラウザ通知を送信しました - {0}</value></data>
+  <data name="Settings.DevNotify.Result.WebhookSendingFormat" xml:space="preserve"><value>Webhook 通知を送信中… ({0} 秒の処理として)</value></data>
+  <data name="Settings.DevNotify.Result.WebhookSentFormat" xml:space="preserve"><value>Webhook 通知を送信しました - {0}</value></data>
+  <data name="Settings.DevNotify.SessionName.Browser" xml:space="preserve"><value>通知テストセッション</value></data>
+  <data name="Settings.DevNotify.SessionName.Webhook" xml:space="preserve"><value>Webhook テストセッション</value></data>
+
+  <!-- Settings: Cross-tab messages (saveMessage / validation / version / export / import) -->
+  <data name="Settings.Message.PermissionGranted" xml:space="preserve"><value>通知が許可されました</value></data>
+  <data name="Settings.Message.PermissionDenied" xml:space="preserve"><value>通知が拒否されました</value></data>
+  <data name="Settings.Message.OpenFolderErrorFormat" xml:space="preserve"><value>フォルダを開けませんでした: {0}</value></data>
+  <data name="Settings.Message.ThresholdNegative" xml:space="preserve"><value>通知時間は 0 以上にしてください</value></data>
+  <data name="Settings.Message.WebhookUrlRequired" xml:space="preserve"><value>Webhook URL を入力してください</value></data>
+  <data name="Settings.Message.PathNotExists" xml:space="preserve"><value>指定されたパスが存在しません</value></data>
+  <data name="Settings.Message.FolderNotExists" xml:space="preserve"><value>指定されたフォルダが存在しません</value></data>
+  <data name="Settings.Message.FolderDuplicate" xml:space="preserve"><value>このフォルダは既に追加されています</value></data>
+  <data name="Settings.Message.SaveSuccess" xml:space="preserve"><value>設定を保存しました</value></data>
+  <data name="Settings.Message.SaveErrorFormat" xml:space="preserve"><value>保存エラー: {0}</value></data>
+  <data name="Settings.Message.VersionFetchFailed" xml:space="preserve"><value>バージョン情報を取得できませんでした</value></data>
+  <data name="Settings.Message.VersionCheckErrorFormat" xml:space="preserve"><value>チェックに失敗しました: {0}</value></data>
+  <data name="Settings.Message.ExportSuccessFormat" xml:space="preserve"><value>セッション情報（{0} 件）をエクスポートしました</value></data>
+  <data name="Settings.Message.ExportErrorFormat" xml:space="preserve"><value>エクスポートエラー: {0}</value></data>
+  <data name="Settings.Message.JsonFileRequired" xml:space="preserve"><value>JSON ファイルを選択してください</value></data>
+  <data name="Settings.Message.SessionsNotFound" xml:space="preserve"><value>セッション情報が見つかりませんでした</value></data>
+  <data name="Settings.Message.FileReadErrorFormat" xml:space="preserve"><value>ファイル読み込みエラー: {0}</value></data>
+  <data name="Settings.Message.ImportResultFormat" xml:space="preserve"><value>インポートが完了しました（{0} 件追加、{1} 件は重複のためスキップ）。ページを再読み込みしてください。</value></data>
+  <data name="Settings.Message.ImportErrorFormat" xml:space="preserve"><value>インポートエラー: {0}</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    i18n 共有リソース (日本語)
+    キーは "エリア.要素" の階層ドット記法で書き、英語版 (SharedResource.en.resx) と同じキーを維持する。
+  -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+
+  <!-- Common -->
+  <data name="Common.Close" xml:space="preserve"><value>閉じる</value></data>
+  <data name="Common.Add" xml:space="preserve"><value>追加</value></data>
+
+  <!-- Settings Dialog -->
+  <data name="Settings.Title" xml:space="preserve"><value>設定</value></data>
+
+  <!-- Settings Tabs -->
+  <data name="Settings.Tab.General" xml:space="preserve"><value>一般</value></data>
+  <data name="Settings.Tab.Display" xml:space="preserve"><value>表示</value></data>
+  <data name="Settings.Tab.Notifications" xml:space="preserve"><value>通知</value></data>
+  <data name="Settings.Tab.Sessions" xml:space="preserve"><value>セッション</value></data>
+  <data name="Settings.Tab.ExportImport" xml:space="preserve"><value>エクスポート/インポート</value></data>
+  <data name="Settings.Tab.Commands" xml:space="preserve"><value>コマンド</value></data>
+  <data name="Settings.Tab.RemoteLaunch" xml:space="preserve"><value>リモート起動</value></data>
+  <data name="Settings.Tab.Special" xml:space="preserve"><value>特殊</value></data>
+  <data name="Settings.Tab.DevDiagnose" xml:space="preserve"><value>診断</value></data>
+  <data name="Settings.Tab.DevBuffer" xml:space="preserve"><value>バッファ</value></data>
+  <data name="Settings.Tab.DevNotify" xml:space="preserve"><value>通知テスト</value></data>
+
+  <!-- Settings: General Tab -->
+  <data name="Settings.General.Header" xml:space="preserve"><value>一般設定</value></data>
+  <data name="Settings.General.Language.Label" xml:space="preserve"><value>言語</value></data>
+  <data name="Settings.General.Language.Help" xml:space="preserve"><value>UI の表示言語を切り替えます。選択すると再読み込みされます。</value></data>
+  <data name="Settings.General.DefaultFolder.Label" xml:space="preserve"><value>デフォルトフォルダパス</value></data>
+  <data name="Settings.General.DefaultFolder.PickTitle" xml:space="preserve"><value>フォルダを選択</value></data>
+  <data name="Settings.General.DefaultFolder.Help" xml:space="preserve"><value>新規セッション作成時のデフォルトパスを設定します。空欄の場合はユーザーフォルダが使用されます。</value></data>
+  <data name="Settings.General.FavoriteFolders.Label" xml:space="preserve"><value>お気に入りフォルダ</value></data>
+  <data name="Settings.General.FavoriteFolders.Placeholder" xml:space="preserve"><value>フォルダパスを入力</value></data>
+  <data name="Settings.General.FavoriteFolders.Help" xml:space="preserve"><value>セッション作成時にフォルダ選択の候補として表示されます。</value></data>
+  <data name="Settings.General.Version.Header" xml:space="preserve"><value>バージョン情報</value></data>
+  <data name="Settings.General.Version.Current" xml:space="preserve"><value>現在のバージョン:</value></data>
+  <data name="Settings.General.Version.Checking" xml:space="preserve"><value>バージョンを確認中...</value></data>
+  <data name="Settings.General.Version.NewAvailableHtml" xml:space="preserve"><value>新しいバージョン &lt;strong&gt;v{0}&lt;/strong&gt; があります</value></data>
+  <data name="Settings.General.Version.CheckOnGitHub" xml:space="preserve"><value>GitHubで確認</value></data>
+  <data name="Settings.General.Version.UpToDate" xml:space="preserve"><value>最新バージョンです</value></data>
+  <data name="Settings.General.Community.Header" xml:space="preserve"><value>コミュニティ</value></data>
+  <data name="Settings.General.Community.JoinDiscord" xml:space="preserve"><value>Discord サーバーに参加</value></data>
+  <data name="Settings.General.Community.Help" xml:space="preserve"><value>バグ報告、機能リクエスト、質問などはこちらで受け付けています。</value></data>
+</root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -94,4 +94,61 @@
   <data name="Settings.General.Community.Header" xml:space="preserve"><value>コミュニティ</value></data>
   <data name="Settings.General.Community.JoinDiscord" xml:space="preserve"><value>Discord サーバーに参加</value></data>
   <data name="Settings.General.Community.Help" xml:space="preserve"><value>バグ報告、機能リクエスト、質問などはこちらで受け付けています。</value></data>
+
+  <!-- Settings: Display Tab -->
+  <data name="Settings.Display.Header" xml:space="preserve"><value>表示設定</value></data>
+  <data name="Settings.Display.Theme.Label" xml:space="preserve"><value>テーマ</value></data>
+  <data name="Settings.Display.Theme.Light" xml:space="preserve"><value>ライト</value></data>
+  <data name="Settings.Display.Theme.Dark" xml:space="preserve"><value>ダーク</value></data>
+  <data name="Settings.Display.SessionListScale.Label" xml:space="preserve"><value>セッションリスト表示倍率</value></data>
+  <data name="Settings.Display.SessionListScale.Help" xml:space="preserve"><value>セッションリストの表示倍率を調整します（50%〜150%）。</value></data>
+  <data name="Settings.Display.TerminalFontSize.Label" xml:space="preserve"><value>ターミナルフォントサイズ</value></data>
+  <data name="Settings.Display.TerminalFontSize.Help" xml:space="preserve"><value>ターミナルのフォントサイズを調整します（8px〜28px）。</value></data>
+  <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>サイドバー幅</value></data>
+  <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>セッションリストの幅を調整します（15%〜40%）。境界線のドラッグでも変更できます。</value></data>
+  <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>ターミナル / 入力パネル比率</value></data>
+  <data name="Settings.Display.TerminalHeightRatio.Help" xml:space="preserve"><value>ターミナルと入力パネルの高さ比率を調整します（50:50〜90:10）。境界線のドラッグでも変更できます。</value></data>
+
+  <!-- Settings: Notifications Tab -->
+  <data name="Settings.Notifications.Header" xml:space="preserve"><value>通知設定</value></data>
+  <data name="Settings.Notifications.Browser.Label" xml:space="preserve"><value>ブラウザ通知</value></data>
+  <data name="Settings.Notifications.Status.Granted" xml:space="preserve"><value>許可済み</value></data>
+  <data name="Settings.Notifications.Status.Denied" xml:space="preserve"><value>拒否</value></data>
+  <data name="Settings.Notifications.Status.NotRequested" xml:space="preserve"><value>未許可</value></data>
+  <data name="Settings.Notifications.Status.Checking" xml:space="preserve"><value>確認中...</value></data>
+  <data name="Settings.Notifications.Status.CheckError" xml:space="preserve"><value>確認エラー</value></data>
+  <data name="Settings.Notifications.Status.Unknown" xml:space="preserve"><value>不明</value></data>
+  <data name="Settings.Notifications.Browser.Enable" xml:space="preserve"><value>ブラウザ通知を有効にする</value></data>
+  <data name="Settings.Notifications.Browser.Revoke" xml:space="preserve"><value>通知許可を解除</value></data>
+  <data name="Settings.Notifications.Browser.RevokeHelp" xml:space="preserve"><value>ブラウザの設定画面で通知許可を解除できます。</value></data>
+  <data name="Settings.Notifications.Browser.Request" xml:space="preserve"><value>通知を許可する</value></data>
+  <data name="Settings.Notifications.Browser.RequestHelp" xml:space="preserve"><value>処理完了時にデスクトップ通知を受け取るには、ブラウザの通知を許可してください。</value></data>
+  <data name="Settings.Notifications.Threshold.Label" xml:space="preserve"><value>通知を送信する処理時間（秒）</value></data>
+  <data name="Settings.Notifications.Threshold.Help" xml:space="preserve"><value>0に設定すると、すべての処理完了時に通知します</value></data>
+  <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>Webhook 設定</value></data>
+  <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>Webhook 通知を有効にする</value></data>
+  <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>Webhook URL</value></data>
+  <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>Claude Code Hook設定</value></data>
+  <data name="Settings.Notifications.ClaudeHook.HelpHtml" xml:space="preserve"><value>Claude Code の hook 機能を使用して、より確実に通知を受け取ることができます。セッション作成時に自動的に &lt;code&gt;.claude/settings.local.json&lt;/code&gt; に設定が追加されます。</value></data>
+  <data name="Settings.Notifications.ClaudeHook.Enable" xml:space="preserve"><value>Claude Code Hook を有効にする</value></data>
+  <data name="Settings.Notifications.ClaudeHook.ApplyNoticeHtml" xml:space="preserve"><value>この設定は各セッションが次に起動／再起動されたタイミングで &lt;code&gt;.claude/settings.local.json&lt;/code&gt; に反映されます。既に起動中のセッションや、TerminalHub 管理外のワークスペースには即時適用されません。</value></data>
+
+  <!-- Settings: Sessions Tab -->
+  <data name="Settings.Sessions.Header" xml:space="preserve"><value>セッション設定</value></data>
+  <data name="Settings.Sessions.SortOrder.Label" xml:space="preserve"><value>セッション一覧の並び順</value></data>
+  <data name="Settings.Sessions.SortOrder.ByCreatedAt" xml:space="preserve"><value>作成日時順</value></data>
+  <data name="Settings.Sessions.SortOrder.ByLastAccessed" xml:space="preserve"><value>最終利用日時順</value></data>
+  <data name="Settings.Sessions.SortOrder.ByLastAccessedSub" xml:space="preserve"><value>最近使用したセッションが上に表示</value></data>
+  <data name="Settings.Sessions.SortOrder.ByName" xml:space="preserve"><value>名前順</value></data>
+  <data name="Settings.Sessions.SortOrder.Help" xml:space="preserve"><value>「最終利用日時順」では、子セッション（Worktree）の利用も親セッションの順序に反映されます。</value></data>
+  <data name="Settings.Sessions.Display.Label" xml:space="preserve"><value>セッション一覧の表示設定</value></data>
+  <data name="Settings.Sessions.Display.ShowTerminalType" xml:space="preserve"><value>ターミナル種別を表示</value></data>
+  <data name="Settings.Sessions.Display.ShowTerminalTypeSub" xml:space="preserve"><value>Claude/Gemini/Codexバッジ</value></data>
+  <data name="Settings.Sessions.Display.ShowGitInfo" xml:space="preserve"><value>Git情報を表示</value></data>
+  <data name="Settings.Sessions.Display.ShowGitInfoSub" xml:space="preserve"><value>ブランチ名バッジ</value></data>
+  <data name="Settings.Sessions.Display.Help" xml:space="preserve"><value>セッション一覧に表示する追加情報を選択できます。</value></data>
+  <data name="Settings.Sessions.InputPanel.Label" xml:space="preserve"><value>入力パネル設定</value></data>
+  <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>入力パネルを非表示</value></data>
+  <data name="Settings.Sessions.InputPanel.HideSub" xml:space="preserve"><value>ターミナルのみ表示</value></data>
+  <data name="Settings.Sessions.InputPanel.HideHelp" xml:space="preserve"><value>下部の入力パネルを非表示にして、ターミナル領域を広く使えます。</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -545,4 +545,6 @@
   <data name="Root.Toast.SessionRecreatedWithoutContinue" xml:space="preserve"><value>--continue オプションなしでセッションを再作成しました</value></data>
   <data name="Root.Toast.SessionRecreateFailed" xml:space="preserve"><value>セッション再作成に失敗しました</value></data>
   <data name="Root.Toast.SessionRecreateErrorFormat" xml:space="preserve"><value>セッション再作成エラー: {0}</value></data>
+  <data name="Root.Confirm.DeleteSessionFormat" xml:space="preserve"><value>セッション「{0}」を削除しますか？</value></data>
+  <data name="Root.Confirm.ArchiveSessionFormat" xml:space="preserve"><value>セッション「{0}」をアーカイブしますか？</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -60,6 +60,7 @@
   <data name="Common.Add" xml:space="preserve"><value>追加</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>キャンセル</value></data>
   <data name="Common.Create" xml:space="preserve"><value>作成</value></data>
+  <data name="Common.Unspecified" xml:space="preserve"><value>未指定</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>エラー: {0}</value></data>
 
   <!-- Settings Dialog -->
@@ -131,7 +132,7 @@
   <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>Webhook 設定</value></data>
   <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>Webhook 通知を有効にする</value></data>
   <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>Webhook URL</value></data>
-  <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>Claude Code Hook設定</value></data>
+  <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>Claude Code Hook 設定</value></data>
   <data name="Settings.Notifications.ClaudeHook.HelpHtml" xml:space="preserve"><value>Claude Code の hook 機能を使用して、より確実に通知を受け取ることができます。セッション作成時に自動的に &lt;code&gt;.claude/settings.local.json&lt;/code&gt; に設定が追加されます。</value></data>
   <data name="Settings.Notifications.ClaudeHook.Enable" xml:space="preserve"><value>Claude Code Hook を有効にする</value></data>
   <data name="Settings.Notifications.ClaudeHook.ApplyNoticeHtml" xml:space="preserve"><value>この設定は各セッションが次に起動／再起動されたタイミングで &lt;code&gt;.claude/settings.local.json&lt;/code&gt; に反映されます。既に起動中のセッションや、TerminalHub 管理外のワークスペースには即時適用されません。</value></data>
@@ -300,4 +301,97 @@
   <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>フォルダの作成</value></data>
   <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>このフォルダを作成しますか？</value></data>
   <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>作成する</value></data>
+
+  <!-- SessionOptionsSelector: common -->
+  <data name="SessionOptions.TerminalType.Label" xml:space="preserve"><value>ターミナルタイプ</value></data>
+  <data name="SessionOptions.TerminalType.Terminal" xml:space="preserve"><value>ターミナル</value></data>
+  <data name="SessionOptions.ExtraArgs.Label" xml:space="preserve"><value>追加引数</value></data>
+
+  <!-- SessionOptionsSelector: Terminal (default startup command) -->
+  <data name="SessionOptions.Terminal.StartupCommand.Label" xml:space="preserve"><value>起動コマンド（任意）</value></data>
+  <data name="SessionOptions.Terminal.StartupCommand.Placeholder" xml:space="preserve"><value>例: cmd.exe, powershell.exe</value></data>
+
+  <!-- SessionOptionsSelector: Claude Code -->
+  <data name="SessionOptions.Claude.Header" xml:space="preserve"><value>Claude Code オプション</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.Label" xml:space="preserve"><value>権限モード</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.BypassLabel" xml:space="preserve"><value>バイパス</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.BypassTitle" xml:space="preserve"><value>全操作を無条件で自動承認します（危険）</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoLabel" xml:space="preserve"><value>オートモード</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoTitle" xml:space="preserve"><value>低リスク操作を自動承認し、高リスク操作のみ確認を求めます</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.DefaultLabel" xml:space="preserve"><value>デフォルト</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.DefaultTitle" xml:space="preserve"><value>全ての操作で都度確認を求めます</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpBypass" xml:space="preserve"><value>全操作を無条件で自動承認します（--dangerously-skip-permissions）。</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpAuto" xml:space="preserve"><value>低リスク操作を自動承認し、高リスク操作のみ確認を求めます（--enable-auto-mode）。</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpDefault" xml:space="preserve"><value>全ての操作で都度確認を求めます。</value></data>
+  <data name="SessionOptions.Claude.Continue" xml:space="preserve"><value>コンティニュー (--continue)</value></data>
+  <data name="SessionOptions.Claude.Chrome" xml:space="preserve"><value>ブラウザ連携 (--chrome)</value></data>
+  <data name="SessionOptions.Claude.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --model claude-sonnet-4-20250514 --verbose</value></data>
+  <data name="SessionOptions.Claude.PassToCli" xml:space="preserve"><value>そのまま Claude Code に渡します</value></data>
+
+  <!-- SessionOptionsSelector: Gemini CLI -->
+  <data name="SessionOptions.Gemini.Header" xml:space="preserve"><value>Gemini CLI オプション</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.Label" xml:space="preserve"><value>承認モード</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.DefaultTitle" xml:space="preserve"><value>ツール使用時に都度確認を求めます（デフォルト）</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.AutoEditTitle" xml:space="preserve"><value>ファイル編集など、安全な操作を自動で承認します</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.YoloTitle" xml:space="preserve"><value>全ての操作を警告なしで自動的に承認します（危険）</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpDefault" xml:space="preserve"><value>ツール使用時に都度確認を求めます（デフォルト）。</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpAutoEdit" xml:space="preserve"><value>ファイル編集など、安全な操作を自動で承認します。</value></data>
+  <data name="SessionOptions.Gemini.ApprovalMode.HelpYolo" xml:space="preserve"><value>全ての操作を警告なしで自動的に承認します（危険）。</value></data>
+  <data name="SessionOptions.Gemini.Sandbox" xml:space="preserve"><value>サンドボックスモード (-s)</value></data>
+  <data name="SessionOptions.Gemini.SandboxHelp" xml:space="preserve"><value>この機能を使用するには、Docker Desktop がインストールされている必要があります。</value></data>
+  <data name="SessionOptions.Gemini.Continue" xml:space="preserve"><value>コンティニュー (--resume latest)</value></data>
+  <data name="SessionOptions.Gemini.UseCustomModel" xml:space="preserve"><value>モデルをカスタマイズ</value></data>
+  <data name="SessionOptions.Gemini.ModelSelectLabel" xml:space="preserve"><value>使用するモデル</value></data>
+  <data name="SessionOptions.Gemini.ModelManagementLabel" xml:space="preserve"><value>モデルリスト管理</value></data>
+  <data name="SessionOptions.Gemini.ModelAddPlaceholder" xml:space="preserve"><value>モデル名を追加...</value></data>
+  <data name="SessionOptions.Gemini.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --debug --allowed-tools shell,file</value></data>
+  <data name="SessionOptions.Gemini.PassToCli" xml:space="preserve"><value>そのまま Gemini CLI に渡します</value></data>
+
+  <!-- SessionOptionsSelector: Codex CLI -->
+  <data name="SessionOptions.Codex.Header" xml:space="preserve"><value>Codex CLI オプション</value></data>
+  <data name="SessionOptions.Codex.Mode.Label" xml:space="preserve"><value>実行モード</value></data>
+  <data name="SessionOptions.Codex.Mode.AutoLabel" xml:space="preserve"><value>Auto (推奨)</value></data>
+  <data name="SessionOptions.Codex.Mode.AutoTitle" xml:space="preserve"><value>編集＋ビルド/テスト等を基本自動化</value></data>
+  <data name="SessionOptions.Codex.Mode.StandardLabel" xml:space="preserve"><value>Interactive</value></data>
+  <data name="SessionOptions.Codex.Mode.StandardTitle" xml:space="preserve"><value>明示的な自動実行フラグを付けず、対話ベースで進行します</value></data>
+  <data name="SessionOptions.Codex.Mode.YoloLabel" xml:space="preserve"><value>YOLO (危険)</value></data>
+  <data name="SessionOptions.Codex.Mode.YoloTitle" xml:space="preserve"><value>全自動実行（危険）。隔離環境推奨。</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpAuto" xml:space="preserve"><value>推奨。`--full-auto` を付けて自動実行寄りに進めます。</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpStandard" xml:space="preserve"><value>明示的な自動実行フラグを付けず、対話ベースで進行します。</value></data>
+  <data name="SessionOptions.Codex.Mode.HelpYolo" xml:space="preserve"><value>全自動実行（危険）。隔離環境推奨です。</value></data>
+  <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>警告:</value></data>
+  <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO モードは隔離環境（WSL/Docker/VM/CI）でのみ使用してください。</value></data>
+  <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>最新セッションを再開 (resume --last)</value></data>
+  <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>サンドボックスモード</value></data>
+  <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI 既定</value></data>
+  <data name="SessionOptions.Codex.Sandbox.DefaultTitle" xml:space="preserve"><value>--sandbox を付けず、Codex CLI の既定値に任せます。</value></data>
+  <data name="SessionOptions.Codex.Sandbox.ReadOnlyLabel" xml:space="preserve"><value>読み取り専用</value></data>
+  <data name="SessionOptions.Codex.Sandbox.ReadOnlyTitle" xml:space="preserve"><value>読み取り専用。書き込みはブロック。</value></data>
+  <data name="SessionOptions.Codex.Sandbox.WorkspaceLabel" xml:space="preserve"><value>ワークスペース (推奨)</value></data>
+  <data name="SessionOptions.Codex.Sandbox.WorkspaceTitle" xml:space="preserve"><value>ワークスペース内のみ書き込み可能。</value></data>
+  <data name="SessionOptions.Codex.Sandbox.FullAccessLabel" xml:space="preserve"><value>フルアクセス</value></data>
+  <data name="SessionOptions.Codex.Sandbox.FullAccessTitle" xml:space="preserve"><value>フルアクセス（危険）。</value></data>
+  <data name="SessionOptions.Codex.Sandbox.Help" xml:space="preserve"><value>外部通信やファイルアクセス範囲を制限</value></data>
+  <data name="SessionOptions.Codex.Sandbox.HelpDefault" xml:space="preserve"><value>Codex CLI の既定値に任せます。</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Label" xml:space="preserve"><value>承認ポリシー</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Help" xml:space="preserve"><value>操作の承認レベル（--ask-for-approval）</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>未信頼扱い。すべての操作で承認を求めます。</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>必要なときだけ承認を求めます（デフォルトに近い挙動）。</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.HelpNever" xml:space="preserve"><value>承認を求めません（危険）。</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.Label" xml:space="preserve"><value>ネットワークアクセス</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.Help" xml:space="preserve"><value>workspace-write 時の通信許可（-c sandbox_workspace_write.network_access）。デフォルトは enabled。</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.HelpEnabled" xml:space="preserve"><value>ネットワークアクセスを許可します。</value></data>
+  <data name="SessionOptions.Codex.NetworkAccess.HelpRestricted" xml:space="preserve"><value>ネットワークアクセスを制限します。</value></data>
+  <data name="SessionOptions.Codex.Profile.Label" xml:space="preserve"><value>プロファイル</value></data>
+  <data name="SessionOptions.Codex.Profile.Placeholder" xml:space="preserve"><value>例: trusted</value></data>
+  <data name="SessionOptions.Codex.Profile.Help" xml:space="preserve"><value>Codex CLI の `--profile` を指定します</value></data>
+  <data name="SessionOptions.Codex.Model.Label" xml:space="preserve"><value>モデル</value></data>
+  <data name="SessionOptions.Codex.Model.Placeholder" xml:space="preserve"><value>例: gpt-5-codex</value></data>
+  <data name="SessionOptions.Codex.Model.Help" xml:space="preserve"><value>Codex CLI の `--model` を指定します</value></data>
+  <data name="SessionOptions.Codex.Search" xml:space="preserve"><value>Web 検索を有効化 (--search)</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Label" xml:space="preserve"><value>追加ディレクトリ</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Placeholder" xml:space="preserve"><value>1 行に 1 ディレクトリずつ指定</value></data>
+  <data name="SessionOptions.Codex.AdditionalDirs.Help" xml:space="preserve"><value>各行を `--add-dir` として渡します</value></data>
+  <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --reasoning-effort high</value></data>
+  <data name="SessionOptions.Codex.PassToCli" xml:space="preserve"><value>そのまま Codex CLI に渡します</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -493,4 +493,29 @@
   <data name="ArchivedSessions.DeleteConfirm.SingleFormat" xml:space="preserve"><value>「{0}」を完全に削除しますか？</value></data>
   <data name="ArchivedSessions.DeleteConfirm.Irreversible" xml:space="preserve"><value>この操作は取り消せません。</value></data>
   <data name="ArchivedSessions.DeleteConfirm.Execute" xml:space="preserve"><value>削除する</value></data>
+
+  <!-- BottomPanels: TextInputPanel -->
+  <data name="TextInput.KeyHints.Send" xml:space="preserve"><value>送信</value></data>
+  <data name="TextInput.KeyHints.Newline" xml:space="preserve"><value>改行</value></data>
+  <data name="TextInput.KeyHints.History" xml:space="preserve"><value>履歴</value></data>
+  <data name="TextInput.VoiceInput.Tooltip" xml:space="preserve"><value>音声入力（押している間録音）</value></data>
+  <data name="TextInput.Refine.Tooltip" xml:space="preserve"><value>Claude Code で誤字脱字・表現を整える</value></data>
+  <data name="TextInput.Refine.Label" xml:space="preserve"><value>事前整形</value></data>
+  <data name="TextInput.Send" xml:space="preserve"><value>送信</value></data>
+  <data name="TextInput.ModeSwitch.TooltipFormat" xml:space="preserve"><value>モード切替 ({0})</value></data>
+
+  <!-- BottomPanels: MemoPanel -->
+  <data name="MemoPanel.Placeholder" xml:space="preserve"><value>メモ… (Enter で改行、自動保存)</value></data>
+
+  <!-- BottomPanel (タブホスト) -->
+  <data name="BottomPanel.CloseTab" xml:space="preserve"><value>タブを閉じる</value></data>
+  <data name="BottomPanel.AddCommandPrompt" xml:space="preserve"><value>コマンドプロンプトを追加</value></data>
+  <data name="BottomPanel.AddPowerShell" xml:space="preserve"><value>PowerShell を追加</value></data>
+  <data name="BottomPanel.AddMemo" xml:space="preserve"><value>メモを追加</value></data>
+  <data name="BottomPanel.Tab.TextInputDefault" xml:space="preserve"><value>テキスト入力</value></data>
+  <data name="BottomPanel.Tab.TextInputFormat" xml:space="preserve"><value>テキスト入力({0})</value></data>
+  <data name="BottomPanel.Tab.CommandPromptFormat" xml:space="preserve"><value>コマンドプロンプト({0})</value></data>
+  <data name="BottomPanel.Tab.PowerShellFormat" xml:space="preserve"><value>PowerShell({0})</value></data>
+  <data name="BottomPanel.Tab.GenericFormat" xml:space="preserve"><value>タブ({0})</value></data>
+  <data name="BottomPanel.Tab.MemoFormat" xml:space="preserve"><value>メモ({0})</value></data>
 </root>

--- a/TerminalHub/wwwroot/js/helpers.js
+++ b/TerminalHub/wwwroot/js/helpers.js
@@ -396,5 +396,21 @@ window.terminalHubHelpers = {
     // 現在のテーマ取得
     getTheme: function() {
         return document.documentElement.getAttribute('data-bs-theme') || 'dark';
+    },
+
+    // UI 言語の切替。.AspNetCore.Culture cookie を書き込んでページを reload。
+    // ASP.NET Core 標準の CookieRequestCultureProvider が読む形式 (c=xx|uic=xx)。
+    setUiCulture: function(culture) {
+        try {
+            var value = encodeURIComponent('c=' + culture + '|uic=' + culture);
+            var oneYear = 60 * 60 * 24 * 365;
+            document.cookie = '.AspNetCore.Culture=' + value +
+                '; path=/; max-age=' + oneYear + '; samesite=lax';
+        } catch (e) {
+            // Cookie ブロック環境では書き込みが失敗する。reload 自体は走らせるが、
+            // デバッグ時に原因を追えるよう console に警告を残す。
+            console.warn('[TerminalHub i18n] setUiCulture: cookie write failed', e);
+        }
+        window.location.reload();
     }
 };


### PR DESCRIPTION
## Summary

**Phase 2 全体の締め括り**。`feat/i18n` 統合ブランチに蓄積された 10 件の PR を master にマージする最終 PR。

TerminalHub のアプリ UI 全体が **英語 / 日本語の両言語で完全動作** するようになります。Phase 1 (PR #39) で完了したランディングページ + README の英語 canonical 化に続き、アプリ本体の localize が完了。

+1766/-496 行、16 ファイル変更 (うち resx 2 ファイルで +1096 行)。

## 言語切替の仕組み

- **設定ダイアログ → 一般タブ → 言語** ドロップダウンで選択 (English / 日本語)
- 選択すると `.AspNetCore.Culture` cookie 書き込み → ページリロード
- Accept-Language ヘッダーと cookie を組み合わせた判定:
  - Cookie 優先 → なければ Accept-Language → 対応外言語は英語フォールバック
- Cookie 有効期限 1 年、スライディング更新 (アクセスごとに延長)
- 対応言語: `en`, `ja` (将来の拡張は resx 追加のみで対応可能)

## 対象コンポーネント

### 設定ダイアログ (Phase 2A + 2B)
- 全 11 タブ: 一般 / 表示 / 通知 / セッション / エクスポート / コマンド / リモート起動 / 特殊 / 診断 / バッファ / 通知テスト
- 横断メッセージ: save / validation / version check / export / import の成功/失敗通知

### セッション関連ダイアログ (Phase 2C-1 ～ 2C-2)
- 新規セッション作成ダイアログ (SessionCreateDialog)
- ターミナルオプション選択 (SessionOptionsSelector) — Claude Code / Gemini CLI / Codex CLI の全オプション
- セッション設定ダイアログ (SessionSettingsDialog)
- サブセッション作成ダイアログ (SubSessionDialog) — Worktree 新規作成 / 既存追加 / 同一フォルダ / 新規フォルダの 4 パターン

### サイドバー + アーカイブ (Phase 2C-3)
- セッション一覧 (SessionList) — バッジ・tooltip 含む
- アーカイブ済みセッション管理 (ArchivedSessionsDialog)

### 下部パネル (Phase 2C-4)
- タブホスト (BottomPanel) — タブ追加ドロップダウン・動的タブ名
- テキスト入力パネル (TextInputPanel)
- メモパネル (MemoPanel)

### メインページ (Phase 2C-5)
- Root.razor — プレースホルダー・Toast 通知 (成功/失敗/警告/情報) 15 箇所

## 技術的ハイライト

### i18n インフラ (Phase 2A で構築)
- `services.AddLocalization()` + `IStringLocalizer<SharedResource>`
- `SharedResource.cs` マーカークラスをルート namespace に配置 (resx embed 名との整合)
- `ResourcesPath` は指定せず、resx embed 名と一致させる方針
- `UseRequestLocalization()` + カスタム sliding cookie middleware
- `IRequestCultureFeature` 経由で OnStarting callback に現在の culture を取得

### リソースキー設計
- ドット階層命名: `{Area}.{Section}.{Element}`
- サフィックス規約: `*Format` (format string) / `*Help` (説明文) / `*Title` (tooltip) / `*Html` (HTML 含む、MarkupString 経由)
- Common 共通キー: `Common.Cancel` / `Common.Create` / `Common.Close` / `Common.ErrorFormat` / `Common.Unspecified` / `Common.DirectoryNotFoundFormat` 等、複数箇所で再利用
- 最終キー数: **~300 キー × 2 言語** (resx 各 548 行)

### 固有名詞 (製品名) の非 localize
Claude Code / Gemini CLI / Codex CLI / PowerShell / Webhook / Git / Worktree 等はブランド名・技術名として各言語でそのまま表示。

## Phase 2 内訳 (PR 単位)

| Phase | 内容 | PR |
|---|---|---|
| 2A | インフラ構築 + 設定一般タブ | #40 |
| 2B-1 | 設定: 表示 / 通知 / セッション | #41 |
| 2B-2 | 設定: エクスポート / コマンド / リモート起動 | #42 |
| 2B-3 | 設定: 特殊 / 開発系 + 横断メッセージ | #43 |
| 2C-1 | SessionCreateDialog shell | #44 |
| 2C-1b | SessionOptionsSelector (shared) | #45 |
| 2C-2 | SessionSettings + SubSession | #46 |
| 2C-3 | SessionList + Archived | #47 |
| 2C-4 | BottomPanel 3 コンポーネント | #48 |
| 2C-5 | Root.razor | #49 |

## 動作確認済み

- [x] C# コンパイル成功 (0 警告 0 エラー)
- [x] 各サブ PR で dev 再起動 → 実画面動作確認済み
- [x] 言語切替 → ページリロードで全 UI が culture 連動
- [x] cookie 永続化 (再起動後も選択が維持)
- [x] Accept-Language フォールバック (対応外言語ブラウザで英語表示)

## 意図的に非 localize の範囲

- `Logger.LogInformation/Warning/Error` の日本語メッセージ (開発ログ、メンテナ向け)
- C# / Razor コメント (メンテナ向け)
- `<option value="ja">日本語</option>` (言語ピッカーは自言語表記の慣例)
- 製品名・ブランド名・技術用語 (Claude Code / Gemini CLI / Codex CLI / PowerShell / Git / Worktree 等)

## リリース方針

マージ後は **v1.0.55 としてリリース** を予定:
- `/release` スキルで version bump + commit + tag + GitHub release + Discord 告知
- 英語圏ユーザー + 中韓エンジニア向けの初回 English UI 提供

## 後続 Phase (参考)

- **Phase 3** (反響次第): 中国語簡体字・繁体字・韓国語対応。resx 追加のみで対応可能な構造は本 PR で完成済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)