### PR TITLE
feat: ユーザー定義カスタムCLIオプション機能

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/CustomCliOptionsSection.razor
+++ b/TerminalHub/Components/Shared/Dialogs/CustomCliOptionsSection.razor
@@ -1,0 +1,45 @@
+@namespace TerminalHub.Components.Shared.Dialogs
+@using TerminalHub.Models
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SharedResource> L
+
+@if (Options is { Count: > 0 })
+{
+    <div class="mt-3">
+        <label class="form-label small text-muted mb-1">@L["SessionOptions.CustomOptions.Label"]</label>
+        @foreach (var opt in Options)
+        {
+            var checkedState = States.GetValueOrDefault(opt.Id, opt.DefaultEnabled);
+            var domId = $"customOpt-{Prefix}-{opt.Id}";
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="@domId"
+                       checked="@checkedState"
+                       @onchange="(e) => OnToggle(opt.Id, (bool)e.Value!)" />
+                <label class="form-check-label" for="@domId">
+                    @if (!string.IsNullOrEmpty(opt.Label))
+                    {
+                        <strong>@opt.Label</strong>
+                        <code class="ms-2 small text-muted">@opt.Arguments</code>
+                    }
+                    else
+                    {
+                        <code class="small">@opt.Arguments</code>
+                    }
+                </label>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    [Parameter] public List<UserCliOption>? Options { get; set; }
+    [Parameter] public Dictionary<string, bool> States { get; set; } = new();
+    [Parameter] public string Prefix { get; set; } = "";
+    [Parameter] public EventCallback<(string Id, bool Enabled)> OnStateChanged { get; set; }
+
+    private async Task OnToggle(string id, bool enabled)
+    {
+        States[id] = enabled;
+        await OnStateChanged.InvokeAsync((id, enabled));
+    }
+}

--- a/TerminalHub/Components/Shared/Dialogs/CustomCliOptionsSection.razor
+++ b/TerminalHub/Components/Shared/Dialogs/CustomCliOptionsSection.razor
@@ -11,9 +11,11 @@
         {
             var checkedState = States.GetValueOrDefault(opt.Id, opt.DefaultEnabled);
             var domId = $"customOpt-{Prefix}-{opt.Id}";
+            var ariaLabel = string.IsNullOrEmpty(opt.Label) ? opt.Arguments : $"{opt.Label} ({opt.Arguments})";
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="@domId"
                        checked="@checkedState"
+                       aria-label="@ariaLabel"
                        @onchange="(e) => OnToggle(opt.Id, (bool)e.Value!)" />
                 <label class="form-check-label" for="@domId">
                     @if (!string.IsNullOrEmpty(opt.Label))
@@ -37,9 +39,8 @@
     [Parameter] public string Prefix { get; set; } = "";
     [Parameter] public EventCallback<(string Id, bool Enabled)> OnStateChanged { get; set; }
 
-    private async Task OnToggle(string id, bool enabled)
-    {
-        States[id] = enabled;
-        await OnStateChanged.InvokeAsync((id, enabled));
-    }
+    // State の真実は親 (SessionOptionsSelector) が持つ。子は変更を通知するだけにし、
+    // Dictionary を直接書かないことで責務をレイヤリング。
+    private Task OnToggle(string id, bool enabled) =>
+        OnStateChanged.InvokeAsync((id, enabled));
 }

--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -191,6 +191,9 @@
                 folderPath = defaultPath;
             }
             favoriteFolders = new List<string>(settings.General.FavoriteFolders);
