### PR TITLE
feat: Worktree のブランチ非依存化 — 「ブランチを後で選ぶ」モードと UX 改善

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1747,9 +1747,11 @@
             switch (result.OperationType)
             {
                 case SubSessionDialog.SubSessionType.CreateNew:
-                    // Worktree作成（新規・既存ブランチ共通）
+                    // Worktree作成（新規ブランチ／既存ブランチ／detached 共通）
                     newSession = await SessionManager.CreateWorktreeSessionAsync(
-                        subSessionParentSessionId.Value, result.BranchName, result.TerminalType, result.Options);
+                        subSessionParentSessionId.Value, result.BranchName, result.TerminalType, result.Options,
+                        string.IsNullOrWhiteSpace(result.FolderSuffix) ? null : result.FolderSuffix,
+                        result.UseDetached);
                     break;
 
                 case SubSessionDialog.SubSessionType.AddExisting:
@@ -1793,7 +1795,9 @@
                 string successMessage = result.OperationType switch
                 {
                     SubSessionDialog.SubSessionType.CreateNew =>
-                        string.Format(L["Root.Toast.WorktreeCreatedFormat"], result.BranchName),
+                        result.UseDetached
+                            ? L["Root.Toast.WorktreeCreatedDetached"]
+                            : string.Format(L["Root.Toast.WorktreeCreatedFormat"], result.BranchName),
                     SubSessionDialog.SubSessionType.AddExisting =>
                         string.Format(L["Root.Toast.WorktreeAddedFormat"], result.BranchName),
                     SubSessionDialog.SubSessionType.SamePath =>

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -49,12 +49,13 @@
                 OnSidebarWidthPercentChanged="HandleSidebarWidthPercentChanged"
                 OnVoiceInputEnabledChanged="HandleVoiceInputEnabledChanged"
                 OnThemeChanged="HandleThemeChanged" />
-<SubSessionDialog IsVisible="showSubSessionDialog" 
+<SubSessionDialog IsVisible="showSubSessionDialog"
                          ParentSessionName="@subSessionParentSessionName"
                          ParentSessionId="@subSessionParentSessionId"
                          ParentSessionPath="@subSessionParentSessionPath"
                          IsGitRepository="@subSessionParentSessionIsGitRepository"
-                         OnSubSessionOperation="OnSubSessionOperation" 
+                         ParentTerminalType="@subSessionParentTerminalType"
+                         OnSubSessionOperation="OnSubSessionOperation"
                          OnCancel="() => showSubSessionDialog = false" />
 <SessionSettingsDialog IsVisible="showSessionSettingsDialog"
                        SessionId="@settingsSessionId"
@@ -206,6 +207,7 @@
     private Guid? subSessionParentSessionId = null;
     private string? subSessionParentSessionPath = null;
     private bool subSessionParentSessionIsGitRepository = true;
+    private TerminalType subSessionParentTerminalType = TerminalType.Terminal;
     private bool showSessionSettingsDialog = false;
     private Guid? settingsSessionId = null;
     private bool showArchivedSessionsDialog = false;
@@ -1728,6 +1730,7 @@
             subSessionParentSessionName = session.GetDisplayName();
             subSessionParentSessionPath = session.FolderPath;
             subSessionParentSessionIsGitRepository = session.IsGitRepository;
+            subSessionParentTerminalType = session.TerminalType;
             showSubSessionDialog = true;
         }
     }
@@ -1826,6 +1829,7 @@
             subSessionParentSessionName = null;
             subSessionParentSessionPath = null;
             subSessionParentSessionIsGitRepository = true;
+            subSessionParentTerminalType = TerminalType.Terminal;
         }
     }
 

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1850,10 +1850,10 @@
             return null;
         }
 
-        // 既存のWorktreeをセッションとして追加（統一された表示名を使用）
+        // 既存のWorktreeをセッションとして追加（親はツリー表示でぶら下がるため省略）
         var sessionInfo = await SessionManager.CreateSessionAsync(
             worktreePath,
-            $"{parentSession.DisplayName} ({branchName})",
+            branchName,
             terminalType,
             options
         );

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -364,6 +364,19 @@
     // LocalStorage: 直近のブランチ選択方法 (全セッション共通で 1 つ保持)
     private const string LAST_BRANCH_SELECTION_MODE_KEY = "lastBranchSelectionMode";
     private static readonly HashSet<string> ValidBranchSelectionModes = new() { "NewBranch", "ExistingBranch", "Detached" };
+
+    // LocalStorage: 直近の CLI モード選択 (SessionCreateDialog とキーを共有して値を流用)
+    private const string LAST_CLAUDE_PERMISSION_MODE_KEY = "lastClaudePermissionMode";
+    private const string LAST_GEMINI_APPROVAL_MODE_KEY = "lastGeminiApprovalMode";
+    private const string LAST_CODEX_MODE_KEY = "lastCodexMode";
+    private const string LAST_CODEX_SANDBOX_MODE_KEY = "lastCodexSandboxMode";
+    private const string LAST_CODEX_APPROVAL_POLICY_KEY = "lastCodexApprovalPolicy";
+
+    private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto", "default" };
+    private static readonly HashSet<string> ValidGeminiApprovalModes = new() { "default", "auto_edit", "yolo" };
+    private static readonly HashSet<string> ValidCodexModes = new() { "auto", "standard", "yolo" };
+    private static readonly HashSet<string> ValidCodexSandboxModes = new() { "", "read-only", "workspace-write", "danger-full-access" };
+    private static readonly HashSet<string> ValidCodexApprovalPolicies = new() { "", "untrusted", "on-request", "never" };
     
     // Worktree関連
     private List<WorktreeInfo>? availableWorktrees = null;
@@ -462,6 +475,8 @@
             claudeOptions = new();
             geminiOptions = new();
             codexOptions = new();
+            // CLI モード系の直近選択も復元（SessionCreateDialog とキー共有）
+            await LoadLastUsedCliModes();
             newFolderPath = "";
             
             // 親セッションのパスがあり、Gitリポジトリの場合はブランチ一覧とworktree一覧を取得
@@ -575,6 +590,48 @@
         // 手動入力でのパス指定を推奨
         // 必要に応じて将来的にFile System Access APIを使用可能
         await Task.CompletedTask;
