### PR TITLE
fix(i18n): resx 精読レビューの指摘を反映

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1637,6 +1637,7 @@
         {
             TerminalType.ClaudeCode => L["Root.Placeholder.ClaudeCode"],
             TerminalType.GeminiCLI => L["Root.Placeholder.GeminiCLI"],
+            TerminalType.CodexCLI => L["Root.Placeholder.CodexCLI"],
             _ => L["Root.Placeholder.Terminal"]
         };
     }

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -124,7 +124,7 @@
   <data name="Settings.Notifications.Browser.Revoke" xml:space="preserve"><value>Revoke notification permission</value></data>
   <data name="Settings.Notifications.Browser.RevokeHelp" xml:space="preserve"><value>You can revoke the notification permission from your browser's settings.</value></data>
   <data name="Settings.Notifications.Browser.Request" xml:space="preserve"><value>Allow notifications</value></data>
-  <data name="Settings.Notifications.Browser.RequestHelp" xml:space="preserve"><value>To receive desktop notifications when processing completes, please allow browser notifications.</value></data>
+  <data name="Settings.Notifications.Browser.RequestHelp" xml:space="preserve"><value>To receive desktop notifications when processing completes, allow browser notifications.</value></data>
   <data name="Settings.Notifications.Threshold.Label" xml:space="preserve"><value>Minimum task duration for notifications (seconds)</value></data>
   <data name="Settings.Notifications.Threshold.Help" xml:space="preserve"><value>Set to 0 to notify on every completion.</value></data>
   <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>Webhook</value></data>
@@ -312,7 +312,7 @@
   <data name="SessionOptions.Claude.PermissionMode.HelpBypass" xml:space="preserve"><value>Auto-approves all operations unconditionally (--dangerously-skip-permissions).</value></data>
   <data name="SessionOptions.Claude.PermissionMode.HelpAuto" xml:space="preserve"><value>Auto-approves low-risk operations and prompts only for high-risk ones (--enable-auto-mode).</value></data>
   <data name="SessionOptions.Claude.PermissionMode.HelpDefault" xml:space="preserve"><value>Prompts for confirmation on every operation.</value></data>
-  <data name="SessionOptions.Claude.Continue" xml:space="preserve"><value>Continue (--continue)</value></data>
+  <data name="SessionOptions.Claude.Continue" xml:space="preserve"><value>Resume previous session (--continue)</value></data>
   <data name="SessionOptions.Claude.Chrome" xml:space="preserve"><value>Browser integration (--chrome)</value></data>
   <data name="SessionOptions.Claude.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --model claude-sonnet-4-20250514 --verbose</value></data>
   <data name="SessionOptions.Claude.PassToCli" xml:space="preserve"><value>Passed as-is to Claude Code</value></data>
@@ -328,7 +328,7 @@
   <data name="SessionOptions.Gemini.ApprovalMode.HelpYolo" xml:space="preserve"><value>Auto-approves all operations without warning (dangerous).</value></data>
   <data name="SessionOptions.Gemini.Sandbox" xml:space="preserve"><value>Sandbox mode (-s)</value></data>
   <data name="SessionOptions.Gemini.SandboxHelp" xml:space="preserve"><value>Docker Desktop must be installed to use this feature.</value></data>
-  <data name="SessionOptions.Gemini.Continue" xml:space="preserve"><value>Continue (--resume latest)</value></data>
+  <data name="SessionOptions.Gemini.Continue" xml:space="preserve"><value>Resume previous session (--resume latest)</value></data>
   <data name="SessionOptions.Gemini.UseCustomModel" xml:space="preserve"><value>Customize model</value></data>
   <data name="SessionOptions.Gemini.ModelSelectLabel" xml:space="preserve"><value>Model to use</value></data>
   <data name="SessionOptions.Gemini.ModelManagementLabel" xml:space="preserve"><value>Model list management</value></data>