+
+            // 設定タブで CLI オプションを編集した直後にダイアログを開き直したケースに対応するため、再ロードを促す。
+            optionsSelector?.ReloadCustomCliOptions();
         }
         catch (Exception ex)
         {

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -449,12 +449,20 @@
             codexCustomOptions = new List<UserCliOption>(cli.CodexCLI);
 
             // 既存 state はそのまま、新規エントリは DefaultEnabled で初期化
+            var aliveIds = new HashSet<string>();
             foreach (var opt in claudeCustomOptions.Concat(geminiCustomOptions).Concat(codexCustomOptions))
             {
+                aliveIds.Add(opt.Id);
                 if (!customOptionStates.ContainsKey(opt.Id))
                 {
                     customOptionStates[opt.Id] = opt.DefaultEnabled;
                 }
+            }
+            // 設定で削除されたエントリの state は破棄して整合性を保つ
+            var staleIds = customOptionStates.Keys.Where(k => !aliveIds.Contains(k)).ToList();
+            foreach (var id in staleIds)
+            {
+                customOptionStates.Remove(id);
             }
         }
         catch

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -5,6 +5,7 @@
 @using Microsoft.JSInterop
 @inject IConfiguration Configuration
 @inject ILocalStorageService LocalStorage
+@inject IAppSettingsService AppSettingsService
 @inject IStringLocalizer<SharedResource> L
 
 <div class="session-options">
@@ -107,6 +108,9 @@
                        placeholder="@L["SessionOptions.Claude.ExtraArgsPlaceholder"]" />
                 <div class="form-text small">@L["SessionOptions.Claude.PassToCli"]</div>
             </div>
+
+            <CustomCliOptionsSection Options="claudeCustomOptions" States="customOptionStates"
+                                     Prefix="@($"claude{UniqueId}")" OnStateChanged="OnCustomOptionToggled" />
         </div>
     }
     else if (SelectedType == TerminalType.GeminiCLI && Configuration.GetValue<bool>("ExternalTools:UseGeminiCli", true))
@@ -217,6 +221,9 @@
                        placeholder="@L["SessionOptions.Gemini.ExtraArgsPlaceholder"]" />
                 <div class="form-text small">@L["SessionOptions.Gemini.PassToCli"]</div>
             </div>
+
+            <CustomCliOptionsSection Options="geminiCustomOptions" States="customOptionStates"
+                                     Prefix="@($"gemini{UniqueId}")" OnStateChanged="OnCustomOptionToggled" />
         </div>
     }
     else if (SelectedType == TerminalType.CodexCLI && Configuration.GetValue<bool>("ExternalTools:UseCodexCli", true))
@@ -370,6 +377,9 @@
                        placeholder="@L["SessionOptions.Codex.ExtraArgsPlaceholder"]" />
                 <div class="form-text small">@L["SessionOptions.Codex.PassToCli"]</div>
             </div>
+
+            <CustomCliOptionsSection Options="codexCustomOptions" States="customOptionStates"
+                                     Prefix="@($"codex{UniqueId}")" OnStateChanged="OnCustomOptionToggled" />
         </div>
     }
     else
@@ -398,6 +408,18 @@
     private List<string> geminiModelList = new();
     private string newGeminiModelName = "";
 
+    // ユーザー定義カスタムオプション (AppSettings.CliOptions から読み込む)
+    private List<UserCliOption> claudeCustomOptions = new();
+    private List<UserCliOption> geminiCustomOptions = new();
+    private List<UserCliOption> codexCustomOptions = new();
+    // チェック状態は Id 単位で保持 (CLI 切替で消えないようにするため)
+    private Dictionary<string, bool> customOptionStates = new();
+
+    protected override void OnInitialized()
+    {
+        LoadCustomCliOptions();
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
@@ -405,6 +427,60 @@
             await LoadGeminiModelsAsync();
             StateHasChanged();
         }