+    }
+
+    // SessionCreateDialog が保存した CLI モードの直近選択を、初期値として読むだけ。
+    // SubSessionDialog 側で書き戻しはしない (値の発生源は新規セッション作成画面に一元化)。
+    private async Task LoadLastUsedCliModes()
+    {
+        try
+        {
+            var claudePerm = await LocalStorage.GetAsync<string>(LAST_CLAUDE_PERMISSION_MODE_KEY);
+            if (claudePerm != null && ValidClaudePermissionModes.Contains(claudePerm))
+            {
+                claudeOptions.PermissionMode = claudePerm;
+            }
+
+            var geminiApproval = await LocalStorage.GetAsync<string>(LAST_GEMINI_APPROVAL_MODE_KEY);
+            if (geminiApproval != null && ValidGeminiApprovalModes.Contains(geminiApproval))
+            {
+                geminiOptions.ApprovalMode = geminiApproval;
+            }
+
+            var codexMode = await LocalStorage.GetAsync<string>(LAST_CODEX_MODE_KEY);
+            if (codexMode != null && ValidCodexModes.Contains(codexMode))
+            {
+                codexOptions.Mode = codexMode;
+            }
+
+            var codexSandbox = await LocalStorage.GetAsync<string>(LAST_CODEX_SANDBOX_MODE_KEY);
+            if (codexSandbox != null && ValidCodexSandboxModes.Contains(codexSandbox))
+            {
+                codexOptions.SandboxMode = codexSandbox;
+            }
+
+            var codexApproval = await LocalStorage.GetAsync<string>(LAST_CODEX_APPROVAL_POLICY_KEY);
+            if (codexApproval != null && ValidCodexApprovalPolicies.Contains(codexApproval))
+            {
+                codexOptions.ApprovalPolicy = codexApproval;
+            }
+        }
+        catch
+        {
+            // 失敗してもデフォルト値のまま続行
+        }
     }
 
     private async Task LoadLastBranchSelectionMode()

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -342,6 +342,7 @@
     [Parameter] public string? ParentSessionName { get; set; }
     [Parameter] public Guid? ParentSessionId { get; set; }
     [Parameter] public bool IsGitRepository { get; set; }
+    [Parameter] public TerminalType ParentTerminalType { get; set; } = TerminalType.Terminal;
     [Parameter] public EventCallback<SubSessionResult> OnSubSessionOperation { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
 
@@ -443,7 +444,8 @@
             branchSelectionMode = BranchSelectionMode.NewBranch;
             selectedExistingBranch = "";
             folderSuffix = "";
-            selectedTerminalType = TerminalType.Terminal;
+            // 親セッションの TerminalType を初期値として引き継ぐ
+            selectedTerminalType = ParentTerminalType;
             availableBranches = null;
             availableWorktrees = null;
             selectedWorktreePath = "";

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -2,6 +2,7 @@
 @using TerminalHub.Services
 @using Microsoft.Extensions.Localization
 @inject IGitService GitService
+@inject ILocalStorageService LocalStorage
 @inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
@@ -359,6 +360,10 @@
 
     // Windows のファイル名禁止文字 + Git/Path 的に避けたい文字
     private static readonly char[] InvalidFolderSuffixChars = new[] { '<', '>', ':', '"', '/', '\\', '|', '?', '*' };
+
+    // LocalStorage: 直近のブランチ選択方法 (全セッション共通で 1 つ保持)
+    private const string LAST_BRANCH_SELECTION_MODE_KEY = "lastBranchSelectionMode";
+    private static readonly HashSet<string> ValidBranchSelectionModes = new() { "NewBranch", "ExistingBranch", "Detached" };
     
     // Worktree関連
     private List<WorktreeInfo>? availableWorktrees = null;
@@ -446,6 +451,9 @@
             folderSuffix = "";
             // 親セッションの TerminalType を初期値として引き継ぐ
             selectedTerminalType = ParentTerminalType;
+
+            // 直近の選択を LocalStorage から復元
+            await LoadLastBranchSelectionMode();
             availableBranches = null;
             availableWorktrees = null;
             selectedWorktreePath = "";
@@ -511,6 +519,12 @@
                 FolderSuffix = activeTab == TabType.Create ? folderSuffix?.Trim() ?? "" : ""
             };
 
+            // Create タブの選択結果を「直近の選択」として LocalStorage に保存
+            if (activeTab == TabType.Create)
+            {
+                await SaveLastBranchSelectionMode();
+            }
+
             await OnSubSessionOperation.InvokeAsync(result);
         }
         catch (Exception ex)
@@ -561,6 +575,35 @@
         // 手動入力でのパス指定を推奨
         // 必要に応じて将来的にFile System Access APIを使用可能
         await Task.CompletedTask;
+    }
+
+    private async Task LoadLastBranchSelectionMode()
+    {
+        try
+        {
+            var saved = await LocalStorage.GetAsync<string>(LAST_BRANCH_SELECTION_MODE_KEY);
+            if (!string.IsNullOrEmpty(saved) && ValidBranchSelectionModes.Contains(saved)
+                && Enum.TryParse<BranchSelectionMode>(saved, out var mode))
+            {
+                branchSelectionMode = mode;
+            }
+        }
+        catch
+        {
+            // LocalStorage アクセス失敗時はデフォルト (NewBranch) のまま
+        }
+    }
+
+    private async Task SaveLastBranchSelectionMode()
+    {
+        try
+        {
+            await LocalStorage.SetAsync(LAST_BRANCH_SELECTION_MODE_KEY, branchSelectionMode.ToString());
+        }
+        catch
+        {
+            // LocalStorage アクセス失敗時は無視
+        }
     }
 
     private async Task LoadAvailableBranches()

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -80,6 +80,11 @@
                                            checked="@(branchSelectionMode == BranchSelectionMode.ExistingBranch)"
                                            @onclick="@(() => branchSelectionMode = BranchSelectionMode.ExistingBranch)">
                                     <label class="btn btn-outline-secondary" for="existingBranch">@L["SubSession.BranchSelection.Existing"]</label>
+
+                                    <input type="radio" class="btn-check" name="branchOption" id="detachedBranch"
+                                           checked="@(branchSelectionMode == BranchSelectionMode.Detached)"
+                                           @onclick="@(() => branchSelectionMode = BranchSelectionMode.Detached)">
+                                    <label class="btn btn-outline-secondary" for="detachedBranch">@L["SubSession.BranchSelection.Detached"]</label>
                                 </div>
                             </div>
 
@@ -96,6 +101,13 @@
                                     <small class="form-text text-muted">
                                         @L["SubSession.NewBranch.Help"]
                                     </small>
+                                </div>
+                            }
+                            else if (branchSelectionMode == BranchSelectionMode.Detached)
+                            {
+                                <div class="alert alert-info">
+                                    <i class="bi bi-info-circle me-2"></i>
+                                    @L["SubSession.Detached.Help"]
                                 </div>
                             }
                             else
@@ -139,6 +151,25 @@
                                 }
                             }
                             
