### PR TITLE
chore: エラーレポート Webhook URL の埋め込みインフラを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,14 @@ jobs:
           $json.Mqtt.Password = "${{ secrets.MQTT_PASSWORD }}"
           $json | ConvertTo-Json -Depth 10 | Set-Content $settingsPath -NoNewline
 
+      - name: Inject Discord error-report webhook URL
+        shell: pwsh
+        run: |
+          $settingsPath = "TerminalHub/appsettings.json"
+          $json = Get-Content $settingsPath -Raw | ConvertFrom-Json
+          $json.ErrorReport.WebhookUrl = "${{ secrets.DISCORD_ERROR_WEBHOOK_URL }}"
+          $json | ConvertTo-Json -Depth 10 | Set-Content $settingsPath -NoNewline
+
       - name: Publish application
         run: dotnet publish TerminalHub/TerminalHub.csproj -c Release -r win-x64 --self-contained true -o ./publish /p:Version=${{ steps.get_version.outputs.VERSION }}
 

--- a/TerminalHub/appsettings.json
+++ b/TerminalHub/appsettings.json
@@ -22,5 +22,8 @@
     "UseClaudeCode": true,
     "UseGeminiCli": true,
     "UseCodexCli": true
+  },
+  "ErrorReport": {
+    "WebhookUrl": ""
   }
 }


### PR DESCRIPTION
## 概要

エラーレポート機能 (例外発生時の Discord 送信テレメトリ) の準備として、**リリースビルド時に Discord Webhook URL を `appsettings.json` に注入するインフラ**を整備する。**機能本体は別 PR**。

## 変更

### \`TerminalHub/appsettings.json\`
\`\`\`json
"ErrorReport": {
  "WebhookUrl": ""
}
\`\`\`
空フィールドを 1 つ追加。開発ビルドではこの空のまま (= テレメトリ送信されない)。

### \`.github/workflows/release.yml\`
既存の MQTT クレデンシャル注入ステップと同パターンで、\`secrets.DISCORD_ERROR_WEBHOOK_URL\` を \`appsettings.json\` の \`ErrorReport.WebhookUrl\` に書き込むステップを追加。

## 事前準備済み

- [x] TerminalHub Discord サーバーに非公開チャンネル \`#error-reports\` を作成 (\`@everyone\` には View Channel deny、zio3 のみ allow)
- [x] そのチャンネル向け Webhook \`TerminalHub Error Reporter\` を発行
- [x] Webhook URL を GitHub Repository Secret \`DISCORD_ERROR_WEBHOOK_URL\` に登録 (\`gh secret set\` 経由、リポ/Actions ログには値出ない)

## 動作確認

- 開発ビルド (タグなし、本ブランチ): \`appsettings.json\` の \`ErrorReport.WebhookUrl\` は空文字のまま → 機能本体実装後も「URL 空ならテレメトリ送信スキップ」とすることでローカル開発時の誤送信を防ぐ
- リリースビルド (\`v*\` タグプッシュ時): GH Actions が secret から URL を流し込み、配布バイナリの \`appsettings.json\` には実 URL が書き込まれる

## エラーレポート機能本体は別 PR

本 PR は**埋め込みインフラのみ**。以下の本体機能は次の PR で追加予定:
- 例外ハンドラ (\`Blazor Circuit OnUnhandledException\` + \`AppDomain.UnhandledException\`)
- 設定タブ「エラーレポート」(ラジオ 3 値: 毎回ダイアログ / 自動送信 / 送信しない)
- 確認ダイアログ (送信内容プレビュー + 「次回以降この選択を使う」チェック)
- PII スクラビング (パス → \`~\` 置換、コマンド履歴除外、環境変数値除外)
- レート制限 (同セッション内、同種例外 1 回)
- Discord Embed フォーマットでの送信ロジック

## リスク

- 本 PR 単体で配布バイナリに URL は埋め込まれるが、それを使うコードがないため実害なし
- 機能本体実装後、初回起動時に何もしないことを確認してからリリース反映