+    }
+
+    /// <summary>
+    /// 設定変更後にダイアログを開き直したケースを拾うため、外部から再読込できるよう公開している。
+    /// </summary>
+    public void ReloadCustomCliOptions()
+    {
+        LoadCustomCliOptions();
+        StateHasChanged();
+    }
+
+    private void LoadCustomCliOptions()
+    {
+        try
+        {
+            var settings = AppSettingsService.GetSettings();
+            var cli = settings.CliOptions ?? new CustomCliOptionsSettings();
+            claudeCustomOptions = new List<UserCliOption>(cli.ClaudeCode);
+            geminiCustomOptions = new List<UserCliOption>(cli.GeminiCLI);
+            codexCustomOptions = new List<UserCliOption>(cli.CodexCLI);
+
+            // 既存 state はそのまま、新規エントリは DefaultEnabled で初期化
+            foreach (var opt in claudeCustomOptions.Concat(geminiCustomOptions).Concat(codexCustomOptions))
+            {
+                if (!customOptionStates.ContainsKey(opt.Id))
+                {
+                    customOptionStates[opt.Id] = opt.DefaultEnabled;
+                }
+            }
+        }
+        catch
+        {
+            // 設定読み込みに失敗しても起動を阻害しない (カスタムオプションなし扱い)
+        }
+    }
+
+    private void OnCustomOptionToggled((string Id, bool Enabled) change)
+    {
+        customOptionStates[change.Id] = change.Enabled;
+    }
+
+    private List<UserCliOption> GetActiveCustomOptions()
+    {
+        var list = SelectedType switch
+        {
+            TerminalType.ClaudeCode => claudeCustomOptions,
+            TerminalType.GeminiCLI => geminiCustomOptions,
+            TerminalType.CodexCLI => codexCustomOptions,
+            _ => new List<UserCliOption>()
+        };
+        return list
+            .Where(o => customOptionStates.GetValueOrDefault(o.Id, o.DefaultEnabled)
+                        && !string.IsNullOrWhiteSpace(o.Arguments))
+            .ToList();
     }
 
     private async Task LoadGeminiModelsAsync()
@@ -595,6 +671,14 @@
                     options["extra-args"] = CodexOptions.ExtraArgs.Trim();
                 }
                 break;
+        }
+
+        // ON にされたカスタムオプションを空白連結して "custom-args" に束ねる。
+        // TerminalConstants.Build*Args が末尾に追記する。
+        var activeCustom = GetActiveCustomOptions();
+        if (activeCustom.Count > 0)
+        {
+            options["custom-args"] = string.Join(" ", activeCustom.Select(o => o.Arguments.Trim()));
         }
 
         return options;

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -74,6 +74,13 @@
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
+                            <button class="nav-link @(activeTab == "cliOptions" ? "active" : "")"
+                                    type="button"
+                                    @onclick="@(() => activeTab = "cliOptions")">
+                                <i class="bi bi-sliders me-1"></i>@L["Settings.Tab.CliOptions"]
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
                             <button class="nav-link @(activeTab == "remoteLaunch" ? "active" : "")"
                                     type="button"
                                     @onclick="@(() => activeTab = "remoteLaunch")">
@@ -643,6 +650,67 @@
                                 }
                             </div>
                         }
