### PR TITLE
refactor: ビルトイン CLI オプションの精査・簡素化

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -2,9 +2,7 @@
 @using TerminalHub.Services
 @using Microsoft.Extensions.Configuration
 @using Microsoft.Extensions.Localization
-@using Microsoft.JSInterop
 @inject IConfiguration Configuration
-@inject ILocalStorageService LocalStorage
 @inject IAppSettingsService AppSettingsService
 @inject IStringLocalizer<SharedResource> L
 
@@ -172,49 +170,6 @@
                 }
             </div>
 
-            <!-- Custom Model -->
-            <div class="mt-3">
-                <div class="form-check">
-                    <input class="form-check-input" type="checkbox" @bind="GeminiOptions.UseCustomModel" id="@($"geminiUseCustomModel{UniqueId}")">
-                    <label class="form-check-label" for="@($"geminiUseCustomModel{UniqueId}")">
-                        @L["SessionOptions.Gemini.UseCustomModel"]
-                    </label>
-                </div>
-
-                @if (GeminiOptions.UseCustomModel)
-                {
-                    <div class="mt-2 ps-4">
-                        <div class="mb-2">
-                            <label for="@($"geminiModelSelect{UniqueId}")" class="form-label small text-muted mb-1">@L["SessionOptions.Gemini.ModelSelectLabel"]</label>
-                            <select class="form-select form-select-sm" id="@($"geminiModelSelect{UniqueId}")" @bind="GeminiOptions.Model">
-                                @foreach (var model in geminiModelList)
-                                {
-                                    <option value="@model">@model</option>
-                                }
-                            </select>
-                        </div>
-                        <div>
-                            <label class="form-label small text-muted mb-1">@L["SessionOptions.Gemini.ModelManagementLabel"]</label>
-                            <div class="input-group input-group-sm">
-                                <input type="text" class="form-control" @bind="newGeminiModelName" placeholder="@L["SessionOptions.Gemini.ModelAddPlaceholder"]" @onkeydown="OnModelInputKeyDown" />
-                                <button class="btn btn-outline-secondary" type="button" @onclick="AddGeminiModel">@L["Common.Add"]</button>
-                            </div>
-                            <ul class="list-group mt-2" style="max-height: 150px; overflow-y: auto;">
-                                @foreach (var model in geminiModelList.OrderBy(m => m))
-                                {
-                                    <li class="list-group-item list-group-item-sm d-flex justify-content-between align-items-center py-1">
-                                        <span class="text-truncate" title="@model">@model</span>
-                                        <button class="btn btn-sm btn-outline-danger p-0" style="width: 1.5rem; height: 1.5rem;" @onclick="() => RemoveGeminiModel(model)">
-                                            <i class="bi bi-trash"></i>
-                                        </button>
-                                    </li>
-                                }
-                            </ul>
-                        </div>
-                    </div>
-                }
-            </div>
-            
             <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="GeminiOptions.ExtraArgs"
@@ -329,34 +284,6 @@
                 }
             </div>
 
-            <div class="mt-3">
-                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.NetworkAccess.Label"]</label>
-                <select class="form-select form-select-sm" @bind="CodexOptions.NetworkAccess">
-                    <option value="">@L["Common.Unspecified"]</option>
-                    <option value="restricted">restricted</option>
-                    <option value="enabled">enabled</option>
-                </select>
-                <div class="form-text small">@L["SessionOptions.Codex.NetworkAccess.Help"]</div>
-                @if (!string.IsNullOrWhiteSpace(GetNetworkAccessHelp()))
-                {
-                    <div class="form-text small">@GetNetworkAccessHelp()</div>
-                }
-            </div>
-
-            <div class="mt-3">
-                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Profile.Label"]</label>
-                <input type="text" class="form-control form-control-sm" @bind="CodexOptions.Profile"
-                       placeholder="@L["SessionOptions.Codex.Profile.Placeholder"]" />
-                <div class="form-text small">@L["SessionOptions.Codex.Profile.Help"]</div>
-            </div>
-
-            <div class="mt-3">
-                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Model.Label"]</label>
-                <input type="text" class="form-control form-control-sm" @bind="CodexOptions.Model"
-                       placeholder="@L["SessionOptions.Codex.Model.Placeholder"]" />
-                <div class="form-text small">@L["SessionOptions.Codex.Model.Help"]</div>
-            </div>
-
             <div class="form-check mt-3">
                 <input class="form-check-input" type="checkbox" @bind="CodexOptions.SearchEnabled" id="@($"codexSearch{UniqueId}")">
                 <label class="form-check-label" for="@($"codexSearch{UniqueId}")">
