### PR TITLE
feat: 新規セッション作成時の CLI モード選択を LocalStorage で復元

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -239,41 +239,49 @@
         }
     }
 
+    // 復元値ホワイトリスト: LocalStorage が手動編集等で汚染された場合に
+    // 不正値で起動引数が壊れるのを防ぐ。SessionOptionsSelector の UI 選択肢と一致させる。
+    private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto", "default" };
+    private static readonly HashSet<string> ValidGeminiApprovalModes = new() { "default", "auto_edit", "yolo" };
+    private static readonly HashSet<string> ValidCodexModes = new() { "auto", "standard", "yolo" };
+    private static readonly HashSet<string> ValidCodexSandboxModes = new() { "", "read-only", "workspace-write", "danger-full-access" };
+    private static readonly HashSet<string> ValidCodexApprovalPolicies = new() { "", "untrusted", "on-request", "never" };
+
     // CLI モード系ラジオの最終選択値を LocalStorage から復元する。
-    // 値が無いキーはデフォルト値（各 OptionsData の初期化値）のまま。
+    // 値が無い・ホワイトリスト外のキーはデフォルト値（各 OptionsData の初期化値）のまま。
     // 初回利用ユーザーは現状の安全側デフォルト (Claude=bypass 等) を維持する。
     private async Task LoadLastUsedCliModes()
     {
         try
         {
             var claudePerm = await LocalStorage.GetAsync<string>(LAST_CLAUDE_PERMISSION_MODE_KEY);
-            if (!string.IsNullOrEmpty(claudePerm))
+            if (claudePerm != null && ValidClaudePermissionModes.Contains(claudePerm))
             {
                 claudeCodeOptions.PermissionMode = claudePerm;
             }
 
             var geminiApproval = await LocalStorage.GetAsync<string>(LAST_GEMINI_APPROVAL_MODE_KEY);
-            if (!string.IsNullOrEmpty(geminiApproval))
+            if (geminiApproval != null && ValidGeminiApprovalModes.Contains(geminiApproval))
             {
                 geminiOptions.ApprovalMode = geminiApproval;
             }
 
             var codexMode = await LocalStorage.GetAsync<string>(LAST_CODEX_MODE_KEY);
-            if (!string.IsNullOrEmpty(codexMode))
+            if (codexMode != null && ValidCodexModes.Contains(codexMode))
             {
                 codexOptions.Mode = codexMode;
             }
 
-            // Codex SandboxMode / ApprovalPolicy は "" (Default) を有効値として持つので
-            // null 判定で復元する (空文字列を上書きしてしまうのを防ぐ)。
+            // Codex SandboxMode / ApprovalPolicy は "" (Default) を有効値として含むため
+            // ホワイトリストにも "" を入れている。
             var codexSandbox = await LocalStorage.GetAsync<string>(LAST_CODEX_SANDBOX_MODE_KEY);
-            if (codexSandbox != null)
+            if (codexSandbox != null && ValidCodexSandboxModes.Contains(codexSandbox))
             {
                 codexOptions.SandboxMode = codexSandbox;
             }
 
             var codexApproval = await LocalStorage.GetAsync<string>(LAST_CODEX_APPROVAL_POLICY_KEY);
-            if (codexApproval != null)
+            if (codexApproval != null && ValidCodexApprovalPolicies.Contains(codexApproval))
             {
                 codexOptions.ApprovalPolicy = codexApproval;
             }

--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -142,6 +142,11 @@
     private SessionOptionsSelector.GrokOptionsData grokOptions = new();
     private List<string> favoriteFolders = new();
     private const string LAST_TERMINAL_TYPE_KEY = "lastSelectedTerminalType";
+    private const string LAST_CLAUDE_PERMISSION_MODE_KEY = "lastClaudePermissionMode";
+    private const string LAST_GEMINI_APPROVAL_MODE_KEY = "lastGeminiApprovalMode";
+    private const string LAST_CODEX_MODE_KEY = "lastCodexMode";
+    private const string LAST_CODEX_SANDBOX_MODE_KEY = "lastCodexSandboxMode";
+    private const string LAST_CODEX_APPROVAL_POLICY_KEY = "lastCodexApprovalPolicy";
     private bool showCreateFolderDialog = false;
     private bool pendingSessionCreation = false;
 
@@ -177,6 +182,7 @@
         if (firstRender)
         {
             await LoadLastSelectedTerminalType();
+            await LoadLastUsedCliModes();
             LoadSettings();
             _isInitialized = true;
             StateHasChanged();
@@ -226,6 +232,67 @@
         try
         {
             await LocalStorage.SetAsync(LAST_TERMINAL_TYPE_KEY, (int)type);
+        }
+        catch
+        {
+            // エラーが発生しても継続
+        }
+    }
+
+    // CLI モード系ラジオの最終選択値を LocalStorage から復元する。
+    // 値が無いキーはデフォルト値（各 OptionsData の初期化値）のまま。
+    // 初回利用ユーザーは現状の安全側デフォルト (Claude=bypass 等) を維持する。
+    private async Task LoadLastUsedCliModes()
+    {
+        try
+        {
+            var claudePerm = await LocalStorage.GetAsync<string>(LAST_CLAUDE_PERMISSION_MODE_KEY);
+            if (!string.IsNullOrEmpty(claudePerm))
+            {
+                claudeCodeOptions.PermissionMode = claudePerm;
+            }
+
+            var geminiApproval = await LocalStorage.GetAsync<string>(LAST_GEMINI_APPROVAL_MODE_KEY);
+            if (!string.IsNullOrEmpty(geminiApproval))
+            {
+                geminiOptions.ApprovalMode = geminiApproval;
+            }
+
+            var codexMode = await LocalStorage.GetAsync<string>(LAST_CODEX_MODE_KEY);
+            if (!string.IsNullOrEmpty(codexMode))
+            {
+                codexOptions.Mode = codexMode;
+            }
+
+            // Codex SandboxMode / ApprovalPolicy は "" (Default) を有効値として持つので
+            // null 判定で復元する (空文字列を上書きしてしまうのを防ぐ)。
+            var codexSandbox = await LocalStorage.GetAsync<string>(LAST_CODEX_SANDBOX_MODE_KEY);
+            if (codexSandbox != null)
+            {
+                codexOptions.SandboxMode = codexSandbox;
+            }
+
+            var codexApproval = await LocalStorage.GetAsync<string>(LAST_CODEX_APPROVAL_POLICY_KEY);
+            if (codexApproval != null)
+            {
+                codexOptions.ApprovalPolicy = codexApproval;
+            }
+        }
+        catch
+        {
+            // エラーが発生してもデフォルト値を使用
+        }
+    }
+
+    private async Task SaveLastUsedCliModes()
+    {
+        try
+        {
+            await LocalStorage.SetAsync(LAST_CLAUDE_PERMISSION_MODE_KEY, claudeCodeOptions.PermissionMode);
+            await LocalStorage.SetAsync(LAST_GEMINI_APPROVAL_MODE_KEY, geminiOptions.ApprovalMode);
+            await LocalStorage.SetAsync(LAST_CODEX_MODE_KEY, codexOptions.Mode);
+            await LocalStorage.SetAsync(LAST_CODEX_SANDBOX_MODE_KEY, codexOptions.SandboxMode);
+            await LocalStorage.SetAsync(LAST_CODEX_APPROVAL_POLICY_KEY, codexOptions.ApprovalPolicy);
         }
         catch
         {
@@ -285,8 +352,12 @@
             Options = optionsSelector?.GetOptions() ?? new Dictionary<string, string>()
         };
 
+        // ユーザーが実際に Create を押したタイミングで CLI モード選択を永続化する。
+        // (途中で開いてキャンセルした選択は保存しない)
+        await SaveLastUsedCliModes();
+
         await OnSessionCreate.InvokeAsync(result);
-        ResetForm();
+        await ResetForm();
     }
 
     private async Task ConfirmFolderCreation()
@@ -329,7 +400,7 @@
 
     private async Task Cancel()
     {
-        ResetForm();
+        await ResetForm();
         await OnCancel.InvokeAsync();
     }
 
@@ -349,7 +420,7 @@
         isMouseDownOnBackdrop = false;
     }
 
-    private void ResetForm()
+    private async Task ResetForm()
     {
         folderPath = _cachedDefaultFolderPath;
         // selectedType は保持する（最後に選択したタイプを継続）
@@ -359,6 +430,9 @@
         codexOptions = new();
         antigravityOptions = new();
         grokOptions = new();
+        // Create 後・次回ダイアログ表示で前回の CLI モード選択が見えるよう、
+        // 新しい OptionsData インスタンスに LocalStorage の値を反映しなおす。
+        await LoadLastUsedCliModes();
         showCreateFolderDialog = false;
         pendingSessionCreation = false;
     }


### PR DESCRIPTION
## Summary

新規セッション作成ダイアログを開くたびに CLI モード系ラジオが各デフォルト値 (Claude PermissionMode = `bypass` 等) にリセットされていたのを、LocalStorage に永続化して前回選択を復元するよう変更。既存の `lastSelectedTerminalType` と同じパターン。

ローカル利用前提のスタンス上、デフォルトを `auto` 等に下げると他のユーザーに preference を強制してしまうため、**デフォルトは現状の `bypass` のまま** とし、各ユーザーが自分で一度選んだ値を以降覚える方針。

## 変更点

- `SessionCreateDialog.razor`:
  - LocalStorage キー 5 件追加 (`lastClaudePermissionMode`, `lastGeminiApprovalMode`, `lastCodexMode`, `lastCodexSandboxMode`, `lastCodexApprovalPolicy`)
  - `LoadLastUsedCliModes` / `SaveLastUsedCliModes` 追加
  - `OnAfterRenderAsync(firstRender)` で復元、Create 押下時にのみ保存
  - `ResetForm` 後も復元 → 連続作成でも保持
  - Codex `SandboxMode` / `ApprovalPolicy` は `""` (Default) を有効値として持つので null 判定で復元

## 対象外

- ユーザー定義カスタム CLI オプションのトグル状態: 各オプション設定の `DefaultEnabled` でユーザー側が個別制御済みなので重複機能になるため対象外
- `ExtraArgs` 等の可変テキスト系: 誤発射防止のため対象外
- `SessionSettingsDialog`: 既存セッションの保存値を読む用途なので LocalStorage 復元は不要

## Test plan

- [ ] Claude PermissionMode を `auto` に変更して Create → 新規セッション作成ダイアログを開きなおすと `auto` で復元される
- [ ] 同様に Gemini ApprovalMode / Codex Mode・SandboxMode・ApprovalPolicy も次回復元される
- [ ] Cancel / 閉じるで終了した変更は保存されない
- [ ] 初回利用 (LocalStorage 空) の場合は現状デフォルト (Claude `bypass`) が表示される
- [ ] ブラウザリロード / TerminalHub 再起動を跨いでも前回選択が復元される

🤖 Generated with [Claude Code](https://claude.com/claude-code)