+                        else if (activeTab == "cliOptions")
+                        {
+                            <div class="tab-pane fade show active">
+                                <small class="text-muted d-block mb-3">
+                                    @L["Settings.CliOptions.Help"]
+                                </small>
+
+                                @foreach (var cli in CliOptionTypes)
+                                {
+                                    var type = cli;
+                                    var displayName = type switch
+                                    {
+                                        TerminalType.ClaudeCode => "Claude Code",
+                                        TerminalType.GeminiCLI => "Gemini CLI",
+                                        TerminalType.CodexCLI => "Codex CLI",
+                                        _ => type.ToString()
+                                    };
+                                    var list = editingCliOptions.GetValueOrDefault(type, new List<UserCliOption>());
+
+                                    <div class="mb-4">
+                                        <label class="form-label fw-bold">@displayName</label>
+
+                                        @if (list.Any())
+                                        {
+                                            <ul class="list-group list-group-sm mb-2">
+                                                @for (var i = 0; i < list.Count; i++)
+                                                {
+                                                    var idx = i;
+                                                    var opt = list[i];
+                                                    <li class="list-group-item py-1 px-2">
+                                                        <div class="d-flex align-items-center gap-2">
+                                                            <input type="text" class="form-control form-control-sm"
+                                                                   style="max-width: 160px;"
+                                                                   placeholder="@L["Settings.CliOptions.LabelPlaceholder"]"
+                                                                   @bind="opt.Label" />
+                                                            <input type="text" class="form-control form-control-sm flex-grow-1"
+                                                                   placeholder="@L["Settings.CliOptions.ArgsPlaceholder"]"
+                                                                   @bind="opt.Arguments" />
+                                                            <div class="form-check form-switch m-0" title="@L["Settings.CliOptions.DefaultEnabled.Title"]">
+                                                                <input class="form-check-input" type="checkbox"
+                                                                       @bind="opt.DefaultEnabled" />
+                                                            </div>
+                                                            <button class="btn btn-outline-danger btn-sm border-0" type="button"
+                                                                    @onclick="() => RemoveCliOption(type, idx)"
+                                                                    style="font-size: 0.7rem;">
+                                                                <i class="bi bi-x-lg"></i>
+                                                            </button>
+                                                        </div>
+                                                    </li>
+                                                }
+                                            </ul>
+                                        }
+
+                                        <button class="btn btn-outline-primary btn-sm" type="button"
+                                                @onclick="() => AddCliOption(type)">
+                                            <i class="bi bi-plus-lg me-1"></i>@L["Settings.CliOptions.Add"]
+                                        </button>
+                                    </div>
+                                }
+                            </div>
+                        }
                         else if (activeTab == "remoteLaunch")
                         {
                             <div class="tab-pane fade show active">
@@ -1048,6 +1116,14 @@
     private Dictionary<string, string> newCommandTexts = new();
     private Dictionary<string, CustomCommandType> newCommandTypes = new();
     private Dictionary<string, string> newCommandKeyNames = new();
+
+    // カスタムオプション (CLI 別)
+    private static readonly TerminalType[] CliOptionTypes = new[]
+    {
+        TerminalType.ClaudeCode, TerminalType.GeminiCLI, TerminalType.CodexCLI
+    };
+    private Dictionary<TerminalType, List<UserCliOption>> editingCliOptions = new();
+
     private string activeTab = "general";
 
     // 現在の UI culture (dropdown の選択値)。CultureInfo の two-letter name をそのまま使う (ja / en)。
@@ -1248,6 +1324,15 @@
                 if (!newCommandKeyNames.ContainsKey(type))
                     newCommandKeyNames[type] = KeySequencePresets.DefaultKey;
             }
+
+            // カスタムCLIオプション (CLI 別、編集中はリストを clone してから扱う)
+            var cliOptions = settings.CliOptions ?? new CustomCliOptionsSettings();
+            editingCliOptions = new Dictionary<TerminalType, List<UserCliOption>>
+            {
+                [TerminalType.ClaudeCode] = cliOptions.ClaudeCode.Select(CloneCliOption).ToList(),
+                [TerminalType.GeminiCLI] = cliOptions.GeminiCLI.Select(CloneCliOption).ToList(),
+                [TerminalType.CodexCLI] = cliOptions.CodexCLI.Select(CloneCliOption).ToList(),
+            };
 
             // リモート起動設定
             remoteLaunchEnabled = settings.RemoteLaunch.Enabled;
@@ -1460,6 +1545,19 @@
                     CommandsByTerminalType = editingCommands
                         .ToDictionary(kv => kv.Key, kv => new List<CustomCommand>(kv.Value))
                 },
+                CliOptions = new CustomCliOptionsSettings
+                {
+                    // 空の Arguments は永続化しない (ノイズになるため)
+                    ClaudeCode = editingCliOptions.GetValueOrDefault(TerminalType.ClaudeCode, new())
+                        .Where(o => !string.IsNullOrWhiteSpace(o.Arguments))
+                        .Select(CloneCliOption).ToList(),
+                    GeminiCLI = editingCliOptions.GetValueOrDefault(TerminalType.GeminiCLI, new())
+                        .Where(o => !string.IsNullOrWhiteSpace(o.Arguments))
+                        .Select(CloneCliOption).ToList(),
+                    CodexCLI = editingCliOptions.GetValueOrDefault(TerminalType.CodexCLI, new())
+                        .Where(o => !string.IsNullOrWhiteSpace(o.Arguments))
+                        .Select(CloneCliOption).ToList(),
+                },
                 RemoteLaunch = new RemoteLaunchSettings
                 {
                     Enabled = remoteLaunchEnabled,
@@ -1556,6 +1654,31 @@
     private void RemoveFavoriteFolder(string folder)
     {
         favoriteFolders.Remove(folder);
+    }
+
+    private static UserCliOption CloneCliOption(UserCliOption src) => new()
+    {
+        Id = src.Id,
+        Label = src.Label,
+        Arguments = src.Arguments,
+        DefaultEnabled = src.DefaultEnabled
+    };
+
+    private void AddCliOption(TerminalType terminalType)
+    {
+        if (!editingCliOptions.ContainsKey(terminalType))
+        {
+            editingCliOptions[terminalType] = new List<UserCliOption>();
+        }
+        editingCliOptions[terminalType].Add(new UserCliOption());
+    }
+
+    private void RemoveCliOption(TerminalType terminalType, int index)
+    {
+        if (editingCliOptions.TryGetValue(terminalType, out var list) && index >= 0 && index < list.Count)
+        {
+            list.RemoveAt(index);
+        }
     }
 
     private void AddCommand(string terminalType)

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -102,6 +102,8 @@ namespace TerminalHub.Constants
                 args.Add(extraArgs.Trim());
             }
 