+                            <!-- フォルダ名サフィックス(任意) -->
+                            <div class="mb-3">
+                                <label for="folderSuffix" class="form-label">@L["SubSession.FolderSuffix.Label"]</label>
+                                <input type="text" class="form-control" id="folderSuffix"
+                                       @bind="folderSuffix"
+                                       @bind:event="oninput"
+                                       @onkeydown="OnKeyDown"
+                                       placeholder="@GetFolderSuffixPlaceholder()">
+                                <small class="form-text text-muted">
+                                    @L["SubSession.FolderSuffix.Help"]
+                                </small>
+                                @if (!string.IsNullOrWhiteSpace(folderSuffix) && !IsValidFolderSuffix(folderSuffix))
+                                {
+                                    <div class="text-danger small mt-1">
+                                        <i class="bi bi-exclamation-circle me-1"></i>@L["SubSession.FolderSuffix.Invalid"]
+                                    </div>
+                                }
+                            </div>
+
                             <!-- 共通オプションセレクター -->
                             <SessionOptionsSelector @ref="optionsSelector"
                                                   SelectedType="selectedTerminalType"
@@ -318,11 +349,15 @@
     private string branchName = "";
     private string errorMessage = "";
     private bool isProcessing = false;
-    
+
     // 新規プロパティ
     private BranchSelectionMode branchSelectionMode = BranchSelectionMode.NewBranch;
     private string selectedExistingBranch = "";
+    private string folderSuffix = "";
     private List<string>? availableBranches = null;
+
+    // Windows のファイル名禁止文字 + Git/Path 的に避けたい文字
+    private static readonly char[] InvalidFolderSuffixChars = new[] { '<', '>', ':', '"', '/', '\\', '|', '?', '*' };
     
     // Worktree関連
     private List<WorktreeInfo>? availableWorktrees = null;
@@ -344,17 +379,48 @@
     {
         get
         {
+            // サフィックス入力ありで内容が不正な場合はブロック
+            if (activeTab == TabType.Create && !string.IsNullOrWhiteSpace(folderSuffix) && !IsValidFolderSuffix(folderSuffix))
+            {
+                return false;
+            }
+
             return activeTab switch
             {
-                TabType.Create => IsGitRepository && (branchSelectionMode == BranchSelectionMode.NewBranch 
-                    ? !string.IsNullOrWhiteSpace(branchName)
-                    : (!string.IsNullOrWhiteSpace(selectedExistingBranch) && branchWorktreeInfo == null)),
+                TabType.Create => IsGitRepository && branchSelectionMode switch
+                {
+                    BranchSelectionMode.NewBranch => !string.IsNullOrWhiteSpace(branchName),
+                    BranchSelectionMode.ExistingBranch => !string.IsNullOrWhiteSpace(selectedExistingBranch) && branchWorktreeInfo == null,
+                    BranchSelectionMode.Detached => true,
+                    _ => false
+                },
                 TabType.Existing => IsGitRepository && !string.IsNullOrWhiteSpace(selectedWorktreePath),
-                TabType.SamePath => true, // 同じフォルダの場合は常に有効
-                TabType.NewFolder => !string.IsNullOrWhiteSpace(newFolderPath), // 新しいフォルダパスが入力されている
+                TabType.SamePath => true,
+                TabType.NewFolder => !string.IsNullOrWhiteSpace(newFolderPath),
                 _ => false
             };
         }
+    }
+
+    private bool IsValidFolderSuffix(string suffix)
+    {
+        var trimmed = suffix.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+            return true; // 空は「未入力扱い」なのでOK
+        if (trimmed.IndexOfAny(InvalidFolderSuffixChars) >= 0)
+            return false;
+        if (trimmed.StartsWith('.') || trimmed.StartsWith('-') || trimmed.EndsWith('.'))
+            return false;
+        return true;
+    }
+
+    private string GetFolderSuffixPlaceholder()
+    {
+        return branchSelectionMode switch
+        {
+            BranchSelectionMode.Detached => L["SubSession.FolderSuffix.Placeholder.Detached"],
+            _ => L["SubSession.FolderSuffix.Placeholder.Default"]
+        };
     }
     
     // 新しいフォルダ用の変数
@@ -376,6 +442,7 @@
             isProcessing = false;
             branchSelectionMode = BranchSelectionMode.NewBranch;
             selectedExistingBranch = "";
+            folderSuffix = "";
             selectedTerminalType = TerminalType.Terminal;
             availableBranches = null;
             availableWorktrees = null;
@@ -418,10 +485,15 @@
                     TabType.NewFolder => SubSessionType.NewFolder,
                     _ => SubSessionType.CreateNew
                 },
-                BranchName = activeTab == TabType.Create 
-                    ? (branchSelectionMode == BranchSelectionMode.NewBranch ? branchName : selectedExistingBranch)
+                BranchName = activeTab == TabType.Create
+                    ? branchSelectionMode switch
+                    {
+                        BranchSelectionMode.NewBranch => branchName,
+                        BranchSelectionMode.ExistingBranch => selectedExistingBranch,
+                        _ => ""
+                    }
                     : availableWorktrees?.FirstOrDefault(w => w.Path == selectedWorktreePath)?.BranchName ?? "",
-                WorktreePath = activeTab == TabType.Existing ? selectedWorktreePath : 
+                WorktreePath = activeTab == TabType.Existing ? selectedWorktreePath :
                                activeTab == TabType.NewFolder ? newFolderPath : null,
                 TerminalType = selectedTerminalType,
                 Options = activeTab switch
@@ -432,7 +504,9 @@
                     TabType.NewFolder => optionsSelectorNewFolder?.GetOptions() ?? new Dictionary<string, string>(),
                     _ => new Dictionary<string, string>()
                 },
-                UseExistingBranch = activeTab == TabType.Create && branchSelectionMode == BranchSelectionMode.ExistingBranch
+                UseExistingBranch = activeTab == TabType.Create && branchSelectionMode == BranchSelectionMode.ExistingBranch,
+                UseDetached = activeTab == TabType.Create && branchSelectionMode == BranchSelectionMode.Detached,
+                FolderSuffix = activeTab == TabType.Create ? folderSuffix?.Trim() ?? "" : ""
             };
 
             await OnSubSessionOperation.InvokeAsync(result);
@@ -596,8 +670,10 @@
         public TerminalType TerminalType { get; set; } = TerminalType.Terminal;
         public Dictionary<string, string> Options { get; set; } = new();
         public bool UseExistingBranch { get; set; }
+        public bool UseDetached { get; set; }
+        public string FolderSuffix { get; set; } = "";
     }
-    
+
     public enum SubSessionType
     {
         CreateNew,
@@ -605,11 +681,12 @@
         SamePath,
         NewFolder
     }
-    
+
     private enum BranchSelectionMode
     {
         NewBranch,
-        ExistingBranch
+        ExistingBranch,
+        Detached
     }
 
 

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -445,6 +445,13 @@
   <data name="SubSession.BranchSelection.Label" xml:space="preserve"><value>Branch selection</value></data>
   <data name="SubSession.BranchSelection.New" xml:space="preserve"><value>New branch</value></data>
   <data name="SubSession.BranchSelection.Existing" xml:space="preserve"><value>Existing branch</value></data>