@@ -350,7 +350,7 @@
   <data name="SessionOptions.Codex.Mode.HelpYolo" xml:space="preserve"><value>Fully automatic execution (dangerous). Isolated environment recommended.</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>Warning:</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO mode should only be used in isolated environments (WSL/Docker/VM/CI).</value></data>
-  <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>Resume last session (resume --last)</value></data>
+  <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>Resume previous session (resume --last)</value></data>
   <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>Sandbox mode</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI default</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultTitle" xml:space="preserve"><value>Do not add --sandbox; use the Codex CLI default.</value></data>
@@ -509,6 +509,7 @@
   <data name="Root.NoSessionSelected" xml:space="preserve"><value>Select a session from the left sidebar</value></data>
   <data name="Root.Placeholder.ClaudeCode" xml:space="preserve"><value>Type a message for Claude Code...</value></data>
   <data name="Root.Placeholder.GeminiCLI" xml:space="preserve"><value>Type a message for Gemini CLI...</value></data>
+  <data name="Root.Placeholder.CodexCLI" xml:space="preserve"><value>Type a message for Codex CLI...</value></data>
   <data name="Root.Placeholder.Terminal" xml:space="preserve"><value>Enter a command...</value></data>
   <data name="Root.SessionType.Terminal" xml:space="preserve"><value>Terminal</value></data>
   <data name="Root.SessionType.Fallback" xml:space="preserve"><value>Session</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -312,7 +312,7 @@
   <data name="SessionOptions.Claude.PermissionMode.HelpBypass" xml:space="preserve"><value>全操作を無条件で自動承認します（--dangerously-skip-permissions）。</value></data>
   <data name="SessionOptions.Claude.PermissionMode.HelpAuto" xml:space="preserve"><value>低リスク操作を自動承認し、高リスク操作のみ確認を求めます（--enable-auto-mode）。</value></data>
   <data name="SessionOptions.Claude.PermissionMode.HelpDefault" xml:space="preserve"><value>全ての操作で都度確認を求めます。</value></data>
-  <data name="SessionOptions.Claude.Continue" xml:space="preserve"><value>コンティニュー (--continue)</value></data>
+  <data name="SessionOptions.Claude.Continue" xml:space="preserve"><value>直前のセッションに接続 (--continue)</value></data>
   <data name="SessionOptions.Claude.Chrome" xml:space="preserve"><value>ブラウザ連携 (--chrome)</value></data>
   <data name="SessionOptions.Claude.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --model claude-sonnet-4-20250514 --verbose</value></data>
   <data name="SessionOptions.Claude.PassToCli" xml:space="preserve"><value>そのまま Claude Code に渡します</value></data>
@@ -328,7 +328,7 @@
   <data name="SessionOptions.Gemini.ApprovalMode.HelpYolo" xml:space="preserve"><value>全ての操作を警告なしで自動的に承認します（危険）。</value></data>
   <data name="SessionOptions.Gemini.Sandbox" xml:space="preserve"><value>サンドボックスモード (-s)</value></data>
   <data name="SessionOptions.Gemini.SandboxHelp" xml:space="preserve"><value>この機能を使用するには、Docker Desktop がインストールされている必要があります。</value></data>
-  <data name="SessionOptions.Gemini.Continue" xml:space="preserve"><value>コンティニュー (--resume latest)</value></data>
+  <data name="SessionOptions.Gemini.Continue" xml:space="preserve"><value>直前のセッションに接続 (--resume latest)</value></data>
   <data name="SessionOptions.Gemini.UseCustomModel" xml:space="preserve"><value>モデルをカスタマイズ</value></data>
   <data name="SessionOptions.Gemini.ModelSelectLabel" xml:space="preserve"><value>使用するモデル</value></data>
   <data name="SessionOptions.Gemini.ModelManagementLabel" xml:space="preserve"><value>モデルリスト管理</value></data>