+            AppendCustomArgs(args, options);
+
             return string.Join(" ", args);
         }
 
@@ -133,6 +135,8 @@ namespace TerminalHub.Constants
             {
                 args.Add(extraArgs);
             }
+
+            AppendCustomArgs(args, options);
 
             return string.Join(" ", args);
         }
@@ -224,7 +228,19 @@ namespace TerminalHub.Constants
                 args.Add(extraArgs.Trim());
             }
 
+            AppendCustomArgs(args, options);
+
             return string.Join(" ", args);
+        }
+
+        // ユーザー定義カスタムオプションで ON にされた行を、まとめて末尾に追記する。
+        // SessionOptionsSelector が options["custom-args"] にスペース連結済みの文字列を入れる。
+        private static void AppendCustomArgs(List<string> args, Dictionary<string, string> options)
+        {
+            if (options.TryGetValue("custom-args", out var custom) && !string.IsNullOrWhiteSpace(custom))
+            {
+                args.Add(custom.Trim());
+            }
         }
     }
 }

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -14,6 +14,7 @@ public class AppSettings
     public GeneralSettings General { get; set; } = new();
     public GeminiSettings Gemini { get; set; } = new();
     public CustomCommandSettings Commands { get; set; } = new();
+    public CustomCliOptionsSettings CliOptions { get; set; } = new();
     public RemoteLaunchSettings RemoteLaunch { get; set; } = new();
 }
 
@@ -124,6 +125,40 @@ public class CustomCommand
     public CustomCommandType Type { get; set; } = CustomCommandType.Text;
     /// <summary>KeySequence 時に参照するプリセットキー名（KeySequencePresets.All のキー）</summary>
     public string? KeyName { get; set; }
+}
+
+/// <summary>
+/// CLI ごとに保存しておくユーザー定義カスタムオプションのコンテナ。
+/// 起動時にチェックボックスで ON/OFF できる「お気に入りのコマンドラインオプション」を CLI 別に保持する。
+/// </summary>
+public class CustomCliOptionsSettings
+{
+    public List<UserCliOption> ClaudeCode { get; set; } = new();
+    public List<UserCliOption> GeminiCLI { get; set; } = new();
+    public List<UserCliOption> CodexCLI { get; set; } = new();
+
+    public List<UserCliOption> ForType(TerminalType type) => type switch
+    {
+        TerminalType.ClaudeCode => ClaudeCode,
+        TerminalType.GeminiCLI => GeminiCLI,
+        TerminalType.CodexCLI => CodexCLI,
+        _ => new List<UserCliOption>()
+    };
+}
+
+/// <summary>
+/// ユーザーが定義した一行ぶんのコマンドラインオプション。
+/// Arguments はそのまま起動コマンドラインの末尾に連結されるので、複数フラグを 1 行にまとめても良い。
+/// </summary>
+public class UserCliOption
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    /// <summary>UI に表示する短いラベル (空文字も許容、その場合は Arguments 自体を表示)</summary>
+    public string Label { get; set; } = "";
+    /// <summary>実引数文字列 (例: "--model gpt-5", "-c sandbox.foo=true")</summary>
+    public string Arguments { get; set; } = "";
+    /// <summary>新規セッション作成ダイアログを開いた時に初期 ON にするか</summary>
+    public bool DefaultEnabled { get; set; } = false;
 }
 
 /// <summary>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -74,6 +74,7 @@
   <data name="Settings.Tab.Sessions" xml:space="preserve"><value>Sessions</value></data>
   <data name="Settings.Tab.ExportImport" xml:space="preserve"><value>Export / Import</value></data>
   <data name="Settings.Tab.Commands" xml:space="preserve"><value>Commands</value></data>
