### PR TITLE
fix(i18n): 日本語 UI の文言品質を改善 + 設定タブの重複見出し削除

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -118,8 +118,6 @@
                         @if (activeTab == "general")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.General.Header"]</h6>
-
                                 <!-- UI 言語切替 -->
                                 <div class="mb-4">
                                     <label class="form-label">@L["Settings.General.Language.Label"]</label>
@@ -248,8 +246,6 @@
                         else if (activeTab == "display")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.Display.Header"]</h6>
-
                                 <div class="mb-4">
                                     <label class="form-label">@L["Settings.Display.Theme.Label"]</label>
                                     <div class="form-check">
@@ -330,8 +326,6 @@
                         else if (activeTab == "notifications")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.Notifications.Header"]</h6>
-
                     <div class="mb-4">
                         <div class="d-flex align-items-center justify-content-between mb-2">
                             <label class="form-label mb-0">@L["Settings.Notifications.Browser.Label"]</label>
@@ -415,8 +409,6 @@
                         else if (activeTab == "sessions")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.Sessions.Header"]</h6>
-
                                 <div class="mb-4">
                                     <label class="form-label">@L["Settings.Sessions.SortOrder.Label"]</label>
                                     <div class="form-check">
@@ -495,8 +487,6 @@
                         else if (activeTab == "export")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.Export.Header"]</h6>
-
                                 <!-- エクスポート -->
                                 <div class="mb-4">
                                     <h6 class="mb-2">@L["Settings.Export.Export.Header"]</h6>
@@ -522,7 +512,7 @@
                                 <div>
                                     <h6 class="mb-2">@L["Settings.Export.Import.Header"]</h6>
                                     <p class="text-muted small">
-                                        @string.Format(L["Settings.Export.Import.Help"], "SQLite")
+                                        @L["Settings.Export.Import.Help"]
                                     </p>
 
                                     <div class="mb-3">
@@ -548,7 +538,6 @@
                         else if (activeTab == "commands")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.Commands.Header"]</h6>
                                 <small class="text-muted d-block mb-3">
                                     @L["Settings.Commands.Help"]
                                 </small>
@@ -657,7 +646,6 @@
                         else if (activeTab == "remoteLaunch")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.RemoteLaunch.Header"]</h6>
                                 <small class="text-muted d-block mb-3">
                                     @L["Settings.RemoteLaunch.Help"]
                                 </small>
@@ -796,8 +784,6 @@
                         else if (activeTab == "special")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.Special.Header"]</h6>
-
                                 <div class="mb-4">
                                     <h6 class="mb-2">@L["Settings.Special.ClaudeModeKey.Header"]</h6>
                                     <p class="text-muted small">@L["Settings.Special.ClaudeModeKey.Help"]</p>
@@ -883,8 +869,6 @@
                         else if (activeTab == "devDiagnose")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.DevDiagnose.Header"]</h6>
-
                                 <div class="mb-3">
                                     <button class="btn btn-info btn-sm me-2" @onclick="RefreshDiagnostics">
                                         <i class="bi bi-arrow-clockwise me-1"></i>@L["Settings.DevDiagnose.Refresh"]
@@ -954,7 +938,6 @@
                         else if (activeTab == "devBuffer")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.DevBuffer.Header"]</h6>
                                 <p class="text-muted small mb-3">@L["Settings.DevBuffer.Help"]</p>
 
                                 <div class="mb-3">