@@ -402,11 +329,6 @@
     [Parameter] public bool DisableContinueOption { get; set; } = false;
 
     private string UniqueId = Guid.NewGuid().ToString("N");
-    private const string GEMINI_MODELS_KEY = "gemini_models";
-
-    // Geminiモデル管理用
-    private List<string> geminiModelList = new();
-    private string newGeminiModelName = "";
 
     // ユーザー定義カスタムオプション (AppSettings.CliOptions から読み込む)
     private List<UserCliOption> claudeCustomOptions = new();
@@ -418,15 +340,6 @@
     protected override void OnInitialized()
     {
         LoadCustomCliOptions();
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            await LoadGeminiModelsAsync();
-            StateHasChanged();
-        }
     }
 
     /// <summary>
@@ -491,71 +404,9 @@
             .ToList();
     }
 
-    private async Task LoadGeminiModelsAsync()
-    {
-        try
-        {
-            var models = await LocalStorage.GetAsync<List<string>>(GEMINI_MODELS_KEY);
-            if (models == null || !models.Any())
-            {
-                // LocalStorageにない場合はappsettings.jsonから読み込む
-                models = Configuration.GetSection("ExternalTools:GeminiModels").Get<List<string>>() ?? new List<string>();
-                await LocalStorage.SetAsync(GEMINI_MODELS_KEY, models);
-            }
-            geminiModelList = models;
-
-            // 選択中のモデルがリストにない場合は、リストの先頭を選択する
-            if (!string.IsNullOrEmpty(GeminiOptions.Model) && !geminiModelList.Contains(GeminiOptions.Model))
-            {
-                GeminiOptions.Model = geminiModelList.FirstOrDefault();
-            }
-            else if (string.IsNullOrEmpty(GeminiOptions.Model))
-            {
-                GeminiOptions.Model = geminiModelList.FirstOrDefault();
-            }
-        }
-        catch
-        {
-            geminiModelList = new List<string> { "gemini-1.5-pro-latest" };
-        }
-    }
-
-    private async Task AddGeminiModel()
-    {
-        if (!string.IsNullOrWhiteSpace(newGeminiModelName) && !geminiModelList.Contains(newGeminiModelName.Trim()))
-        {
-            geminiModelList.Add(newGeminiModelName.Trim());
-            newGeminiModelName = "";
-            await LocalStorage.SetAsync(GEMINI_MODELS_KEY, geminiModelList);
-        }
-    }
-
-    private async Task RemoveGeminiModel(string modelToRemove)
-    {
-        geminiModelList.Remove(modelToRemove);
-        if (GeminiOptions.Model == modelToRemove)
-        {
-            GeminiOptions.Model = geminiModelList.FirstOrDefault();
-        }
-        await LocalStorage.SetAsync(GEMINI_MODELS_KEY, geminiModelList);
-    }
-
-    private async Task OnModelInputKeyDown(KeyboardEventArgs e)
-    {
-        if (e.Key == "Enter")
-        {
-            await AddGeminiModel();
-        }
-    }
-
     private async Task OnTerminalTypeChanged(TerminalType newType)
     {
         SelectedType = newType;
-        if (newType == TerminalType.GeminiCLI)
-        {
-            // Geminiが選択されたときにモデルリストを再読み込み
-            await LoadGeminiModelsAsync();
-        }
         await SelectedTypeChanged.InvokeAsync(newType);
     }
 