+  <data name="Settings.Tab.CliOptions" xml:space="preserve"><value>Custom Options</value></data>
   <data name="Settings.Tab.RemoteLaunch" xml:space="preserve"><value>Remote Launch</value></data>
   <data name="Settings.Tab.Special" xml:space="preserve"><value>Special</value></data>
   <data name="Settings.Tab.DevDiagnose" xml:space="preserve"><value>Diagnostics</value></data>
@@ -171,6 +172,13 @@
   <data name="Settings.Commands.TitlePlaceholder" xml:space="preserve"><value>Title (optional)</value></data>
   <data name="Settings.Commands.CommandPlaceholder" xml:space="preserve"><value>Command (e.g., /plan)</value></data>
   <data name="Settings.Commands.DragToReorder" xml:space="preserve"><value>Drag to reorder</value></data>
+
+  <!-- Settings: Custom CLI Options Tab -->
+  <data name="Settings.CliOptions.Help" xml:space="preserve"><value>Register frequently used command-line options per CLI. Toggle them on or off via checkboxes when creating a new session. Options with the switch turned on are pre-checked by default.</value></data>
+  <data name="Settings.CliOptions.Add" xml:space="preserve"><value>Add</value></data>
+  <data name="Settings.CliOptions.LabelPlaceholder" xml:space="preserve"><value>Label (optional)</value></data>
+  <data name="Settings.CliOptions.ArgsPlaceholder" xml:space="preserve"><value>e.g. --model gpt-5</value></data>
+  <data name="Settings.CliOptions.DefaultEnabled.Title" xml:space="preserve"><value>On by default</value></data>
 
   <!-- Settings: Remote Launch Tab -->
   <data name="Settings.RemoteLaunch.Help" xml:space="preserve"><value>Start Claude Code sessions from your phone when you're away from your PC. Use the URL below on your mobile device.</value></data>
@@ -295,6 +303,7 @@
   <data name="SessionOptions.TerminalType.Label" xml:space="preserve"><value>Terminal type</value></data>
   <data name="SessionOptions.TerminalType.Terminal" xml:space="preserve"><value>Terminal</value></data>
   <data name="SessionOptions.ExtraArgs.Label" xml:space="preserve"><value>Additional arguments</value></data>
+  <data name="SessionOptions.CustomOptions.Label" xml:space="preserve"><value>Custom options</value></data>
 
   <!-- SessionOptionsSelector: Terminal (default startup command) -->
   <data name="SessionOptions.Terminal.StartupCommand.Label" xml:space="preserve"><value>Startup command (optional)</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -174,7 +174,7 @@
   <data name="Settings.Commands.DragToReorder" xml:space="preserve"><value>Drag to reorder</value></data>
 
   <!-- Settings: Custom CLI Options Tab -->
-  <data name="Settings.CliOptions.Help" xml:space="preserve"><value>Register frequently used command-line options per CLI. Toggle them on or off via checkboxes when creating a new session. Options with the switch turned on are pre-checked by default.</value></data>
+  <data name="Settings.CliOptions.Help" xml:space="preserve"><value>Register frequently used command-line options per CLI. Toggle them on or off via checkboxes when creating a new session. Options with the switch turned on are pre-checked by default. Wrap values containing spaces in double quotes (e.g. --add-dir "C:\path with space").</value></data>
   <data name="Settings.CliOptions.Add" xml:space="preserve"><value>Add</value></data>
   <data name="Settings.CliOptions.LabelPlaceholder" xml:space="preserve"><value>Label (optional)</value></data>
   <data name="Settings.CliOptions.ArgsPlaceholder" xml:space="preserve"><value>e.g. --model gpt-5</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -174,7 +174,7 @@
   <data name="Settings.Commands.DragToReorder" xml:space="preserve"><value>ドラッグで並び替え</value></data>
 
   <!-- Settings: Custom CLI Options Tab -->