@@ -1000,8 +983,6 @@
                         else if (activeTab == "devNotify")
                         {
                             <div class="tab-pane fade show active">
-                                <h6 class="mb-3">@L["Settings.DevNotify.Header"]</h6>
-
                                 <div class="mb-3">
                                     <label class="form-label">@L["Settings.DevNotify.TestElapsedLabel"]</label>
                                     <input type="number" class="form-control" @bind="testElapsedSeconds" min="1" max="300" style="max-width: 150px;" />

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -491,7 +491,7 @@
                                 <div class="mb-4">
                                     <h6 class="mb-2">@L["Settings.Export.Export.Header"]</h6>
                                     <p class="text-muted small">
-                                        @string.Format(L["Settings.Export.Export.Help"], "SQLite")
+                                        @L["Settings.Export.Export.Help"]
                                     </p>
 
                                     <div class="alert alert-secondary mb-3">

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -81,7 +81,6 @@
   <data name="Settings.Tab.DevNotify" xml:space="preserve"><value>Notification Test</value></data>
 
   <!-- Settings: General Tab -->
-  <data name="Settings.General.Header" xml:space="preserve"><value>General</value></data>
   <data name="Settings.General.Language.Label" xml:space="preserve"><value>Language</value></data>
   <data name="Settings.General.Language.Help" xml:space="preserve"><value>Switch the UI language. Selecting a value reloads the page.</value></data>
   <data name="Settings.General.DefaultFolder.Label" xml:space="preserve"><value>Default folder path</value></data>
@@ -101,7 +100,6 @@
   <data name="Settings.General.Community.Help" xml:space="preserve"><value>Bug reports, feature requests, and questions are welcome there.</value></data>
 
   <!-- Settings: Display Tab -->
-  <data name="Settings.Display.Header" xml:space="preserve"><value>Display</value></data>
   <data name="Settings.Display.Theme.Label" xml:space="preserve"><value>Theme</value></data>
   <data name="Settings.Display.Theme.Light" xml:space="preserve"><value>Light</value></data>
   <data name="Settings.Display.Theme.Dark" xml:space="preserve"><value>Dark</value></data>
@@ -115,7 +113,6 @@
   <data name="Settings.Display.TerminalHeightRatio.Help" xml:space="preserve"><value>Height split between terminal and input panel (50:50–90:10). Drag the border to adjust.</value></data>
 
   <!-- Settings: Notifications Tab -->
-  <data name="Settings.Notifications.Header" xml:space="preserve"><value>Notifications</value></data>
   <data name="Settings.Notifications.Browser.Label" xml:space="preserve"><value>Browser notifications</value></data>
   <data name="Settings.Notifications.Status.Granted" xml:space="preserve"><value>Allowed</value></data>
   <data name="Settings.Notifications.Status.Denied" xml:space="preserve"><value>Denied</value></data>
@@ -139,7 +136,6 @@
   <data name="Settings.Notifications.ClaudeHook.ApplyNoticeHtml" xml:space="preserve"><value>This setting is applied to &lt;code&gt;.claude/settings.local.json&lt;/code&gt; the next time each session is started/restarted. It is not applied immediately to running sessions or workspaces outside TerminalHub's management.</value></data>
 
   <!-- Settings: Sessions Tab -->
-  <data name="Settings.Sessions.Header" xml:space="preserve"><value>Sessions</value></data>
   <data name="Settings.Sessions.SortOrder.Label" xml:space="preserve"><value>Session list sort order</value></data>
   <data name="Settings.Sessions.SortOrder.ByCreatedAt" xml:space="preserve"><value>By creation date</value></data>
   <data name="Settings.Sessions.SortOrder.ByLastAccessed" xml:space="preserve"><value>By last used</value></data>
@@ -158,19 +154,17 @@
   <data name="Settings.Sessions.InputPanel.HideHelp" xml:space="preserve"><value>Hide the bottom input panel to use more space for the terminal.</value></data>
 
   <!-- Settings: Export/Import Tab -->
-  <data name="Settings.Export.Header" xml:space="preserve"><value>Export / Import Data</value></data>
   <data name="Settings.Export.Export.Header" xml:space="preserve"><value>Export</value></data>
   <data name="Settings.Export.Export.Help" xml:space="preserve"><value>Downloads session data from the current storage ({0}) as a JSON file.</value></data>
   <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>Export target: {0} sessions</value></data>
   <data name="Settings.Export.Export.Button" xml:space="preserve"><value>Export</value></data>
   <data name="Settings.Export.Import.Header" xml:space="preserve"><value>Import</value></data>
-  <data name="Settings.Export.Import.Help" xml:space="preserve"><value>Select a JSON file to import session data. It will be added to the current storage ({0}).</value></data>
+  <data name="Settings.Export.Import.Help" xml:space="preserve"><value>Select a JSON file to import session data. Existing sessions are kept and the imported data is added.</value></data>
   <data name="Settings.Export.Import.PreviewHeader" xml:space="preserve"><value>Import preview</value></data>
   <data name="Settings.Export.Import.PreviewSessions" xml:space="preserve"><value>Sessions: {0}</value></data>
   <data name="Settings.Export.Import.RunButton" xml:space="preserve"><value>Run import</value></data>
 
   <!-- Settings: Commands Tab -->
-  <data name="Settings.Commands.Header" xml:space="preserve"><value>Custom Commands</value></data>
   <data name="Settings.Commands.Help" xml:space="preserve"><value>Register commands shown in the button bar for each terminal type.</value></data>
   <data name="Settings.Commands.Type.Text" xml:space="preserve"><value>Text</value></data>
   <data name="Settings.Commands.Type.Key" xml:space="preserve"><value>Key</value></data>
@@ -179,7 +173,6 @@
   <data name="Settings.Commands.DragToReorder" xml:space="preserve"><value>Drag to reorder</value></data>
 
   <!-- Settings: Remote Launch Tab -->
-  <data name="Settings.RemoteLaunch.Header" xml:space="preserve"><value>Remote Launch</value></data>
   <data name="Settings.RemoteLaunch.Help" xml:space="preserve"><value>Start Claude Code sessions from your phone when you're away from your PC. Use the URL below on your mobile device.</value></data>
   <data name="Settings.RemoteLaunch.Enable" xml:space="preserve"><value>Enable remote launch</value></data>
   <data name="Settings.RemoteLaunch.Connected" xml:space="preserve"><value>Connected</value></data>
@@ -202,7 +195,6 @@
   <data name="Settings.RemoteLaunch.RegenerateGuidHelp" xml:space="preserve"><value>Regenerating invalidates the existing access URL.</value></data>
 
   <!-- Settings: Special Tab -->
-  <data name="Settings.Special.Header" xml:space="preserve"><value>Special Settings</value></data>
   <data name="Settings.Special.ClaudeModeKey.Header" xml:space="preserve"><value>Claude Code mode switch key</value></data>
   <data name="Settings.Special.ClaudeModeKey.Help" xml:space="preserve"><value>Select the keyboard shortcut used for mode switching in Claude Code.</value></data>
   <data name="Settings.Special.ClaudeModeKey.None" xml:space="preserve"><value>None</value></data>
@@ -219,7 +211,6 @@
   <data name="Settings.Special.Logs.Help" xml:space="preserve"><value>Opens the folder where application log files are stored.</value></data>
 
   <!-- Settings: Dev Diagnose Tab -->
-  <data name="Settings.DevDiagnose.Header" xml:space="preserve"><value>Diagnostics</value></data>
   <data name="Settings.DevDiagnose.Refresh" xml:space="preserve"><value>Refresh diagnostics</value></data>
   <data name="Settings.DevDiagnose.RunJs" xml:space="preserve"><value>Run JS diagnostics</value></data>
   <data name="Settings.DevDiagnose.SessionList" xml:space="preserve"><value>Session list</value></data>
@@ -239,7 +230,6 @@
   <data name="Settings.DevDiagnose.ScrollInfo.PositionFormat" xml:space="preserve"><value>Scroll position: {0} - {1}</value></data>
 
   <!-- Settings: Dev Buffer Tab -->
-  <data name="Settings.DevBuffer.Header" xml:space="preserve"><value>Buffer Dump</value></data>
   <data name="Settings.DevBuffer.Help" xml:space="preserve"><value>Downloads the session's output buffer (up to 2MB) as a file.</value></data>
   <data name="Settings.DevBuffer.SelectLabel" xml:space="preserve"><value>Select session</value></data>
   <data name="Settings.DevBuffer.SelectPlaceholder" xml:space="preserve"><value>-- Select a session --</value></data>
@@ -256,7 +246,6 @@
   <data name="Settings.DevBuffer.HeaderBufferContent" xml:space="preserve"><value>Buffer Content</value></data>
 
   <!-- Settings: Dev Notify Tab -->
-  <data name="Settings.DevNotify.Header" xml:space="preserve"><value>Notification Test</value></data>
   <data name="Settings.DevNotify.TestElapsedLabel" xml:space="preserve"><value>Test elapsed time (seconds)</value></data>
   <data name="Settings.DevNotify.TestBrowser" xml:space="preserve"><value>Test browser notification</value></data>
   <data name="Settings.DevNotify.TestWebhook" xml:space="preserve"><value>Test webhook notification</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -155,7 +155,7 @@
 
   <!-- Settings: Export/Import Tab -->
   <data name="Settings.Export.Export.Header" xml:space="preserve"><value>Export</value></data>
-  <data name="Settings.Export.Export.Help" xml:space="preserve"><value>Downloads session data from the current storage ({0}) as a JSON file.</value></data>
+  <data name="Settings.Export.Export.Help" xml:space="preserve"><value>Downloads session data as a JSON file.</value></data>
   <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>Export target: {0} sessions</value></data>
   <data name="Settings.Export.Export.Button" xml:space="preserve"><value>Export</value></data>
   <data name="Settings.Export.Import.Header" xml:space="preserve"><value>Import</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -155,7 +155,7 @@
 
   <!-- Settings: Export/Import Tab -->
   <data name="Settings.Export.Export.Header" xml:space="preserve"><value>エクスポート</value></data>
-  <data name="Settings.Export.Export.Help" xml:space="preserve"><value>現在のストレージ（{0}）からセッション情報をJSONファイルとしてダウンロードします。</value></data>
+  <data name="Settings.Export.Export.Help" xml:space="preserve"><value>セッション情報をJSONファイルとしてダウンロードします。</value></data>
   <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>エクスポート対象: セッション情報（{0} 件）</value></data>
   <data name="Settings.Export.Export.Button" xml:space="preserve"><value>エクスポート</value></data>
   <data name="Settings.Export.Import.Header" xml:space="preserve"><value>インポート</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -81,15 +81,14 @@
   <data name="Settings.Tab.DevNotify" xml:space="preserve"><value>通知テスト</value></data>
 
   <!-- Settings: General Tab -->
-  <data name="Settings.General.Header" xml:space="preserve"><value>一般設定</value></data>
   <data name="Settings.General.Language.Label" xml:space="preserve"><value>言語</value></data>
   <data name="Settings.General.Language.Help" xml:space="preserve"><value>UI の表示言語を切り替えます。選択すると再読み込みされます。</value></data>
   <data name="Settings.General.DefaultFolder.Label" xml:space="preserve"><value>デフォルトフォルダパス</value></data>
   <data name="Settings.General.DefaultFolder.PickTitle" xml:space="preserve"><value>フォルダを選択</value></data>
-  <data name="Settings.General.DefaultFolder.Help" xml:space="preserve"><value>新規セッション作成時のデフォルトパスを設定します。空欄の場合はユーザーフォルダが使用されます。</value></data>
+  <data name="Settings.General.DefaultFolder.Help" xml:space="preserve"><value>新規セッション作成時のデフォルトパスを設定します。空欄の場合はユーザーフォルダを使用します。</value></data>
   <data name="Settings.General.FavoriteFolders.Label" xml:space="preserve"><value>お気に入りフォルダ</value></data>
   <data name="Settings.General.FavoriteFolders.Placeholder" xml:space="preserve"><value>フォルダパスを入力</value></data>
-  <data name="Settings.General.FavoriteFolders.Help" xml:space="preserve"><value>セッション作成時にフォルダ選択の候補として表示されます。</value></data>
+  <data name="Settings.General.FavoriteFolders.Help" xml:space="preserve"><value>新規セッション作成時にフォルダ選択の候補として表示されます。</value></data>
   <data name="Settings.General.Version.Header" xml:space="preserve"><value>バージョン情報</value></data>
   <data name="Settings.General.Version.Current" xml:space="preserve"><value>現在のバージョン:</value></data>
   <data name="Settings.General.Version.Checking" xml:space="preserve"><value>バージョンを確認中…</value></data>
@@ -101,21 +100,19 @@
   <data name="Settings.General.Community.Help" xml:space="preserve"><value>バグ報告、機能リクエスト、質問などはこちらで受け付けています。</value></data>
 
   <!-- Settings: Display Tab -->
-  <data name="Settings.Display.Header" xml:space="preserve"><value>表示設定</value></data>
   <data name="Settings.Display.Theme.Label" xml:space="preserve"><value>テーマ</value></data>
   <data name="Settings.Display.Theme.Light" xml:space="preserve"><value>ライト</value></data>
   <data name="Settings.Display.Theme.Dark" xml:space="preserve"><value>ダーク</value></data>
   <data name="Settings.Display.SessionListScale.Label" xml:space="preserve"><value>セッションリスト表示倍率</value></data>
-  <data name="Settings.Display.SessionListScale.Help" xml:space="preserve"><value>セッションリストの表示倍率を調整します（50%〜150%）。</value></data>
+  <data name="Settings.Display.SessionListScale.Help" xml:space="preserve"><value>表示倍率（50%〜150%）。</value></data>
   <data name="Settings.Display.TerminalFontSize.Label" xml:space="preserve"><value>ターミナルフォントサイズ</value></data>
-  <data name="Settings.Display.TerminalFontSize.Help" xml:space="preserve"><value>ターミナルのフォントサイズを調整します（8px〜28px）。</value></data>
+  <data name="Settings.Display.TerminalFontSize.Help" xml:space="preserve"><value>フォントサイズ（8px〜28px）。</value></data>
   <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>サイドバー幅</value></data>
-  <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>セッションリストの幅を調整します（15%〜40%）。境界線のドラッグでも変更できます。</value></data>
+  <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>幅（15%〜40%）。境界線のドラッグでも変更可能。</value></data>
   <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>ターミナル / 入力パネル比率</value></data>
-  <data name="Settings.Display.TerminalHeightRatio.Help" xml:space="preserve"><value>ターミナルと入力パネルの高さ比率を調整します（50:50〜90:10）。境界線のドラッグでも変更できます。</value></data>
+  <data name="Settings.Display.TerminalHeightRatio.Help" xml:space="preserve"><value>高さ比率（50:50〜90:10）。境界線のドラッグでも変更可能。</value></data>
 
   <!-- Settings: Notifications Tab -->
-  <data name="Settings.Notifications.Header" xml:space="preserve"><value>通知設定</value></data>
   <data name="Settings.Notifications.Browser.Label" xml:space="preserve"><value>ブラウザ通知</value></data>
   <data name="Settings.Notifications.Status.Granted" xml:space="preserve"><value>許可済み</value></data>
   <data name="Settings.Notifications.Status.Denied" xml:space="preserve"><value>拒否</value></data>
@@ -128,8 +125,8 @@
   <data name="Settings.Notifications.Browser.RevokeHelp" xml:space="preserve"><value>ブラウザの設定画面で通知許可を解除できます。</value></data>
   <data name="Settings.Notifications.Browser.Request" xml:space="preserve"><value>通知を許可する</value></data>
   <data name="Settings.Notifications.Browser.RequestHelp" xml:space="preserve"><value>処理完了時にデスクトップ通知を受け取るには、ブラウザの通知を許可してください。</value></data>
-  <data name="Settings.Notifications.Threshold.Label" xml:space="preserve"><value>通知を送信する処理時間（秒）</value></data>
-  <data name="Settings.Notifications.Threshold.Help" xml:space="preserve"><value>0に設定すると、すべての処理完了時に通知します</value></data>
+  <data name="Settings.Notifications.Threshold.Label" xml:space="preserve"><value>通知する最小処理時間（秒）</value></data>
+  <data name="Settings.Notifications.Threshold.Help" xml:space="preserve"><value>0に設定すると、すべての処理完了時に通知します。</value></data>
   <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>Webhook 設定</value></data>
   <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>Webhook 通知を有効にする</value></data>
   <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>Webhook URL</value></data>
@@ -139,7 +136,6 @@
   <data name="Settings.Notifications.ClaudeHook.ApplyNoticeHtml" xml:space="preserve"><value>この設定は各セッションが次に起動／再起動されたタイミングで &lt;code&gt;.claude/settings.local.json&lt;/code&gt; に反映されます。既に起動中のセッションや、TerminalHub 管理外のワークスペースには即時適用されません。</value></data>
 
   <!-- Settings: Sessions Tab -->
-  <data name="Settings.Sessions.Header" xml:space="preserve"><value>セッション設定</value></data>
   <data name="Settings.Sessions.SortOrder.Label" xml:space="preserve"><value>セッション一覧の並び順</value></data>
   <data name="Settings.Sessions.SortOrder.ByCreatedAt" xml:space="preserve"><value>作成日時順</value></data>
   <data name="Settings.Sessions.SortOrder.ByLastAccessed" xml:space="preserve"><value>最終利用日時順</value></data>
@@ -158,19 +154,17 @@
   <data name="Settings.Sessions.InputPanel.HideHelp" xml:space="preserve"><value>下部の入力パネルを非表示にして、ターミナル領域を広く使えます。</value></data>
 
   <!-- Settings: Export/Import Tab -->
-  <data name="Settings.Export.Header" xml:space="preserve"><value>データのエクスポート/インポート</value></data>
   <data name="Settings.Export.Export.Header" xml:space="preserve"><value>エクスポート</value></data>
   <data name="Settings.Export.Export.Help" xml:space="preserve"><value>現在のストレージ（{0}）からセッション情報をJSONファイルとしてダウンロードします。</value></data>
   <data name="Settings.Export.Export.TargetInfo" xml:space="preserve"><value>エクスポート対象: セッション情報（{0} 件）</value></data>
   <data name="Settings.Export.Export.Button" xml:space="preserve"><value>エクスポート</value></data>
   <data name="Settings.Export.Import.Header" xml:space="preserve"><value>インポート</value></data>
-  <data name="Settings.Export.Import.Help" xml:space="preserve"><value>JSONファイルを選択してセッション情報をインポートします。現在のストレージ（{0}）に追加されます。</value></data>
+  <data name="Settings.Export.Import.Help" xml:space="preserve"><value>JSONファイルを選択してセッション情報をインポートします。既存のセッション情報は保持され、読み込んだデータが追加されます。</value></data>
   <data name="Settings.Export.Import.PreviewHeader" xml:space="preserve"><value>インポートプレビュー</value></data>
   <data name="Settings.Export.Import.PreviewSessions" xml:space="preserve"><value>セッション情報: {0} 件</value></data>
   <data name="Settings.Export.Import.RunButton" xml:space="preserve"><value>インポート実行</value></data>
 
   <!-- Settings: Commands Tab -->
-  <data name="Settings.Commands.Header" xml:space="preserve"><value>カスタムコマンド</value></data>
   <data name="Settings.Commands.Help" xml:space="preserve"><value>ターミナル種別ごとにボタンバーに表示するコマンドを登録できます。</value></data>
   <data name="Settings.Commands.Type.Text" xml:space="preserve"><value>テキスト</value></data>
   <data name="Settings.Commands.Type.Key" xml:space="preserve"><value>キー</value></data>
@@ -179,8 +173,7 @@
   <data name="Settings.Commands.DragToReorder" xml:space="preserve"><value>ドラッグで並び替え</value></data>
 
   <!-- Settings: Remote Launch Tab -->
-  <data name="Settings.RemoteLaunch.Header" xml:space="preserve"><value>リモート起動</value></data>
-  <data name="Settings.RemoteLaunch.Help" xml:space="preserve"><value>外出先のスマートフォンから Claude Code セッションを起動し、Remote Control URL を取得できます。</value></data>
+  <data name="Settings.RemoteLaunch.Help" xml:space="preserve"><value>スマートフォンから Claude Code セッションを起動できます。下のアクセスURLを端末で開いて使用します。</value></data>
   <data name="Settings.RemoteLaunch.Enable" xml:space="preserve"><value>リモート起動を有効にする</value></data>
   <data name="Settings.RemoteLaunch.Connected" xml:space="preserve"><value>接続中</value></data>
   <data name="Settings.RemoteLaunch.Disconnected" xml:space="preserve"><value>未接続</value></data>
@@ -193,19 +186,18 @@
   <data name="Settings.RemoteLaunch.DiagPingNgFormat" xml:space="preserve"><value>NG: {0}</value></data>
   <data name="Settings.RemoteLaunch.AccessUrl" xml:space="preserve"><value>アクセスURL</value></data>
   <data name="Settings.RemoteLaunch.CopyUrlTitle" xml:space="preserve"><value>URLをコピー</value></data>
-  <data name="Settings.RemoteLaunch.UrlWarning" xml:space="preserve"><value>このURLは他人に公開しないでください。URLを知っている人がセッションを起動できます。</value></data>
+  <data name="Settings.RemoteLaunch.UrlWarning" xml:space="preserve"><value>このURLは第三者に共有しないでください。URLを知っている人は誰でもセッションを起動できます。</value></data>
   <data name="Settings.RemoteLaunch.PasswordLabel" xml:space="preserve"><value>パスワード（任意）</value></data>
   <data name="Settings.RemoteLaunch.PasswordPlaceholder" xml:space="preserve"><value>設定するとアクセス時にパスワードが必要になります</value></data>
   <data name="Settings.RemoteLaunch.PasswordHelp" xml:space="preserve"><value>空欄の場合はURLのみでアクセスできます。</value></data>
-  <data name="Settings.RemoteLaunch.TopicGuid" xml:space="preserve"><value>トピックGUID</value></data>
+  <data name="Settings.RemoteLaunch.TopicGuid" xml:space="preserve"><value>接続ID</value></data>
   <data name="Settings.RemoteLaunch.RegenerateGuidTitle" xml:space="preserve"><value>GUIDを再発行（既存のアクセスURLが無効になります）</value></data>
   <data name="Settings.RemoteLaunch.RegenerateGuidHelp" xml:space="preserve"><value>再発行すると既存のアクセスURLが無効になります。</value></data>
 
   <!-- Settings: Special Tab -->
-  <data name="Settings.Special.Header" xml:space="preserve"><value>特殊設定</value></data>
   <data name="Settings.Special.ClaudeModeKey.Header" xml:space="preserve"><value>Claude Code モード切替キー</value></data>
   <data name="Settings.Special.ClaudeModeKey.Help" xml:space="preserve"><value>Claude Code でモード切替に使用するキーボードショートカットを選択します。</value></data>
-  <data name="Settings.Special.ClaudeModeKey.None" xml:space="preserve"><value>無し</value></data>
+  <data name="Settings.Special.ClaudeModeKey.None" xml:space="preserve"><value>なし</value></data>
   <data name="Settings.Special.ClaudeModeKey.DefaultNote" xml:space="preserve"><value>（デフォルト）</value></data>
   <data name="Settings.Special.ClaudeModeKey.ConflictNote" xml:space="preserve"><value>環境によっては Alt+M が他の機能と競合する場合があります。その場合は Shift+Tab をお試しください。</value></data>
   <data name="Settings.Special.VoiceInput.Header" xml:space="preserve"><value>音声入力</value></data>
@@ -219,7 +211,6 @@
   <data name="Settings.Special.Logs.Help" xml:space="preserve"><value>アプリケーションのログファイルが保存されているフォルダを開きます。</value></data>
 
   <!-- Settings: Dev Diagnose Tab -->
-  <data name="Settings.DevDiagnose.Header" xml:space="preserve"><value>診断情報</value></data>
   <data name="Settings.DevDiagnose.Refresh" xml:space="preserve"><value>診断情報を更新</value></data>
   <data name="Settings.DevDiagnose.RunJs" xml:space="preserve"><value>JS 診断実行</value></data>
   <data name="Settings.DevDiagnose.SessionList" xml:space="preserve"><value>セッション一覧</value></data>
@@ -239,7 +230,6 @@
   <data name="Settings.DevDiagnose.ScrollInfo.PositionFormat" xml:space="preserve"><value>スクロール位置: {0} - {1}</value></data>
 
   <!-- Settings: Dev Buffer Tab -->
-  <data name="Settings.DevBuffer.Header" xml:space="preserve"><value>バッファダンプ</value></data>
   <data name="Settings.DevBuffer.Help" xml:space="preserve"><value>セッションの出力バッファ（最大2MB）をファイルにダウンロードします。</value></data>
   <data name="Settings.DevBuffer.SelectLabel" xml:space="preserve"><value>セッション選択</value></data>
   <data name="Settings.DevBuffer.SelectPlaceholder" xml:space="preserve"><value>-- セッションを選択 --</value></data>
@@ -256,7 +246,6 @@
   <data name="Settings.DevBuffer.HeaderBufferContent" xml:space="preserve"><value>バッファ内容</value></data>
 
   <!-- Settings: Dev Notify Tab -->
-  <data name="Settings.DevNotify.Header" xml:space="preserve"><value>通知テスト</value></data>
   <data name="Settings.DevNotify.TestElapsedLabel" xml:space="preserve"><value>テスト用経過時間（秒）</value></data>
   <data name="Settings.DevNotify.TestBrowser" xml:space="preserve"><value>ブラウザ通知テスト</value></data>
   <data name="Settings.DevNotify.TestWebhook" xml:space="preserve"><value>Webhook 通知テスト</value></data>
@@ -408,7 +397,7 @@
   <data name="SessionSettings.OpenMemoManagement" xml:space="preserve"><value>メモ管理</value></data>
   <data name="SessionSettings.DisplayName.Label" xml:space="preserve"><value>表示名</value></data>
   <data name="SessionSettings.DisplayName.Placeholder" xml:space="preserve"><value>セッションの表示名</value></data>
-  <data name="SessionSettings.DisplayName.Help" xml:space="preserve"><value>空白の場合はフォルダ名が使用されます</value></data>
+  <data name="SessionSettings.DisplayName.Help" xml:space="preserve"><value>空白の場合はフォルダ名を使用します</value></data>
   <data name="SessionSettings.Pin.Label" xml:space="preserve"><value>セッションをピン留め</value></data>
   <data name="SessionSettings.Pin.PriorityLabel" xml:space="preserve"><value>優先度:</value></data>
   <data name="SessionSettings.Memo.Label" xml:space="preserve"><value>メモ</value></data>


### PR DESCRIPTION
## Summary

外部レビュー (\`terminalhub_ja_localization_fixes.md\`) のフィードバックに基づき、日本語 UI の文言品質を改善。**あわせて、各設定タブ冒頭のタブ名と重複する h6 見出しを全面削除** してダイアログの構造をスッキリさせる。

英語 UI (PR #52) と同じ分類で、主に日本語側の調整。一部は ja/en 両方に反映 (Export Import Help)。

## 修正項目 (優先度別)

### 🔴 High
- **通知の閾値ラベル**: \`通知を送信する処理時間（秒）\` → \`通知する最小処理時間（秒）\` (意図を明確化)
- **通知ヘルプ**: 末尾に句点追加

### 🟡 Medium
- **リモート起動 導入文**: \`外出先のスマートフォンから ... Remote Control URL を取得できます。\` → \`スマートフォンから ... セッションを起動できます。下のアクセスURLを端末で開いて使用します。\`
  - \`外出先の\` 限定解除 (自宅内ソファや別室からも使える)
  - \`Remote Control URL\` 英語残存を \`アクセスURL\` (下のラベルと統一) へ
- **URL 警告**: \`このURLは他人に公開しないでください。URLを知っている人がセッションを起動できます。\` → \`このURLは第三者に共有しないでください。URLを知っている人は誰でもセッションを起動できます。\`
  - \"他人\"→\"第三者\" (セキュリティ文言として一段強い)
  - \"人が\"→\"人は誰でも\" (脅威範囲の明確化)
  - \"公開\"→\"共有\" (URL の性質に合致)
- **\`トピックGUID\` → \`接続ID\`**: MQTT 内部用語の露出解消、値 (GUID) はそのまま
- **受動形の能動化**:
  - \`ユーザーフォルダが使用されます\` → \`ユーザーフォルダを使用します\`
  - \`フォルダ名が使用されます\` → \`フォルダ名を使用します\`

### 🟢 Low
- **表記揺れ統一**: \`セッション作成時\` → \`新規セッション作成時\` (お気に入りフォルダ説明文)
- **「調整します」4連打解消** (表示タブ、体言止め + 簡潔化):
  - \`セッションリストの表示倍率を調整します（50%〜150%）。\` → \`表示倍率（50%〜150%）。\`
  - \`ターミナルのフォントサイズを調整します（8px〜28px）。\` → \`フォントサイズ（8px〜28px）。\`
  - 他 2 件も同様に短縮
- **「無し」→「なし」**: ひらがな化で柔らかく
- **インポート説明明示**: \`現在のストレージ（SQLite）に追加されます。\` → \`既存のセッション情報は保持され、読み込んだデータが追加されます。\`
  - コード上 \`string.Format(..., \"SQLite\")\` も不要になり \`L[...]\` 参照に簡素化

## 設定ダイアログの構造改善 (重複見出し削除)

各設定タブの冒頭にあった h6 見出し (**全 11 箇所**) を削除:
- 一般 / 表示 / 通知 / セッション / エクスポート/インポート / コマンド / リモート起動 / 特殊 / 診断 / バッファ / 通知テスト

タブ名で既に明確なため、見出しは情報の重複。削除に伴い、未使用になった \`Settings.*.Header\` キー 11 件を ja/en 両 resx から削除。

- **保持**: \`Settings.DevBuffer.HeaderBufferInfo\` / \`HeaderBufferContent\` はバッファダンプ出力用の別セクション見出しなので残す

## 変更ファイル

| ファイル | 変更 |
|---|---|
| \`SharedResource.ja.resx\` | 日本語値 13 箇所修正 + Header キー 11 件削除 |
| \`SharedResource.en.resx\` | Export.Import.Help 改善 + Header キー 11 件削除 |
| \`SettingsDialog.razor\` | h6 見出し 11 箇所削除 + \`string.Format\` 簡素化 |

**統計**: 3 ファイル、+16 / −57 行

**resx キーパリティ**: ja=419 / en=419 (完全パリティ維持、PR 前 430 から -11)

## 意図的に採用しなかった項目

- **#7 Memo デフォルトタブ名の英語残存**: resx 側は既に \`メモ({0})\` で対応済み。レビュアーが見たのは以前のバージョンで作成され永続化された既存タブの可能性。Migration は別途要検討。
- **#8 英数字前後の半角スペース**: 全体ポリシー判断が必要なため今回は見送り (レビュアーも \"好み\" と明記)
- **#14 \`Terminal\` → \`ターミナル\`**: 一貫性を優先してツール名は英語のまま据え置き (\`Claude Code\` / \`Gemini CLI\` と同列扱い)

## Test plan

- [ ] 設定 > 各タブ: 開いた直後に重複見出しがない (タブ名のみで明確)
- [ ] 設定 > 通知: 閾値ラベルが \`通知する最小処理時間（秒）\` で表示される
- [ ] 設定 > リモート起動: 導入文に \`Remote Control URL\` が含まれない、警告文が \`第三者\` \`誰でも\` \`共有\` に変更されている
- [ ] 設定 > リモート起動: GUID ラベルが \`接続ID\` で表示される
- [ ] 設定 > エクスポート/インポート: インポート説明が \`既存のセッション情報は保持され、読み込んだデータが追加されます。\` に変更されている
- [ ] 設定 > 特殊 > Claude Code モード切替キー: \`● なし（デフォルト）\` が表示される
- [ ] 設定 > 表示: 4 つの Help テキストが短い体言止めに変わっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)