+  <data name="SubSession.BranchSelection.Detached" xml:space="preserve"><value>No branch</value></data>
+  <data name="SubSession.Detached.Help" xml:space="preserve"><value>Create a worktree with detached HEAD (no branch). Suitable for experiments or throwaway workspaces.</value></data>
+  <data name="SubSession.FolderSuffix.Label" xml:space="preserve"><value>Folder name suffix (optional)</value></data>
+  <data name="SubSession.FolderSuffix.Help" xml:space="preserve"><value>Leave empty for auto-naming. When set, the worktree folder will be named {parent}-{suffix}.</value></data>
+  <data name="SubSession.FolderSuffix.Placeholder.Default" xml:space="preserve"><value>Empty: auto-derive from branch name</value></data>
+  <data name="SubSession.FolderSuffix.Placeholder.Detached" xml:space="preserve"><value>Empty: use "detached"</value></data>
+  <data name="SubSession.FolderSuffix.Invalid" xml:space="preserve"><value>Contains invalid characters (&lt; &gt; : " / \ | ? * not allowed; cannot start with "." "-" or end with ".")</value></data>
   <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>New branch name</value></data>
   <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>A new worktree will be created for this branch</value></data>
   <data name="SubSession.ExistingBranch.Label" xml:space="preserve"><value>Select an existing branch</value></data>
@@ -548,6 +555,7 @@
   <data name="Root.Toast.SelectSessionFirst" xml:space="preserve"><value>Please select this session first, then recreate the terminal</value></data>
   <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>Terminal recreate error: {0}</value></data>
   <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' created</value></data>
+  <data name="Root.Toast.WorktreeCreatedDetached" xml:space="preserve"><value>Detached worktree created</value></data>
   <data name="Root.Toast.WorktreeAddedFormat" xml:space="preserve"><value>Existing worktree '{0}' added</value></data>
   <data name="Root.Toast.SamePathSessionCreatedFormat" xml:space="preserve"><value>New {0} session created</value></data>
   <data name="Root.Toast.NewFolderSessionCreatedFormat" xml:space="preserve"><value>New session created in folder '{0}'</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -445,8 +445,8 @@
   <data name="SubSession.BranchSelection.Label" xml:space="preserve"><value>Branch selection</value></data>
   <data name="SubSession.BranchSelection.New" xml:space="preserve"><value>New branch</value></data>
   <data name="SubSession.BranchSelection.Existing" xml:space="preserve"><value>Existing branch</value></data>
-  <data name="SubSession.BranchSelection.Detached" xml:space="preserve"><value>No branch</value></data>
-  <data name="SubSession.Detached.Help" xml:space="preserve"><value>Create a worktree with detached HEAD (no branch). Suitable for experiments or throwaway workspaces.</value></data>
+  <data name="SubSession.BranchSelection.Detached" xml:space="preserve"><value>Choose branch later</value></data>
+  <data name="SubSession.Detached.Help" xml:space="preserve"><value>Create only the worktree folder without a branch. After creation, you can switch to any branch inside the folder using git switch.</value></data>
   <data name="SubSession.FolderSuffix.Label" xml:space="preserve"><value>Folder name suffix (optional)</value></data>
   <data name="SubSession.FolderSuffix.Help" xml:space="preserve"><value>Leave empty for auto-naming. When set, the worktree folder will be named {parent}-{suffix}.</value></data>
   <data name="SubSession.FolderSuffix.Placeholder.Default" xml:space="preserve"><value>Empty: auto-derive from branch name</value></data>
@@ -555,7 +555,7 @@
   <data name="Root.Toast.SelectSessionFirst" xml:space="preserve"><value>Please select this session first, then recreate the terminal</value></data>
   <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>Terminal recreate error: {0}</value></data>
   <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' created</value></data>
-  <data name="Root.Toast.WorktreeCreatedDetached" xml:space="preserve"><value>Detached worktree created</value></data>
+  <data name="Root.Toast.WorktreeCreatedDetached" xml:space="preserve"><value>Worktree created (branch not set)</value></data>
   <data name="Root.Toast.WorktreeAddedFormat" xml:space="preserve"><value>Existing worktree '{0}' added</value></data>
   <data name="Root.Toast.SamePathSessionCreatedFormat" xml:space="preserve"><value>New {0} session created</value></data>
   <data name="Root.Toast.NewFolderSessionCreatedFormat" xml:space="preserve"><value>New session created in folder '{0}'</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -450,7 +450,7 @@
   <data name="SubSession.FolderSuffix.Label" xml:space="preserve"><value>Folder name suffix (optional)</value></data>
   <data name="SubSession.FolderSuffix.Help" xml:space="preserve"><value>Leave empty for auto-naming. When set, the worktree folder will be named {parent}-{suffix}.</value></data>
   <data name="SubSession.FolderSuffix.Placeholder.Default" xml:space="preserve"><value>Empty: auto-derive from branch name</value></data>
-  <data name="SubSession.FolderSuffix.Placeholder.Detached" xml:space="preserve"><value>Empty: use "detached"</value></data>
+  <data name="SubSession.FolderSuffix.Placeholder.Detached" xml:space="preserve"><value>Empty: auto-name as "worktree-1", etc.</value></data>
   <data name="SubSession.FolderSuffix.Invalid" xml:space="preserve"><value>Contains invalid characters (&lt; &gt; : " / \ | ? * not allowed; cannot start with "." "-" or end with ".")</value></data>
   <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>New branch name</value></data>
   <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>A new worktree will be created for this branch</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -445,8 +445,8 @@
   <data name="SubSession.BranchSelection.Label" xml:space="preserve"><value>ブランチ選択方法</value></data>
   <data name="SubSession.BranchSelection.New" xml:space="preserve"><value>新規ブランチ</value></data>
   <data name="SubSession.BranchSelection.Existing" xml:space="preserve"><value>既存ブランチ</value></data>
-  <data name="SubSession.BranchSelection.Detached" xml:space="preserve"><value>ブランチなし</value></data>
-  <data name="SubSession.Detached.Help" xml:space="preserve"><value>ブランチを作らずに detached HEAD で Worktree を作成します。試行錯誤や使い捨ての作業場に適しています。</value></data>
+  <data name="SubSession.BranchSelection.Detached" xml:space="preserve"><value>ブランチを後で選ぶ</value></data>
+  <data name="SubSession.Detached.Help" xml:space="preserve"><value>ブランチを作らず Worktree フォルダだけ作成します。作成後、フォルダ内で git switch で任意のブランチに切り替えて作業できます。</value></data>
   <data name="SubSession.FolderSuffix.Label" xml:space="preserve"><value>フォルダ名サフィックス（任意）</value></data>
   <data name="SubSession.FolderSuffix.Help" xml:space="preserve"><value>空の場合は自動で命名します。入力した場合、Worktree フォルダ名は {親フォルダ名}-{入力値} になります。</value></data>
   <data name="SubSession.FolderSuffix.Placeholder.Default" xml:space="preserve"><value>未入力ならブランチ名から自動生成</value></data>
@@ -555,7 +555,7 @@
   <data name="Root.Toast.SelectSessionFirst" xml:space="preserve"><value>このセッションを選択してからターミナルを再作成してください</value></data>
   <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>ターミナル再作成エラー: {0}</value></data>
   <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' を作成しました</value></data>
-  <data name="Root.Toast.WorktreeCreatedDetached" xml:space="preserve"><value>Worktree を detached HEAD で作成しました</value></data>
+  <data name="Root.Toast.WorktreeCreatedDetached" xml:space="preserve"><value>Worktree を作成しました（ブランチ未指定）</value></data>
   <data name="Root.Toast.WorktreeAddedFormat" xml:space="preserve"><value>既存の Worktree '{0}' を追加しました</value></data>
   <data name="Root.Toast.SamePathSessionCreatedFormat" xml:space="preserve"><value>新しい{0}セッションを作成しました</value></data>
   <data name="Root.Toast.NewFolderSessionCreatedFormat" xml:space="preserve"><value>新しいフォルダ '{0}' でセッションを作成しました</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -450,7 +450,7 @@
   <data name="SubSession.FolderSuffix.Label" xml:space="preserve"><value>フォルダ名サフィックス（任意）</value></data>
   <data name="SubSession.FolderSuffix.Help" xml:space="preserve"><value>空の場合は自動で命名します。入力した場合、Worktree フォルダ名は {親フォルダ名}-{入力値} になります。</value></data>
   <data name="SubSession.FolderSuffix.Placeholder.Default" xml:space="preserve"><value>未入力ならブランチ名から自動生成</value></data>
-  <data name="SubSession.FolderSuffix.Placeholder.Detached" xml:space="preserve"><value>未入力なら "detached" を使用</value></data>
+  <data name="SubSession.FolderSuffix.Placeholder.Detached" xml:space="preserve"><value>未入力なら "worktree-1" など連番で自動命名</value></data>
   <data name="SubSession.FolderSuffix.Invalid" xml:space="preserve"><value>使用できない文字が含まれています（&lt; &gt; : " / \ | ? * は不可、先頭の "." "-" や末尾の "." も不可）</value></data>
   <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>新しいブランチ名</value></data>
   <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>このブランチ名で新しい Worktree が作成されます</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -445,6 +445,13 @@
   <data name="SubSession.BranchSelection.Label" xml:space="preserve"><value>ブランチ選択方法</value></data>
   <data name="SubSession.BranchSelection.New" xml:space="preserve"><value>新規ブランチ</value></data>
   <data name="SubSession.BranchSelection.Existing" xml:space="preserve"><value>既存ブランチ</value></data>
+  <data name="SubSession.BranchSelection.Detached" xml:space="preserve"><value>ブランチなし</value></data>
+  <data name="SubSession.Detached.Help" xml:space="preserve"><value>ブランチを作らずに detached HEAD で Worktree を作成します。試行錯誤や使い捨ての作業場に適しています。</value></data>
+  <data name="SubSession.FolderSuffix.Label" xml:space="preserve"><value>フォルダ名サフィックス（任意）</value></data>
+  <data name="SubSession.FolderSuffix.Help" xml:space="preserve"><value>空の場合は自動で命名します。入力した場合、Worktree フォルダ名は {親フォルダ名}-{入力値} になります。</value></data>
+  <data name="SubSession.FolderSuffix.Placeholder.Default" xml:space="preserve"><value>未入力ならブランチ名から自動生成</value></data>
+  <data name="SubSession.FolderSuffix.Placeholder.Detached" xml:space="preserve"><value>未入力なら "detached" を使用</value></data>
+  <data name="SubSession.FolderSuffix.Invalid" xml:space="preserve"><value>使用できない文字が含まれています（&lt; &gt; : " / \ | ? * は不可、先頭の "." "-" や末尾の "." も不可）</value></data>
   <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>新しいブランチ名</value></data>
   <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>このブランチ名で新しい Worktree が作成されます</value></data>
   <data name="SubSession.ExistingBranch.Label" xml:space="preserve"><value>既存のブランチを選択</value></data>
@@ -548,6 +555,7 @@
   <data name="Root.Toast.SelectSessionFirst" xml:space="preserve"><value>このセッションを選択してからターミナルを再作成してください</value></data>
   <data name="Root.Toast.TerminalRecreateErrorFormat" xml:space="preserve"><value>ターミナル再作成エラー: {0}</value></data>
   <data name="Root.Toast.WorktreeCreatedFormat" xml:space="preserve"><value>Worktree '{0}' を作成しました</value></data>
+  <data name="Root.Toast.WorktreeCreatedDetached" xml:space="preserve"><value>Worktree を detached HEAD で作成しました</value></data>
   <data name="Root.Toast.WorktreeAddedFormat" xml:space="preserve"><value>既存の Worktree '{0}' を追加しました</value></data>
   <data name="Root.Toast.SamePathSessionCreatedFormat" xml:space="preserve"><value>新しい{0}セッションを作成しました</value></data>
   <data name="Root.Toast.NewFolderSessionCreatedFormat" xml:space="preserve"><value>新しいフォルダ '{0}' でセッションを作成しました</value></data>

--- a/TerminalHub/Services/GitService.cs
+++ b/TerminalHub/Services/GitService.cs
@@ -92,7 +92,7 @@ namespace TerminalHub.Services
             }
         }
 
