### PR TITLE
fix(i18n): window.confirm() のアーカイブ/削除確認を多言語化

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1165,7 +1165,7 @@
             bool confirmed;
             try
             {
-                confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"セッション「{sessionName}」を削除しますか？");
+                confirmed = await JSRuntime.InvokeAsync<bool>("confirm", string.Format(L["Root.Confirm.DeleteSessionFormat"], sessionName));
             }
             catch (JSDisconnectedException)
             {
@@ -1240,7 +1240,7 @@
         bool confirmed;
         try
         {
-            confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"セッション「{sessionName}」をアーカイブしますか？");
+            confirmed = await JSRuntime.InvokeAsync<bool>("confirm", string.Format(L["Root.Confirm.ArchiveSessionFormat"], sessionName));
         }
         catch (JSDisconnectedException)
         {

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -545,4 +545,6 @@
   <data name="Root.Toast.SessionRecreatedWithoutContinue" xml:space="preserve"><value>Session recreated without --continue option</value></data>
   <data name="Root.Toast.SessionRecreateFailed" xml:space="preserve"><value>Failed to recreate session</value></data>
   <data name="Root.Toast.SessionRecreateErrorFormat" xml:space="preserve"><value>Session recreate error: {0}</value></data>
+  <data name="Root.Confirm.DeleteSessionFormat" xml:space="preserve"><value>Delete session "{0}"?</value></data>
+  <data name="Root.Confirm.ArchiveSessionFormat" xml:space="preserve"><value>Archive session "{0}"?</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -545,4 +545,6 @@
   <data name="Root.Toast.SessionRecreatedWithoutContinue" xml:space="preserve"><value>--continue オプションなしでセッションを再作成しました</value></data>
   <data name="Root.Toast.SessionRecreateFailed" xml:space="preserve"><value>セッション再作成に失敗しました</value></data>
   <data name="Root.Toast.SessionRecreateErrorFormat" xml:space="preserve"><value>セッション再作成エラー: {0}</value></data>
+  <data name="Root.Confirm.DeleteSessionFormat" xml:space="preserve"><value>セッション「{0}」を削除しますか？</value></data>
+  <data name="Root.Confirm.ArchiveSessionFormat" xml:space="preserve"><value>セッション「{0}」をアーカイブしますか？</value></data>
 </root>


### PR DESCRIPTION
## Summary

Phase 2C-5 (#49) で Root.razor をローカライズした際、`JSRuntime.InvokeAsync<bool>(\"confirm\", ...)` 呼び出し 2 箇所がハードコーディングされた日本語のまま残っていたのを修正。

## 変更点

- `Root.razor:1168` 削除確認 → `L[\"Root.Confirm.DeleteSessionFormat\"]`
- `Root.razor:1243` アーカイブ確認 → `L[\"Root.Confirm.ArchiveSessionFormat\"]`
- `SharedResource.ja.resx` / `.en.resx` に 2 キー追加

## Test plan

- [ ] en ロケールでセッション削除 → `Delete session "xxx"?` が表示される
- [ ] en ロケールでセッションアーカイブ → `Archive session "xxx"?` が表示される
- [ ] ja ロケールで従来通り「セッション「xxx」を削除しますか？」「〜アーカイブしますか？」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)