### PR TITLE
fix: フォルダ選択ダイアログを最前面に表示

### DIFF
--- a/TerminalHub/Services/FolderPickerService.cs
+++ b/TerminalHub/Services/FolderPickerService.cs
@@ -19,12 +19,73 @@ public class FolderPickerService : IFolderPickerService
     [DllImport("user32.dll")]
     private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    [DllImport("user32.dll")]
+    private static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
+
+    [DllImport("user32.dll")]
+    private static extern bool BringWindowToTop(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("kernel32.dll")]
+    private static extern uint GetCurrentThreadId();
+
     private static readonly IntPtr HWND_TOPMOST = new(-1);
     private static readonly IntPtr HWND_NOTOPMOST = new(-2);
     private const uint SWP_NOMOVE = 0x0002;
     private const uint SWP_NOSIZE = 0x0001;
     private const uint SWP_NOACTIVATE = 0x0010;
     private const uint TopMostFlags = SWP_NOMOVE | SWP_NOSIZE;
+    private const int SW_SHOW = 5;
+
+    /// <summary>
+    /// 指定ウィンドウを強制的にフォアグラウンド化する。
+    /// Blazor Server はバックグラウンドプロセスのため、単純な SetForegroundWindow は
+    /// Windows のフォアグラウンドロックで拒否される。現在フォアグラウンドのウィンドウの
+    /// 入力スレッドへ一時的に AttachThreadInput することで前面化を成功させる。
+    /// ShowDialog(owner) で開くモーダルの IFileDialog はオーナーに追従して前面に出る。
+    /// </summary>
+    private static void ForceForeground(IntPtr hWnd)
+    {
+        if (hWnd == IntPtr.Zero) return;
+
+        var foreground = GetForegroundWindow();
+        uint foreThread = foreground == IntPtr.Zero ? 0 : GetWindowThreadProcessId(foreground, out _);
+        uint thisThread = GetCurrentThreadId();
+
+        bool attached = false;
+        try
+        {
+            if (foreThread != 0 && foreThread != thisThread)
+            {
+                attached = AttachThreadInput(foreThread, thisThread, true);
+            }
+
+            SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0, TopMostFlags);
+            ShowWindow(hWnd, SW_SHOW);
+            BringWindowToTop(hWnd);
+            SetForegroundWindow(hWnd);
+            // TOPMOST は前面化のための一時措置。アクティブ化後は解除して通常の Z オーダーに戻す。
+            SetWindowPos(hWnd, HWND_NOTOPMOST, 0, 0, 0, 0, TopMostFlags | SWP_NOACTIVATE);
+        }
+        finally
+        {
+            if (attached)
+            {
+                AttachThreadInput(foreThread, thisThread, false);
+            }
+        }
+    }
 
     public Task<string?> PickFolderAsync(string? initialDirectory = null)
     {
@@ -48,6 +109,9 @@ public class FolderPickerService : IFolderPickerService
                 // Blazor Serverはバックグラウンドプロセスのため、
                 // そのままではWindowsがダイアログを前面に出さない。
                 using var owner = new TopmostOwnerWindow();
+                // オーナーを強制的にフォアグラウンド化してから ShowDialog する。
+                // こうしないと App Mode(Chrome) などが前面のとき、ダイアログが裏に回ってしまう。
+                ForceForeground(owner.Handle);
                 var result = dialog.ShowDialog(owner);
                 tcs.SetResult(result == System.Windows.Forms.DialogResult.OK ? dialog.SelectedPath : null);
             }


### PR DESCRIPTION
## 概要

新しいセッション作成ダイアログの「参照 → フォルダを選択...」から OS のフォルダ選択ダイアログ（`FolderBrowserDialog`）を開いたとき、**ダイアログが他ウィンドウの裏に隠れて見えない**問題を修正します。

## 原因

- TerminalHub は Blazor Server アプリで、`FolderBrowserDialog` はサーバープロセス（`TerminalHub.exe`）が表示する
- App Mode（Chrome `--app`）など別プロセスが前面にあると、サーバープロセスは Windows のフォアグラウンドロックにより自前のウィンドウを前面化できず、ダイアログが裏に回る
- 既存の `TopmostOwnerWindow`（オーナーを TOPMOST 化）だけでは効ききらないケースがあった
- 開発時（`dotnet run`）はコンソールが前面のため問題が顕在化せず、インストール版（App Mode 起動）でのみ再現していた

## 修正内容

`ShowDialog` の直前に `ForceForeground` を追加し、オーナーウィンドウを確実にフォアグラウンド化する:

1. `GetForegroundWindow` で現在前面のウィンドウのスレッドを取得
2. `AttachThreadInput` でそのスレッドへ一時アタッチ（フォアグラウンドロック回避）
3. `BringWindowToTop` / `SetForegroundWindow` でオーナーを強制アクティブ化
4. アタッチを解除

`ShowDialog(owner)` で開くモーダルの `IFileDialog` はオーナーに追従するため、結果としてフォルダ選択ダイアログが最前面に表示される。`explorer` 起動（別プロセス）は OS が自動で前面化してくれるが、同一プロセス内モーダルである本ダイアログには本処理が必要。

## 確認

- インストール版（App Mode）で「参照 → フォルダを選択...」を押し、ダイアログが最前面に出ることを確認済み
- `dotnet build` 成功（0 警告 / 0 エラー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)