-        public async Task<bool> CreateWorktreeAsync(string sourcePath, string branchName, string worktreePath)
+        public async Task<bool> CreateWorktreeAsync(string sourcePath, string branchName, string worktreePath, bool detach = false)
         {
             try
             {
@@ -108,26 +108,34 @@ namespace TerminalHub.Services
                     return false;
                 }
 
-                // ブランチが既に存在するかチェック
-                var branchCheckResult = await ExecuteGitCommandAsync(sourcePath, $"rev-parse --verify refs/heads/{branchName}");
-                
                 string command;
-                if (branchCheckResult.Success)
+                if (detach)
                 {
-                    // 既存のブランチを使用してWorktreeを作成
-                    command = $"worktree add \"{worktreePath}\" \"{branchName}\"";
+                    // ブランチを作らず detached HEAD で作成
+                    command = $"worktree add --detach \"{worktreePath}\"";
                 }
                 else
                 {
-                    // 新しいブランチでWorktreeを作成
-                    command = $"worktree add -b \"{branchName}\" \"{worktreePath}\"";
+                    // ブランチが既に存在するかチェック
+                    var branchCheckResult = await ExecuteGitCommandAsync(sourcePath, $"rev-parse --verify refs/heads/{branchName}");
+
+                    if (branchCheckResult.Success)
+                    {
+                        // 既存のブランチを使用してWorktreeを作成
+                        command = $"worktree add \"{worktreePath}\" \"{branchName}\"";
+                    }
+                    else
+                    {
+                        // 新しいブランチでWorktreeを作成
+                        command = $"worktree add -b \"{branchName}\" \"{worktreePath}\"";
+                    }
                 }
-                
+
                 var result = await ExecuteGitCommandAsync(sourcePath, command);
 
                 if (result.Success)
                 {
-                    _logger.LogInformation("Worktree作成成功: ブランチ={Branch}, パス={Path}", branchName, worktreePath);
+                    _logger.LogInformation("Worktree作成成功: detach={Detach}, ブランチ={Branch}, パス={Path}", detach, branchName, worktreePath);
                     return true;
                 }
                 else

--- a/TerminalHub/Services/IGitService.cs
+++ b/TerminalHub/Services/IGitService.cs
@@ -26,13 +26,14 @@ namespace TerminalHub.Services
         Task<GitInfo?> GetGitInfoAsync(string path);
 
         /// <summary>
-        /// 新しいブランチを作成してWorktreeを作成
+        /// Worktreeを作成（新規ブランチ／既存ブランチ／detached を切替）
         /// </summary>
         /// <param name="sourcePath">元のリポジトリパス</param>
-        /// <param name="branchName">新しいブランチ名</param>
+        /// <param name="branchName">ブランチ名。detach=true の場合は無視可</param>
         /// <param name="worktreePath">Worktreeのパス</param>
+        /// <param name="detach">true の場合 --detach で作成（ブランチを作らない）</param>
         /// <returns>成功した場合true</returns>
-        Task<bool> CreateWorktreeAsync(string sourcePath, string branchName, string worktreePath);
+        Task<bool> CreateWorktreeAsync(string sourcePath, string branchName, string worktreePath, bool detach = false);
 
         /// <summary>
         /// Worktreeを削除

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -623,7 +623,7 @@ namespace TerminalHub.Services
                             SessionId = Guid.NewGuid(),
                             FolderPath = existingWorktree.Path,
                             FolderName = Path.GetFileName(existingWorktree.Path),
-                            DisplayName = $"{parentSession.DisplayName} ({branchName})",
+                            DisplayName = branchName,
                             TerminalType = terminalType,
                             Options = options ?? new Dictionary<string, string>(),
                             ParentSessionId = parentSessionId
@@ -648,7 +648,15 @@ namespace TerminalHub.Services
                     parentPath = parentPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                 }
 