@@ -350,7 +350,7 @@
   <data name="SessionOptions.Codex.Mode.HelpYolo" xml:space="preserve"><value>全自動実行（危険）。隔離環境推奨です。</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>警告:</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO モードは隔離環境（WSL/Docker/VM/CI）でのみ使用してください。</value></data>
-  <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>最新セッションを再開 (resume --last)</value></data>
+  <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>直前のセッションに接続 (resume --last)</value></data>
   <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>サンドボックスモード</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI 既定</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultTitle" xml:space="preserve"><value>--sandbox を付けず、Codex CLI の既定値に任せます。</value></data>
@@ -360,10 +360,10 @@
   <data name="SessionOptions.Codex.Sandbox.WorkspaceTitle" xml:space="preserve"><value>ワークスペース内のみ書き込み可能。</value></data>
   <data name="SessionOptions.Codex.Sandbox.FullAccessLabel" xml:space="preserve"><value>フルアクセス</value></data>
   <data name="SessionOptions.Codex.Sandbox.FullAccessTitle" xml:space="preserve"><value>フルアクセス（危険）。</value></data>
-  <data name="SessionOptions.Codex.Sandbox.Help" xml:space="preserve"><value>外部通信やファイルアクセス範囲を制限</value></data>
+  <data name="SessionOptions.Codex.Sandbox.Help" xml:space="preserve"><value>外部通信やファイルアクセス範囲を制限します。</value></data>
   <data name="SessionOptions.Codex.Sandbox.HelpDefault" xml:space="preserve"><value>Codex CLI の既定値に任せます。</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.Label" xml:space="preserve"><value>承認ポリシー</value></data>
-  <data name="SessionOptions.Codex.ApprovalPolicy.Help" xml:space="preserve"><value>操作の承認レベル（--ask-for-approval）</value></data>
+  <data name="SessionOptions.Codex.ApprovalPolicy.Help" xml:space="preserve"><value>Codex が承認を求めるタイミング（--ask-for-approval）</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>未信頼扱い。すべての操作で承認を求めます。</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>必要なときだけ承認を求めます（デフォルトに近い挙動）。</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpNever" xml:space="preserve"><value>承認を求めません（危険）。</value></data>
@@ -509,6 +509,7 @@
   <data name="Root.NoSessionSelected" xml:space="preserve"><value>左側からセッションを選択してください</value></data>
   <data name="Root.Placeholder.ClaudeCode" xml:space="preserve"><value>Claude Code へのメッセージを入力…</value></data>
   <data name="Root.Placeholder.GeminiCLI" xml:space="preserve"><value>Gemini CLI へのメッセージを入力…</value></data>
+  <data name="Root.Placeholder.CodexCLI" xml:space="preserve"><value>Codex CLI へのメッセージを入力…</value></data>
   <data name="Root.Placeholder.Terminal" xml:space="preserve"><value>コマンドを入力…</value></data>
   <data name="Root.SessionType.Terminal" xml:space="preserve"><value>ターミナル</value></data>
   <data name="Root.SessionType.Fallback" xml:space="preserve"><value>セッション</value></data>


### PR DESCRIPTION
## Summary

