### PR TITLE
fix(db): v3 マイグレーションを冪等化 (duplicate column 対策)

### DIFF
--- a/TerminalHub/Services/SessionDbContext.cs
+++ b/TerminalHub/Services/SessionDbContext.cs
@@ -168,11 +168,33 @@ namespace TerminalHub.Services
             if (currentVersion < 3)
             {
                 // v3: ピン留め・優先度カラムを追加
+                // ⚠️ 過去に IsPinned/PinPriority が先回りして入っているのに
+                //    SchemaVersion=2 のまま残された DB が観測されたため、
+                //    カラムの存在を個別チェックして不足分だけ追加する冪等実装にしている。
                 _logger.LogInformation("[DB][マイグレーション] v3 適用開始: IsPinned, PinPriority カラム追加");
                 await using var connection = new SqliteConnection(_connectionString);
                 await connection.OpenAsync();
-                await connection.ExecuteNonQueryAsync("ALTER TABLE Sessions ADD COLUMN IsPinned INTEGER DEFAULT 0");
-                await connection.ExecuteNonQueryAsync("ALTER TABLE Sessions ADD COLUMN PinPriority INTEGER");
+
+                if (!await ColumnExistsAsync(connection, "Sessions", "IsPinned"))
+                {
+                    await connection.ExecuteNonQueryAsync("ALTER TABLE Sessions ADD COLUMN IsPinned INTEGER DEFAULT 0");
+                    _logger.LogInformation("[DB][マイグレーション] v3: IsPinned カラムを追加");
+                }
+                else
+                {
+                    _logger.LogInformation("[DB][マイグレーション] v3: IsPinned カラムは既存のためスキップ");
+                }
+
+                if (!await ColumnExistsAsync(connection, "Sessions", "PinPriority"))
+                {
+                    await connection.ExecuteNonQueryAsync("ALTER TABLE Sessions ADD COLUMN PinPriority INTEGER");
+                    _logger.LogInformation("[DB][マイグレーション] v3: PinPriority カラムを追加");
+                }
+                else
+                {
+                    _logger.LogInformation("[DB][マイグレーション] v3: PinPriority カラムは既存のためスキップ");
+                }
+
                 await SetSchemaVersionAsync(3);
                 _logger.LogInformation("[DB][マイグレーション] v3 適用完了");
             }
@@ -404,6 +426,23 @@ namespace TerminalHub.Services
             ";
 
             await connection.ExecuteNonQueryAsync(sql);
+        }
+
+        /// <summary>
+        /// 指定したテーブルに指定カラムが存在するか確認する。
+        /// PRAGMA table_info の結果を走査して名前一致を見る。
+        /// </summary>
+        private static async Task<bool> ColumnExistsAsync(SqliteConnection connection, string table, string column)
+        {
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"PRAGMA table_info({table})";
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                // PRAGMA table_info: cid(0), name(1), type(2), notnull(3), dflt_value(4), pk(5)
+                if (reader.GetString(1) == column) return true;
+            }
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
## 背景

知人の環境で起動時に以下のエラーが発生した:

```
SQLite Error 1: 'duplicate column name: IsPinned'
```

調査したところ、`SchemaVersion = 2` のまま残っている DB に対して、
すでに `Sessions.IsPinned` カラムだけが先回りで存在している状態だった。
v3 マイグレーションが無条件に `ALTER TABLE ADD COLUMN IsPinned` を
実行するため duplicate column エラーで起動不能になっていた。

## 変更

v3 ブロック内で `PRAGMA table_info(Sessions)` を使ってカラムの存在を
個別チェックし、無い場合だけ `ALTER TABLE ADD COLUMN` を実行するよう
冪等化。最終的に `SetSchemaVersionAsync(3)` を呼んで SchemaVersion を
進める挙動は維持。

- `IsPinned` / `PinPriority` をそれぞれ独立にチェック
- 既存の場合はスキップログを出力するだけで前進
- ヘルパー `ColumnExistsAsync` を private static で追加

## スコープ

- v3 ブロックのみ。v6 (`AddMemoSoftDeleteColumnsAsync`) は同じ脆弱性を
  持つが、必要性が確認できた時点で別途対応する方針 (現時点では事例なし)
- `CreateV1SchemaAsync` / マイグレーションの順序や設計思想は無変更

## 動作確認

- ビルド: `dotnet build` 成功 (0 警告 0 エラー)
- 想定挙動:
  - **新規 DB**: v0→v1→v2→v3 と順次進む (両カラムとも追加される)
  - **正常な v2 DB** (両カラム未存在): 両カラム追加、SchemaVersion=3 へ
  - **壊れた v2 DB** (IsPinned だけ存在): IsPinned スキップ、PinPriority 追加、SchemaVersion=3 へ
  - **両カラム既存の v2 DB**: 両方スキップ、SchemaVersion=3 へ (= 知人の環境を救うケース)

## リスク

- 既存 v3+ ユーザーには影響なし (`currentVersion < 3` ブロック内のみ変更)
- カラム存在チェックは PRAGMA で軽量、ALTER 失敗時の握りつぶしではないため
  別種のエラーは従来どおり例外として表面化する