@@ -630,10 +481,6 @@
                 {
                     options["approval-mode"] = GeminiOptions.ApprovalMode;
                 }
-                if (GeminiOptions.UseCustomModel && !string.IsNullOrWhiteSpace(GeminiOptions.Model))
-                {
-                    options["model"] = GeminiOptions.Model;
-                }
                 if (!string.IsNullOrWhiteSpace(GeminiOptions.ExtraArgs))
                 {
                     options["extra-args"] = GeminiOptions.ExtraArgs.Trim();
@@ -653,18 +500,6 @@
                 if (!string.IsNullOrWhiteSpace(CodexOptions.ApprovalPolicy))
                 {
                     options["ask-for-approval"] = CodexOptions.ApprovalPolicy;
-                }
-                if (!string.IsNullOrWhiteSpace(CodexOptions.NetworkAccess))
-                {
-                    options["network-access"] = CodexOptions.NetworkAccess;
-                }
-                if (!string.IsNullOrWhiteSpace(CodexOptions.Profile))
-                {
-                    options["profile"] = CodexOptions.Profile.Trim();
-                }
-                if (!string.IsNullOrWhiteSpace(CodexOptions.Model))
-                {
-                    options["model"] = CodexOptions.Model.Trim();
                 }
                 if (CodexOptions.SearchEnabled)
                 {
@@ -705,8 +540,6 @@
         public bool Continue { get; set; } = true;
         public bool SandboxMode { get; set; }
         public string ApprovalMode { get; set; } = "default"; // default, auto_edit, yolo
-        public bool UseCustomModel { get; set; }
-        public string? Model { get; set; }
         public string ExtraArgs { get; set; } = "";
     }
 
@@ -716,9 +549,6 @@
         public bool ResumeLast { get; set; } = false;
         public string SandboxMode { get; set; } = ""; // "", read-only, workspace-write, danger-full-access
         public string ApprovalPolicy { get; set; } = "";
-        public string NetworkAccess { get; set; } = "";
-        public string Profile { get; set; } = "";
-        public string Model { get; set; } = "";
         public bool SearchEnabled { get; set; }
         public string AdditionalDirectories { get; set; } = "";
         public string ExtraArgs { get; set; } = "";
@@ -780,13 +610,4 @@
         };
     }
 
-    private string GetNetworkAccessHelp()
-    {
-        return CodexOptions.NetworkAccess switch
-        {
-            "enabled" => L["SessionOptions.Codex.NetworkAccess.HelpEnabled"],
-            "restricted" => L["SessionOptions.Codex.NetworkAccess.HelpRestricted"],
-            _ => ""
-        };
-    }
 }

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -277,9 +277,7 @@
                     SandboxMode = options.ContainsKey("sandbox") && options["sandbox"] == "true",
                     Continue = options.ContainsKey("continue") && options["continue"] == "true",
                     ExtraArgs = options.ContainsKey("extra-args") ? options["extra-args"] : "",
-                    ApprovalMode = options.ContainsKey("approval-mode") ? options["approval-mode"] : "default",
-                    Model = options.ContainsKey("model") ? options["model"] : null,
-                    UseCustomModel = options.ContainsKey("model")
+                    ApprovalMode = options.ContainsKey("approval-mode") ? options["approval-mode"] : "default"
                 };
             }
             else if (selectedType == TerminalType.CodexCLI)
@@ -291,9 +289,6 @@
                         || (options.ContainsKey("resume-picker") && options["resume-picker"] == "true"),
                     SandboxMode = options.ContainsKey("sandbox-mode") ? options["sandbox-mode"] : "",
                     ApprovalPolicy = options.ContainsKey("ask-for-approval") ? options["ask-for-approval"] : "",