-  <data name="Settings.CliOptions.Help" xml:space="preserve"><value>各 CLI ごとに、よく使うコマンドラインオプションを登録できます。新規セッション作成時のチェックボックスで ON/OFF できます。スイッチをオンにしたものは、デフォルトでチェックされた状態で表示されます。</value></data>
+  <data name="Settings.CliOptions.Help" xml:space="preserve"><value>各 CLI ごとに、よく使うコマンドラインオプションを登録できます。新規セッション作成時のチェックボックスで ON/OFF できます。スイッチをオンにしたものは、デフォルトでチェックされた状態で表示されます。値にスペースを含む場合はダブルクォートで囲んでください（例: --add-dir "C:\path with space"）。</value></data>
   <data name="Settings.CliOptions.Add" xml:space="preserve"><value>追加</value></data>
   <data name="Settings.CliOptions.LabelPlaceholder" xml:space="preserve"><value>ラベル（省略可）</value></data>
   <data name="Settings.CliOptions.ArgsPlaceholder" xml:space="preserve"><value>例: --model gpt-5</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -74,6 +74,7 @@
   <data name="Settings.Tab.Sessions" xml:space="preserve"><value>セッション</value></data>
   <data name="Settings.Tab.ExportImport" xml:space="preserve"><value>エクスポート/インポート</value></data>
   <data name="Settings.Tab.Commands" xml:space="preserve"><value>コマンド</value></data>
+  <data name="Settings.Tab.CliOptions" xml:space="preserve"><value>カスタムオプション</value></data>
   <data name="Settings.Tab.RemoteLaunch" xml:space="preserve"><value>リモート起動</value></data>
   <data name="Settings.Tab.Special" xml:space="preserve"><value>特殊</value></data>
   <data name="Settings.Tab.DevDiagnose" xml:space="preserve"><value>診断</value></data>
@@ -171,6 +172,13 @@
   <data name="Settings.Commands.TitlePlaceholder" xml:space="preserve"><value>タイトル（省略可）</value></data>
   <data name="Settings.Commands.CommandPlaceholder" xml:space="preserve"><value>コマンド（例: /plan）</value></data>
   <data name="Settings.Commands.DragToReorder" xml:space="preserve"><value>ドラッグで並び替え</value></data>
+
+  <!-- Settings: Custom CLI Options Tab -->
+  <data name="Settings.CliOptions.Help" xml:space="preserve"><value>各 CLI ごとに、よく使うコマンドラインオプションを登録できます。新規セッション作成時のチェックボックスで ON/OFF できます。スイッチをオンにしたものは、デフォルトでチェックされた状態で表示されます。</value></data>
+  <data name="Settings.CliOptions.Add" xml:space="preserve"><value>追加</value></data>
+  <data name="Settings.CliOptions.LabelPlaceholder" xml:space="preserve"><value>ラベル（省略可）</value></data>
+  <data name="Settings.CliOptions.ArgsPlaceholder" xml:space="preserve"><value>例: --model gpt-5</value></data>
+  <data name="Settings.CliOptions.DefaultEnabled.Title" xml:space="preserve"><value>デフォルトでオン</value></data>
 
   <!-- Settings: Remote Launch Tab -->
   <data name="Settings.RemoteLaunch.Help" xml:space="preserve"><value>スマートフォンから Claude Code セッションを起動できます。下のアクセスURLを端末で開いて使用します。</value></data>
@@ -295,6 +303,7 @@
   <data name="SessionOptions.TerminalType.Label" xml:space="preserve"><value>ターミナルタイプ</value></data>
   <data name="SessionOptions.TerminalType.Terminal" xml:space="preserve"><value>ターミナル</value></data>
   <data name="SessionOptions.ExtraArgs.Label" xml:space="preserve"><value>追加引数</value></data>
