### PR TITLE
feat: ターミナル右上に再描画用フローティングボタンを追加

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -132,6 +132,17 @@
                              style="display: @(session.SessionId == activeSessionId ? "block" : "none");"></div>
                     }
                 </div>
+                @* xterm の描画が CanvasAddon の不整合で崩れた際の救済用フローティングボタン。
+                   通常はほぼ透明、hover で出現する控えめな存在感を狙う。 *@
+                @if (activeSessionId != null)
+                {
+                    <button type="button"
+                            class="terminal-redraw-btn"
+                            title="@L["Root.Terminal.Redraw.Title"]"
+                            @onclick="() => RecreateTerminal(activeSessionId.Value)">
+                        <i class="bi bi-arrow-clockwise"></i>
+                    </button>
+                }
             </div>
 
             <!-- スプリッター -->

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -545,6 +545,7 @@
   <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>Terminal disposed</value></data>
   <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>Terminal dispose error: {0}</value></data>
   <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>Terminal recreated</value></data>
+  <data name="Root.Terminal.Redraw.Title" xml:space="preserve"><value>Redraw if display is corrupted</value></data>
   <data name="Root.Toast.SelectSessionFirst" xml:space="preserve"><value>Please select this session first, then recreate the terminal</value></data>
   <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>Terminal recreate error: {0}</value></data>
   <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' created</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -545,6 +545,7 @@
   <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>ターミナルを破棄しました</value></data>
   <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>ターミナル破棄エラー: {0}</value></data>
   <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>ターミナルを再作成しました</value></data>
+  <data name="Root.Terminal.Redraw.Title" xml:space="preserve"><value>表示が崩れた場合に再描画します</value></data>
   <data name="Root.Toast.SelectSessionFirst" xml:space="preserve"><value>このセッションを選択してからターミナルを再作成してください</value></data>
   <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>ターミナル再作成エラー: {0}</value></data>
   <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' を作成しました</value></data>

--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -169,6 +169,39 @@ h1:focus {
     min-height: 400px;
 }
 
+/* xterm 再描画ボタン (CanvasAddon 不整合時のレスキュー用)
+   通常はほぼ透明、hover でうっすら出現する控えめな存在感。 */
+.terminal-section {
+    position: relative;
+}
+
+.terminal-redraw-btn {
+    position: absolute;
+    top: 4px;
+    right: 10px;
+    z-index: 10;
+    background: transparent;
+    color: var(--th-text-muted, rgba(204, 204, 204, 0.7));
+    border: none;
+    border-radius: var(--th-radius-sm);
+    padding: 2px 6px;
+    font-size: 0.85rem;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.08;
+    transition: opacity 0.2s ease, background-color 0.2s ease;
+}
+
+.terminal-redraw-btn:hover {
+    opacity: 0.9;
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.terminal-redraw-btn:focus {
+    outline: none;
+    opacity: 0.9;
+}
+
 /* ===========================================
    ボタン
    =========================================== */


### PR DESCRIPTION
## Summary

xterm.js の CanvasAddon が稀に内部レンダラー状態の不整合を起こし、画面に古い glyph が貼り付いて消えなくなる現象 (スリープ復帰・長時間タブ放置等で発生) のレスキュー手段として、ターミナル領域の右上に控えめなフローティングボタンを追加。

経緯としては 2026-02-23 `de1a05f` で「カニが崩れないように」DOM renderer → CanvasAddon に切替えたトレードオフの副作用面。ブラウザ全体をリロードしなくても、このボタン 1 つで該当セッションだけ復旧できるようにする。

## 変更点

- `Root.razor`: `.terminal-section` 配下に `<button class=\"terminal-redraw-btn\">` を追加。アクティブセッションがあるときだけ表示し、既存の未使用メソッド `RecreateTerminal(activeSessionId.Value)` を呼ぶ
- `app.css`: `.terminal-section` に `position: relative` を付与、`.terminal-redraw-btn` のスタイル追加 (top: 4px / right: 10px / opacity 0.08 → hover で 0.9)
- `SharedResource.{ja,en}.resx`: ツールチップ文字列 `Root.Terminal.Redraw.Title` 追加

## デザイン意図

- **目立たない**: opacity 0.08 で「困った人だけ気付けばよい」存在感
- **hover で出現**: opacity 0.9 + 薄背景で押せると分かる
- **副作用なし**: 既存 `RecreateTerminal` は ConPty バッファ (サーバ側) は触らないので出力は失われない。xterm.js のインスタンスだけ作り直す

## Test plan

- [ ] 通常時、右上にうっすらと \"⟳\" アイコンが見える
- [ ] hover でクッキリ表示に変わる
- [ ] クリックでターミナルが再作成され、トースト「ターミナルを再作成しました」が出る
- [ ] アクティブセッションが無いときはボタンが表示されない
- [ ] 描画破綻時 (CanvasAddon 不整合) にこのボタンで復旧できるか (次回発生時に確認)
- [ ] ja / en 両方でツールチップが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)