-                    NetworkAccess = options.ContainsKey("network-access") ? options["network-access"] : "",
-                    Profile = options.ContainsKey("profile") ? options["profile"] : "",
-                    Model = options.ContainsKey("model") ? options["model"] : "",
                     SearchEnabled = options.ContainsKey("search") && options["search"] == "true",
                     AdditionalDirectories = options.ContainsKey("add-dir") ? options["add-dir"] : "",
                     ExtraArgs = options.ContainsKey("extra-args") ? options["extra-args"] : ""

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -116,11 +116,6 @@ namespace TerminalHub.Constants
                 args.Add($"--approval-mode {mode}");
             }
 
-            if (options.TryGetValue("model", out var model) && !string.IsNullOrWhiteSpace(model))
-            {
-                args.Add($"-m {model}");
-            }
-
             if (options.ContainsKey("sandbox") && options["sandbox"] == "true")
             {
                 args.Add("-s");
@@ -145,16 +140,6 @@ namespace TerminalHub.Constants
         {
             var args = new List<string>();
 
-            if (options.TryGetValue("profile", out var profile) && !string.IsNullOrWhiteSpace(profile))
-            {
-                args.Add($"--profile {profile.Trim()}");
-            }
-
-            if (options.TryGetValue("model", out var model) && !string.IsNullOrWhiteSpace(model))
-            {
-                args.Add($"--model {model.Trim()}");
-            }
-
             if (options.ContainsKey("resume-last") && options["resume-last"] == "true")
             {
                 args.Add("resume --last");
@@ -177,14 +162,14 @@ namespace TerminalHub.Constants
             }
 
             // 実行モード: auto, standard, yolo
-            var applyDefaultAutoPolicy = false;
+            // --full-auto は内部的に workspace-write サンドボックス + on-request approval をデフォルト適用するため、
+            // sandbox-mode / ask-for-approval を UI で指定していない限りアプリ側で仮設定はしない。
             if (options.TryGetValue("mode", out var mode))
             {
                 switch (mode)
                 {
                     case "auto":
                         args.Add("--full-auto");
-                        applyDefaultAutoPolicy = true;
                         break;
                     case "yolo":
                         args.Add("--yolo");
@@ -194,33 +179,14 @@ namespace TerminalHub.Constants
             }
 
             // サンドボックスモード: read-only, workspace-write, danger-full-access
-            var hasSandboxMode = options.TryGetValue("sandbox-mode", out var sandboxMode) && !string.IsNullOrEmpty(sandboxMode);
-            if (hasSandboxMode)
+            if (options.TryGetValue("sandbox-mode", out var sandboxMode) && !string.IsNullOrEmpty(sandboxMode))
             {
                 args.Add($"--sandbox {sandboxMode}");
             }
-            else if (applyDefaultAutoPolicy)
-            {
-                sandboxMode = "workspace-write";
-            }
 
-            options.TryGetValue("ask-for-approval", out var approvalPolicy);
-            if (!string.IsNullOrEmpty(approvalPolicy))
+            if (options.TryGetValue("ask-for-approval", out var approvalPolicy) && !string.IsNullOrEmpty(approvalPolicy))
             {
                 args.Add($"--ask-for-approval {approvalPolicy}");
-            }
-            else if (applyDefaultAutoPolicy)
-            {
-                approvalPolicy = "on-request";
-            }
-
-            if (options.TryGetValue("network-access", out var networkAccess) && !string.IsNullOrEmpty(networkAccess))
-            {
-                if (sandboxMode == "workspace-write")
-                {
-                    var networkAccessEnabled = networkAccess == "enabled" ? "true" : "false";
-                    args.Add($"-c sandbox_workspace_write.network_access={networkAccessEnabled}");
-                }
             }
 
             if (options.TryGetValue("extra-args", out var extraArgs) && !string.IsNullOrWhiteSpace(extraArgs))

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -12,7 +12,6 @@ public class AppSettings
     public SessionDisplaySettings Sessions { get; set; } = new();
     public DevToolsSettings DevTools { get; set; } = new();
     public GeneralSettings General { get; set; } = new();
-    public GeminiSettings Gemini { get; set; } = new();
     public CustomCommandSettings Commands { get; set; } = new();
     public CustomCliOptionsSettings CliOptions { get; set; } = new();
     public RemoteLaunchSettings RemoteLaunch { get; set; } = new();
@@ -86,14 +85,6 @@ public class GeneralSettings
     public int TerminalHeightPercent { get; set; } = 70;
     public int SidebarWidthPercent { get; set; } = 25;
     public string Theme { get; set; } = "dark";
-}
-
-/// <summary>
-/// Gemini設定
-/// </summary>
-public class GeminiSettings
-{
-    public List<string> Models { get; set; } = new();
 }
 
 /// <summary>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -338,10 +338,6 @@
   <data name="SessionOptions.Gemini.Sandbox" xml:space="preserve"><value>Sandbox mode (-s)</value></data>
   <data name="SessionOptions.Gemini.SandboxHelp" xml:space="preserve"><value>Docker Desktop must be installed to use this feature.</value></data>
   <data name="SessionOptions.Gemini.Continue" xml:space="preserve"><value>Resume previous session (--resume latest)</value></data>
-  <data name="SessionOptions.Gemini.UseCustomModel" xml:space="preserve"><value>Customize model</value></data>
-  <data name="SessionOptions.Gemini.ModelSelectLabel" xml:space="preserve"><value>Model to use</value></data>
-  <data name="SessionOptions.Gemini.ModelManagementLabel" xml:space="preserve"><value>Model list management</value></data>
-  <data name="SessionOptions.Gemini.ModelAddPlaceholder" xml:space="preserve"><value>Add a model name...</value></data>
   <data name="SessionOptions.Gemini.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --debug --allowed-tools shell,file</value></data>
   <data name="SessionOptions.Gemini.PassToCli" xml:space="preserve"><value>Passed as-is to Gemini CLI</value></data>
 
@@ -376,16 +372,6 @@
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>Treat as untrusted. Prompts for every operation.</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>Prompts only when needed (near-default behavior).</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpNever" xml:space="preserve"><value>Never prompts (dangerous).</value></data>
-  <data name="SessionOptions.Codex.NetworkAccess.Label" xml:space="preserve"><value>Network access</value></data>
-  <data name="SessionOptions.Codex.NetworkAccess.Help" xml:space="preserve"><value>Network permission for workspace-write (-c sandbox_workspace_write.network_access). Default is enabled.</value></data>
-  <data name="SessionOptions.Codex.NetworkAccess.HelpEnabled" xml:space="preserve"><value>Allows network access.</value></data>
-  <data name="SessionOptions.Codex.NetworkAccess.HelpRestricted" xml:space="preserve"><value>Restricts network access.</value></data>
-  <data name="SessionOptions.Codex.Profile.Label" xml:space="preserve"><value>Profile</value></data>
-  <data name="SessionOptions.Codex.Profile.Placeholder" xml:space="preserve"><value>e.g., trusted</value></data>
-  <data name="SessionOptions.Codex.Profile.Help" xml:space="preserve"><value>Passed as --profile to Codex CLI</value></data>
-  <data name="SessionOptions.Codex.Model.Label" xml:space="preserve"><value>Model</value></data>
-  <data name="SessionOptions.Codex.Model.Placeholder" xml:space="preserve"><value>e.g., gpt-5-codex</value></data>
-  <data name="SessionOptions.Codex.Model.Help" xml:space="preserve"><value>Passed as --model to Codex CLI</value></data>
   <data name="SessionOptions.Codex.Search" xml:space="preserve"><value>Enable web search (--search)</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Label" xml:space="preserve"><value>Additional directories</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Placeholder" xml:space="preserve"><value>One directory per line</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -338,10 +338,6 @@
   <data name="SessionOptions.Gemini.Sandbox" xml:space="preserve"><value>サンドボックスモード (-s)</value></data>
   <data name="SessionOptions.Gemini.SandboxHelp" xml:space="preserve"><value>この機能を使用するには、Docker Desktop がインストールされている必要があります。</value></data>
   <data name="SessionOptions.Gemini.Continue" xml:space="preserve"><value>直前のセッションに接続 (--resume latest)</value></data>
-  <data name="SessionOptions.Gemini.UseCustomModel" xml:space="preserve"><value>モデルをカスタマイズ</value></data>
-  <data name="SessionOptions.Gemini.ModelSelectLabel" xml:space="preserve"><value>使用するモデル</value></data>
-  <data name="SessionOptions.Gemini.ModelManagementLabel" xml:space="preserve"><value>モデルリスト管理</value></data>
-  <data name="SessionOptions.Gemini.ModelAddPlaceholder" xml:space="preserve"><value>モデル名を追加...</value></data>
   <data name="SessionOptions.Gemini.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --debug --allowed-tools shell,file</value></data>
   <data name="SessionOptions.Gemini.PassToCli" xml:space="preserve"><value>そのまま Gemini CLI に渡します</value></data>
 
@@ -376,16 +372,6 @@
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>未信頼扱い。すべての操作で承認を求めます。</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>必要なときだけ承認を求めます（デフォルトに近い挙動）。</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpNever" xml:space="preserve"><value>承認を求めません（危険）。</value></data>
-  <data name="SessionOptions.Codex.NetworkAccess.Label" xml:space="preserve"><value>ネットワークアクセス</value></data>
-  <data name="SessionOptions.Codex.NetworkAccess.Help" xml:space="preserve"><value>workspace-write 時の通信許可（-c sandbox_workspace_write.network_access）。デフォルトは enabled。</value></data>
-  <data name="SessionOptions.Codex.NetworkAccess.HelpEnabled" xml:space="preserve"><value>ネットワークアクセスを許可します。</value></data>
-  <data name="SessionOptions.Codex.NetworkAccess.HelpRestricted" xml:space="preserve"><value>ネットワークアクセスを制限します。</value></data>
-  <data name="SessionOptions.Codex.Profile.Label" xml:space="preserve"><value>プロファイル</value></data>
-  <data name="SessionOptions.Codex.Profile.Placeholder" xml:space="preserve"><value>例: trusted</value></data>
-  <data name="SessionOptions.Codex.Profile.Help" xml:space="preserve"><value>Codex CLI の `--profile` を指定します</value></data>
-  <data name="SessionOptions.Codex.Model.Label" xml:space="preserve"><value>モデル</value></data>
-  <data name="SessionOptions.Codex.Model.Placeholder" xml:space="preserve"><value>例: gpt-5-codex</value></data>
-  <data name="SessionOptions.Codex.Model.Help" xml:space="preserve"><value>Codex CLI の `--model` を指定します</value></data>
   <data name="SessionOptions.Codex.Search" xml:space="preserve"><value>Web 検索を有効化 (--search)</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Label" xml:space="preserve"><value>追加ディレクトリ</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Placeholder" xml:space="preserve"><value>1 行に 1 ディレクトリずつ指定</value></data>

--- a/TerminalHub/appsettings.json
+++ b/TerminalHub/appsettings.json
@@ -21,11 +21,6 @@
     "ClaudeCmdPath": null,
     "UseClaudeCode": true,
     "UseGeminiCli": true,
-    "UseCodexCli": true,
-    "GeminiModels": [
-      "gemini-1.5-pro-latest",
-      "gemini-1.5-flash-latest",
-      "gemini-pro"
-    ]
+    "UseCodexCli": true
   }
 }