+  <data name="SessionOptions.CustomOptions.Label" xml:space="preserve"><value>カスタムオプション</value></data>
 
   <!-- SessionOptionsSelector: Terminal (default startup command) -->
   <data name="SessionOptions.Terminal.StartupCommand.Label" xml:space="preserve"><value>起動コマンド（任意）</value></data>


### PR DESCRIPTION
## 背景

現在、Claude Code / Gemini CLI / Codex CLI 起動時のコマンドラインオプションは、ビルトインのもの (権限モード, --continue 等) に加えて「追加引数」フィールドに毎回手入力する必要があった。各自でよく使うオプションがある場合 (例: `--model gpt-5`、特定の `-c` フラグ) 毎回タイピングするのは非効率。

## 追加した機能

各 CLI ごとに「お気に入りのコマンドラインオプション」を事前登録 → 新規セッション作成ダイアログのチェックボックスで ON/OFF できる仕組みを追加。

### 設定ダイアログ「カスタムオプション」タブ
- CLI 別 (Claude Code / Gemini CLI / Codex CLI) のリスト編集
- 各エントリ: ラベル (任意) + 引数文字列 + デフォルトON/OFFスイッチ + 削除
- 「+ 追加」で新規行
- (Terminal は CLI ではないため対象外)

### セッション作成ダイアログ
- 各 CLI 区画末尾に「カスタムオプション」セクションが自動表示
- 登録した行がチェックボックスとして並ぶ
- スイッチ ON のものは初期 checked
- ON にしたものの Arguments を空白連結して起動コマンドラインに付与

## 設計判断

### 永続化先: app-settings.json (DB ではない)
カスタムコマンド (`AppSettings.Commands`) と完全に対称な性質 (CLI 別のユーザー嗜好、件数小、検索性不要) なので AppSettings に同居させるのが一貫性高い。DB スキーマは変更なし。新規プロパティ追加なので既存 JSON は壊れない。

### コマンドライン組み立て
`SessionInfo.Options` に `"custom-args"` キー (空白連結済み文字列) を 1 個追加し、`TerminalConstants.AppendCustomArgs` が `BuildClaudeCodeArgs` / `BuildGeminiArgs` / `BuildCodexArgs` の末尾で追記。既存ビルトインオプションのロジックには触らない。

### 引数のフォーマット
1 行 = 1 オプション (複数フラグを 1 行にまとめても OK)。クォートを跨ぐ複雑なケースは想定外 (現実の CLI オプションはほぼ単純)。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `Models/AppSettings.cs` | `CustomCliOptionsSettings` / `UserCliOption` 追加、`AppSettings.CliOptions` プロパティ |
| `Constants/TerminalConstants.cs` | 各 Build メソッド末尾に `AppendCustomArgs` を追加 |
| `Components/Shared/Dialogs/SessionOptionsSelector.razor` | カスタムオプション読み込み・state 管理・GetOptions に `custom-args` |
| `Components/Shared/Dialogs/CustomCliOptionsSection.razor` | **新規** (再利用 UI) |
| `Components/Shared/Dialogs/SessionCreateDialog.razor` | ダイアログ表示時に `ReloadCustomCliOptions` 呼出し |
| `Components/Shared/Dialogs/SettingsDialog.razor` | 新タブ「カスタムオプション」追加、ロード/セーブ/Add/Remove |
| `Resources/SharedResource.{ja,en}.resx` | 7 キー追加 (タブ名、ヘルプ、ボタン、プレースホルダ、見出し) |

## i18n パリティ
ja: 427 キー / en: 427 キー (完全一致)

## 動作確認
- ビルド成功 (0 警告 0 エラー)
- 想定挙動:
  1. 設定で `--model gpt-5` を Codex に登録 (DefaultEnabled OFF) → 新規セッション作成時に未チェックで表示
  2. DefaultEnabled ON で登録 → 新規セッション作成時に既にチェック済み
  3. ON のまま起動 → コマンドラインに `--model gpt-5` が付加される
  4. 空 Arguments の行は保存時に除外
  5. 既存 app-settings.json (`CliOptions` キー無し) を読み込み → 空のリストとして起動 OK