外部の resx 精読レビュー (\`terminalhub_resx_review_fixes.md\`) のフィードバックを反映。Codex CLI プレースホルダ欠落のバグ修正と、セッション継続系ラベルの 3 CLI 横断統一が主な改善。

## 修正項目

### 🔴 Bug 修正
- **Codex CLI セッションのプレースホルダ欠落**
  - \`Root.razor:1634\` の \`GetPlaceholderText\` が Codex を default (「コマンドを入力…」) に落としていた
  - Claude/Gemini と同じトーンで「Codex CLI へのメッセージを入力…」を追加
  - \`Root.Placeholder.CodexCLI\` キーを新設 (ja/en)

### 🟡 文言品質改善
- **セッション継続系ラベルの 3 CLI 横断統一**
  - 旧: ja 「コンティニュー」「最新セッションを再開」 / en 「Continue」「Resume last session」
  - 新: ja 「直前のセッションに接続 (...)」 / en 「Resume previous session (...)」
  - 対象キー: \`SessionOptions.Claude.Continue\` / \`Gemini.Continue\` / \`Codex.ResumeLast\`
  - フラグ名の括弧併記 (\`--continue\` / \`--resume latest\` / \`resume --last\`) は維持

- **Codex ApprovalPolicy.Help 日本語を自然な動詞句へ**
  - 「操作の承認レベル（--ask-for-approval）」 → 「Codex が承認を求めるタイミング（--ask-for-approval）」
  - 英語版 (#52 で \`When Codex should ask for approval\` に改善済) と歩調を合わせる

- **Codex Sandbox.Help 日本語の句点統一**
  - 「外部通信やファイルアクセス範囲を制限」 → 「外部通信やファイルアクセス範囲を制限します。」
  - 隣接する \`NetworkAccess.Help\` が句点付き文章なので整合

### 🟢 軽微改善
- **英語版 \`Notifications.Browser.RequestHelp\` から \`please\` を削除**
  - UI テキストのレジスタとして引き締める (ja は「〜してください」で自然なので据え置き)

## 意図的に採用しなかった項目

| 項目 | 理由 |
|---|---|
| **#1 \`ResultCodeFormat\` キー削除** | PR #52 で失敗時の診断表示に使用中 (\`SettingsDialog.razor:688\`)。成功時は \`Last tested\` に切り替え済みで、現状で正しく動作。指摘は PR #52 以前のスクショに対するもの。 |
| **#3 英数字前後の半角スペース** | resx 全体 (Claude Code オプション / Gemini CLI オプション / Webhook 設定 等) でスペース付与で統一済み。ポリシー通り。 |
| **#5 全角/半角括弧** | 案 B (英数字隣接は半角、日本語隣接は全角) の使い分け方針でユーザー判断済み。\`Auto (推奨)\` と \`（50%〜150%）\` の混在は意図的な使い分け。 |
| **#7 NetworkAccess.Help 句点** | 現状 \`...（...）。デフォルトは enabled。\` で 2 文目が句点ありで機能している。据え置き。 |
| **#9 CreateSession のボタン/タイトル分離** | 現状英語版で \`New Session\` で一貫性あり、直す必要性低い |
| **#10/#11 Export/Import 「セッション情報」** | 現状でも不自然でない、許容範囲 |
| **#14 Memo.Placeholder 日英不整合** | 日本語の「セッションに関するメモ」は抽象説明として自然、英語は具体例と割り切り |

## 変更ファイル

| ファイル | 変更 |
|---|---|
| \`Root.razor\` | \`GetPlaceholderText\` switch に \`TerminalType.CodexCLI\` ケース追加 |
| \`SharedResource.ja.resx\` | 6 キー修正 + 1 キー追加 |
| \`SharedResource.en.resx\` | 5 キー修正 + 1 キー追加 |

**統計**: 3 ファイル、+12 / −9 行  
**resx キーパリティ**: ja=420 / en=420 (+1 キー、完全パリティ維持)

## Test plan

- [ ] Codex CLI セッションでテキスト入力パネルが「Codex CLI へのメッセージを入力…」(ja) / 「Type a message for Codex CLI...」(en) を表示
- [ ] 3 CLI 全ての新規セッション作成ダイアログで継続系チェックボックスが「直前のセッションに接続 (...)」で統一されている
- [ ] Codex CLI 新規セッションダイアログで Approval policy 説明が「Codex が承認を求めるタイミング」と表示される
- [ ] Codex CLI 新規セッションダイアログで Sandbox 説明が「外部通信やファイルアクセス範囲を制限します。」で句点終わり
- [ ] 英語 UI で通知許可画面のメッセージから \`please\` が消えている
- [ ] Remote Launch 接続成功時は \`Last tested: HH:mm:ss\` が表示 (ResultCode は出ない)
- [ ] Remote Launch 接続失敗時のみ \`ResultCode: <code>\` が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)