-                // フォルダ名サフィックスを決定: ユーザー入力 > ブランチ名 > "detached"
+                var parentName = Path.GetFileName(parentPath);
+                var parentDir = Path.GetDirectoryName(parentPath);
+                if (string.IsNullOrEmpty(parentDir))
+                {
+                    parentDir = Path.GetDirectoryName(Path.GetFullPath(parentPath)) ?? parentPath;
+                }
+
+                // フォルダ名サフィックスを決定:
+                //  ユーザー入力 > (detachedかつ未入力なら "worktree-{序数}") > ブランチ名
                 string folderSegment;
                 if (!string.IsNullOrWhiteSpace(folderSuffix))
                 {
@@ -656,7 +664,13 @@ namespace TerminalHub.Services
                 }
                 else if (detached)
                 {
-                    folderSegment = "detached";
+                    // 親階層内で未使用の "worktree-{N}" を探す
+                    int idx = 1;
+                    while (Directory.Exists(Path.Combine(parentDir, $"{parentName}-worktree-{idx}")))
+                    {
+                        idx++;
+                    }
+                    folderSegment = $"worktree-{idx}";
                 }
                 else
                 {
@@ -664,15 +678,10 @@ namespace TerminalHub.Services
                     folderSegment = branchName.Replace('/', '-').Replace('\\', '-');
                 }
 
-                var worktreeName = $"{Path.GetFileName(parentPath)}-{folderSegment}";
-                var parentDir = Path.GetDirectoryName(parentPath);
-                if (string.IsNullOrEmpty(parentDir))
-                {
-                    parentDir = Path.GetDirectoryName(Path.GetFullPath(parentPath)) ?? parentPath;
-                }
+                var worktreeName = $"{parentName}-{folderSegment}";
                 var worktreePath = Path.Combine(parentDir, worktreeName);
 
-                // 既に存在する場合は連番で別の名前を試す
+                // 念のため衝突した場合の連番フォールバック
                 int counter = 1;
                 var originalWorktreePath = worktreePath;
                 while (Directory.Exists(worktreePath))
@@ -689,14 +698,13 @@ namespace TerminalHub.Services
                     return null;
                 }
 