### PR DESCRIPTION
## 背景

PR #57 で**カスタムCLIオプション**機能を追加し、ユーザーが任意の起動引数をチェックボックスで管理できるようになった。これに伴い、これまで「念のため」ビルトイン UI に並べていた**利用頻度の低い詳細オプション**を整理して、新規セッション作成ダイアログをスリム化する。

## 削除する項目

| CLI | 項目 | 削除理由 |
|---|---|---|
| Gemini | モデル選択ドロップダウン + モデルリスト CRUD UI 一式 | 大半のユーザーはデフォルトで使う + UI 規模大。カスタムで `-m gemini-2.5-pro` と書ける |
| Codex | `--profile` テキスト入力 | マイナー機能、カスタムで代替可 |
| Codex | `--model` テキスト入力 | デフォルト使用が多い、カスタムで代替可 |
| Codex | `--network-access` ドロップダウン | mode/sandbox と複雑に絡んでいたが利用頻度低、カスタムで `-c sandbox_workspace_write.network_access=true` を書けば代替可 |

合わせて以下を削除/整理:
- `LocalStorage` の `"gemini_models"` キー (モデルリストの永続化)
- `appsettings.json` の `ExternalTools.GeminiModels` 配列
- `AppSettings.Gemini` (`GeminiSettings.Models`) — 他で参照されていない
- `TerminalConstants.BuildCodexArgs` の `--full-auto` 暗黙デフォルト適用 (`workspace-write` + `on-request` を仮設定するロジック) — `--full-auto` 自体に CLI 側の暗黙デフォルトがあるためアプリ側で重複適用する必要なし
- 関連 i18n キー 14 個 (Gemini モデル 4 + Codex Profile/Model/NetworkAccess 10)

## 残すビルトイン

- 各 CLI の主要モード: permission-mode / approval-mode / mode
- --continue / --resume 系
- Sandbox スイッチ (Gemini -s, Codex --sandbox 4択)
- Codex --search / --add-dir / ask-for-approval (mode と連動した help)
- 「追加引数」自由入力

## 移行ガイド

ユーザーが従来ビルトインで設定していた値は、設定ダイアログの **「カスタムオプション」タブ**で CLI ごとに登録すれば同じ起動引数を再現できる。

| 例 | ラベル | Arguments |
|---|---|---|
| Gemini モデル指定 | model-pro | `-m gemini-2.5-pro` |
| Codex profile | trusted | `--profile trusted` |
| Codex model | gpt-5-codex | `--model gpt-5-codex` |
| Codex network 制限 | net-restricted | `-c sandbox_workspace_write.network_access=false` |

「デフォルトでオン」スイッチを使えばこれまでと同じ感覚で常時付与もできる。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `Components/Shared/Dialogs/SessionOptionsSelector.razor` | UI 削除 + フィールド/メソッド削除 (179 行減) |
| `Components/Shared/Dialogs/SessionSettingsDialog.razor` | options dict 復元時の削除済みキー参照を除去 |
| `Constants/TerminalConstants.cs` | Gemini `-m`, Codex `--profile`/`--model`/network-access 関連の組立コード削除 (42 行減) |
| `Models/AppSettings.cs` | `GeminiSettings` 削除、`AppSettings.Gemini` プロパティ削除 |
| `appsettings.json` | `ExternalTools.GeminiModels` 削除 |
| `Resources/SharedResource.{ja,en}.resx` | 14 キー削除、ja/en 413 キーパリティ完全一致 |

合計: **+6 行 / -266 行**

## 動作確認

- C#/Razor コンパイル: 成功 (0 エラー)
- 想定挙動:
  - Claude Code セッション作成: 既存通り (変更なし)
  - Gemini CLI セッション作成: モデル選択 UI が消え、Approval モード/Sandbox/Continue/追加引数のみに
  - Codex CLI セッション作成: profile/model/network-access が消え、Mode/Sandbox/Approval/Search/AdditionalDirs/追加引数のみに
  - 既存の保存済みセッション: options に `model`/`profile`/`network-access` キーが残っていても Build*Args が参照しないので害なし

## 後方互換性

- AppSettings JSON: `Gemini` プロパティ削除だが、JSON は未知プロパティを無視するので既存ファイルは壊れない
- LocalStorage `gemini_models` キー: 残存しても無視される (読み込み箇所削除)
- 既存セッション options dict: 削除キーが残っていても新コードはそれらを参照しないので無害