-                // 表示名: detached なら (detached)、それ以外は (ブランチ名)
-                var displaySuffix = detached ? "detached" : branchName;
+                // 表示名: detached モードはフォルダ末尾セグメント (worktree-1 等)、ブランチモードはブランチ名
                 var worktreeSessionInfo = new SessionInfo
                 {
                     SessionId = Guid.NewGuid(),
                     FolderPath = worktreePath,
                     FolderName = Path.GetFileName(worktreePath),
-                    DisplayName = $"{parentSession.DisplayName} ({displaySuffix})",
+                    DisplayName = detached ? folderSegment : branchName,
                     TerminalType = terminalType,
                     Options = options ?? new Dictionary<string, string>(),
                     ParentSessionId = parentSessionId

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -48,6 +48,7 @@ namespace TerminalHub.Services
         Task SaveSessionInfoAsync(SessionInfo sessionInfo);
         Task<SessionInfo?> CreateWorktreeSessionAsync(Guid parentSessionId, string branchName);
         Task<SessionInfo?> CreateWorktreeSessionAsync(Guid parentSessionId, string branchName, TerminalType terminalType, Dictionary<string, string>? options);
+        Task<SessionInfo?> CreateWorktreeSessionAsync(Guid parentSessionId, string branchName, TerminalType terminalType, Dictionary<string, string>? options, string? folderSuffix, bool detached);
         Task<SessionInfo?> CreateSamePathSessionAsync(Guid parentSessionId, string folderPath, TerminalType terminalType, Dictionary<string, string>? options);
         Task<ConPtySession?> RecreateSessionAsync(Guid sessionId, bool removeContinueOption = false);
         Task<bool> RestartSessionAsync(Guid sessionId);
@@ -582,10 +583,15 @@ namespace TerminalHub.Services
 
         public async Task<SessionInfo?> CreateWorktreeSessionAsync(Guid parentSessionId, string branchName)
         {
-            return await CreateWorktreeSessionAsync(parentSessionId, branchName, TerminalType.Terminal, null);
+            return await CreateWorktreeSessionAsync(parentSessionId, branchName, TerminalType.Terminal, null, null, false);
         }
 
         public async Task<SessionInfo?> CreateWorktreeSessionAsync(Guid parentSessionId, string branchName, TerminalType terminalType = TerminalType.Terminal, Dictionary<string, string>? options = null)
+        {
+            return await CreateWorktreeSessionAsync(parentSessionId, branchName, terminalType, options, null, false);
+        }
+
+        public async Task<SessionInfo?> CreateWorktreeSessionAsync(Guid parentSessionId, string branchName, TerminalType terminalType, Dictionary<string, string>? options, string? folderSuffix, bool detached)
         {
             try
             {
@@ -603,60 +609,70 @@ namespace TerminalHub.Services
                     return null;
                 }
 
-                // 既存のworktreeリストを取得
-                var existingWorktrees = await _gitService.GetWorktreeListAsync(parentSession.FolderPath);
-                
-                // 指定したブランチのworktreeが既に存在するかチェック
-                var existingWorktree = existingWorktrees.FirstOrDefault(w => w.BranchName == branchName);
-                if (existingWorktree != null)
+                // detached以外のときだけ、既存ブランチに紐づくworktreeを再利用
+                if (!detached)
                 {
-                    _logger.LogInformation("既存のWorktreeを使用します: ブランチ={Branch}, パス={Path}", branchName, existingWorktree.Path);
-                    
-                    // 既存のworktreeパスでセッションを作成
-                    var existingWorktreeSessionInfo = new SessionInfo
+                    var existingWorktrees = await _gitService.GetWorktreeListAsync(parentSession.FolderPath);
+                    var existingWorktree = existingWorktrees.FirstOrDefault(w => w.BranchName == branchName);
+                    if (existingWorktree != null)
                     {
-                        SessionId = Guid.NewGuid(),
-                        FolderPath = existingWorktree.Path,
-                        FolderName = Path.GetFileName(existingWorktree.Path),
-                        DisplayName = $"{parentSession.DisplayName} ({branchName})",
-                        TerminalType = terminalType,
-                        Options = options ?? new Dictionary<string, string>(),
-                        ParentSessionId = parentSessionId
-                    };
+                        _logger.LogInformation("既存のWorktreeを使用します: ブランチ={Branch}, パス={Path}", branchName, existingWorktree.Path);
 
-                    // Git情報を設定
-                    await PopulateGitInfoAsync(existingWorktreeSessionInfo);
+                        var existingWorktreeSessionInfo = new SessionInfo
+                        {
+                            SessionId = Guid.NewGuid(),
+                            FolderPath = existingWorktree.Path,
+                            FolderName = Path.GetFileName(existingWorktree.Path),
+                            DisplayName = $"{parentSession.DisplayName} ({branchName})",
+                            TerminalType = terminalType,
+                            Options = options ?? new Dictionary<string, string>(),
+                            ParentSessionId = parentSessionId
+                        };
 
-                    // SessionInfoのみを登録（ConPtyセッションは遅延初期化）
-                    _sessionInfos.TryAdd(existingWorktreeSessionInfo.SessionId, existingWorktreeSessionInfo);
-                    _initializationLocks[existingWorktreeSessionInfo.SessionId] = new SemaphoreSlim(1, 1);
+                        await PopulateGitInfoAsync(existingWorktreeSessionInfo);
 
-                    _logger.LogInformation("既存Worktreeセッション情報作成成功: ブランチ={Branch}, パス={Path}, セッションID={SessionId}", 
-                        branchName, existingWorktree.Path, existingWorktreeSessionInfo.SessionId);
+                        _sessionInfos.TryAdd(existingWorktreeSessionInfo.SessionId, existingWorktreeSessionInfo);
+                        _initializationLocks[existingWorktreeSessionInfo.SessionId] = new SemaphoreSlim(1, 1);
 
-                    return existingWorktreeSessionInfo;
+                        _logger.LogInformation("既存Worktreeセッション情報作成成功: ブランチ={Branch}, パス={Path}, セッションID={SessionId}",
+                            branchName, existingWorktree.Path, existingWorktreeSessionInfo.SessionId);
+
+                        return existingWorktreeSessionInfo;
+                    }
                 }
 
                 // Worktreeの作成先パスを決定（常に親と同じ階層に作成）
                 var parentPath = parentSession.FolderPath;
-                // 末尾のディレクトリ区切り文字を削除
                 if (parentPath.EndsWith(Path.DirectorySeparatorChar) || parentPath.EndsWith(Path.AltDirectorySeparatorChar))
                 {
                     parentPath = parentPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                 }
-                // ブランチ名の "/" はフォルダ名として不正なので "-" に置換する（feature/hoge → feature-hoge）
-                var safeBranchName = branchName.Replace('/', '-').Replace('\\', '-');
-                var worktreeName = $"{Path.GetFileName(parentPath)}-{safeBranchName}";
-                // 親ディレクトリと同じ階層に作成（親ディレクトリが取得できない場合は、親の親を使用）
+
+                // フォルダ名サフィックスを決定: ユーザー入力 > ブランチ名 > "detached"
+                string folderSegment;
+                if (!string.IsNullOrWhiteSpace(folderSuffix))
+                {
+                    folderSegment = folderSuffix.Trim();
+                }
+                else if (detached)
+                {
+                    folderSegment = "detached";
+                }
+                else
+                {
+                    // ブランチ名の "/" はフォルダ名として不正なので "-" に置換する
+                    folderSegment = branchName.Replace('/', '-').Replace('\\', '-');
+                }
+
+                var worktreeName = $"{Path.GetFileName(parentPath)}-{folderSegment}";
                 var parentDir = Path.GetDirectoryName(parentPath);
                 if (string.IsNullOrEmpty(parentDir))
                 {
-                    // ルートディレクトリの場合は、一つ上の階層を作成
                     parentDir = Path.GetDirectoryName(Path.GetFullPath(parentPath)) ?? parentPath;
                 }
                 var worktreePath = Path.Combine(parentDir, worktreeName);
 
-                // 既に存在する場合は別の名前を試す
+                // 既に存在する場合は連番で別の名前を試す
                 int counter = 1;
                 var originalWorktreePath = worktreePath;
                 while (Directory.Exists(worktreePath))
@@ -666,40 +682,39 @@ namespace TerminalHub.Services
                 }
 
                 // Worktreeを作成
-                var success = await _gitService.CreateWorktreeAsync(parentPath, branchName, worktreePath);
+                var success = await _gitService.CreateWorktreeAsync(parentPath, branchName, worktreePath, detached);
                 if (!success)
                 {
-                    _logger.LogWarning("Worktree作成に失敗しました: ブランチ={Branch}, パス={Path}", branchName, worktreePath);
+                    _logger.LogWarning("Worktree作成に失敗しました: detach={Detach}, ブランチ={Branch}, パス={Path}", detached, branchName, worktreePath);
                     return null;
                 }
 
-                // 新しいセッションを作成
+                // 表示名: detached なら (detached)、それ以外は (ブランチ名)
+                var displaySuffix = detached ? "detached" : branchName;
                 var worktreeSessionInfo = new SessionInfo
                 {
                     SessionId = Guid.NewGuid(),
                     FolderPath = worktreePath,
                     FolderName = Path.GetFileName(worktreePath),
-                    DisplayName = $"{parentSession.DisplayName} ({branchName})",
+                    DisplayName = $"{parentSession.DisplayName} ({displaySuffix})",
                     TerminalType = terminalType,
                     Options = options ?? new Dictionary<string, string>(),
                     ParentSessionId = parentSessionId
                 };
 
-                // Git情報を設定
                 await PopulateGitInfoAsync(worktreeSessionInfo);
 
-                // SessionInfoのみを登録（ConPtyセッションは遅延初期化）
                 _sessionInfos.TryAdd(worktreeSessionInfo.SessionId, worktreeSessionInfo);
                 _initializationLocks[worktreeSessionInfo.SessionId] = new SemaphoreSlim(1, 1);
 
-                _logger.LogInformation("Worktreeセッション情報作成成功: ブランチ={Branch}, パス={Path}, セッションID={SessionId}", 
-                    branchName, worktreePath, worktreeSessionInfo.SessionId);
+                _logger.LogInformation("Worktreeセッション情報作成成功: detach={Detach}, ブランチ={Branch}, パス={Path}, セッションID={SessionId}",
+                    detached, branchName, worktreePath, worktreeSessionInfo.SessionId);
 
                 return worktreeSessionInfo;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Worktreeセッション作成でエラーが発生しました: 親セッション={ParentSessionId}, ブランチ={Branch}", 
+                _logger.LogError(ex, "Worktreeセッション作成でエラーが発生しました: 親セッション={ParentSessionId}, ブランチ={Branch}",
                     parentSessionId, branchName);
                 return null;
             }


### PR DESCRIPTION
## Summary

Worktree 作成が「先にブランチありき」だった摩擦を取り除き、並列開発レーンを気軽に張れるようにする。あわせて DisplayName / 初期値復元まわりの UX を整理。

### 機能追加

- **「ブランチを後で選ぶ」モード**: SubSessionDialog のブランチ選択ラジオに 3 つ目の選択肢を追加。`git worktree add --detach` で **ブランチを介さず worktree フォルダだけ作成** → ユーザーは中で `git switch` で好きなブランチに乗り換えて作業できる。並列レーン運用向け
- **フォルダ名サフィックス（任意）入力**: 3 モード共通の入力欄。空なら自動命名（ブランチ名 or `worktree-{N}` 連番）、入力ありなら `{親フォルダ名}-{入力値}`。Windows ファイル名禁止文字バリデーション付き
- **DisplayName 簡潔化**: セッション一覧でツリー状にぶら下がるため、親プレフィックスと括弧を撤去（`親 (feature-A)` → `feature-A`）。フォルダ末尾セグメントと DisplayName が一致

### UX 改善

- **TerminalType の親引き継ぎ**: SubSessionDialog の初期 TerminalType を親セッションから引き継ぐ（Claude Code 親 → 初期も Claude Code）
- **ブランチ選択方法を LocalStorage で復元**: 直近選択を全セッション共通の単一キーで保存 (`lastBranchSelectionMode`)、次回開いたとき復元。ホワイトリスト検証付き
- **CLI モード初期値の引き継ぎ**: SessionCreateDialog が保存している直近の Claude PermissionMode / Gemini ApprovalMode / Codex 各モードを SubSessionDialog でも初期値として読み取り（読むだけ、書き戻しはしない）

### Git 用語の UI 表層からの撤去

- ラジオラベル「ブランチなし」→「ブランチを後で選ぶ」（永続感の排除）
- ヘルプ文から `detached HEAD` を排除し、機能ベースの説明へ
- detached モードの自動命名 `detached` → `worktree-{N}`
- トースト文言「Worktree を作成しました（ブランチ未指定）」

## 命名ルール一覧

| 操作 | フォルダ | DisplayName |
|---|---|---|
| 新規ブランチ \`feature-A\` | \`xxx-feature-A\` | \`feature-A\` |
| 既存ブランチ \`main\` | \`xxx-main\` | \`main\` |
| 後で選ぶ + サフィックス \`lane-a\` | \`xxx-lane-a\` | \`lane-a\` |
| 後で選ぶ + 未入力 (1 個目) | \`xxx-worktree-1\` | \`worktree-1\` |
| 後で選ぶ + 未入力 (2 個目) | \`xxx-worktree-2\` | \`worktree-2\` |

## Test plan

- [ ] 「新規ブランチ」モード: 従来通りの挙動（フォルダ名 = `{親}-{ブランチ名}`）
- [ ] 「既存ブランチ」モード: 従来通り（専有競合時の警告も維持）
- [ ] 「ブランチを後で選ぶ」モード:
  - [ ] サフィックス未入力 → `xxx-worktree-1` 作成、DisplayName `worktree-1`
  - [ ] 連続作成で `worktree-2`, `worktree-3` ... と採番
  - [ ] サフィックス入力 `lane-a` → `xxx-lane-a` / `lane-a`
  - [ ] 作成後 `git -C {新worktree} status` で `HEAD detached at ...` を確認
  - [ ] 中で `git switch feature-X` すると、セッション行の Git バッジが `feature-X` に切り替わる
- [ ] フォルダ名サフィックスのバリデーション:
  - [ ] 禁止文字 (`< > : " / \ | ? *`) で赤いエラー＋作成ボタン disable
  - [ ] 先頭 `.` / `-`、末尾 `.` も同様にエラー
- [ ] TerminalType 親引き継ぎ: Claude Code 親で SubSession ダイアログを開くと初期値が Claude Code
- [ ] ブランチ選択方法の復元: 「後で選ぶ」で作成 → ダイアログ閉じる → 再度開くと「後で選ぶ」がプリセット
- [ ] CLI モード引き継ぎ: 新規セッション作成で Claude PermissionMode を `auto` で確定 → SubSession ダイアログを開くと初期値が `auto`
- [ ] 既存の `app-settings.json` / LocalStorage を残したまま起動して見た目・挙動が崩れないこと

ConPty 関連起動の動作確認はユーザー側で実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hb4w6tKo8pj5oxxmR7PNh