### PR TITLE
feat: Gemini CLI を作成 UI から撤去、Antigravity/Grok に承認スキップ・継続オプション追加

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1043,21 +1043,25 @@
                 return;
             }
 
-            // Antigravity / Grok の -c 失敗パターン調査用ログ（リカバリは未実装）
-            // continue オプションあり & 処理開始前の出力チャンクを記録して、
-            // 「継続対象なし」時の実際のエラー文字列を観測してから検知ロジックを実装する。
-            if ((sessionInfo.TerminalType == TerminalType.Antigravity || sessionInfo.TerminalType == TerminalType.Grok) &&
+            // Grok の場合、"No session found for current directory" エラーをチェック
+            // grok -c を初回起動（該当ディレクトリに過去セッションなし）で叩いたときに出るエラーを検出し、
+            // -c なしで再起動する。Antigravity (agy) は -c を無セッションでも grace に扱うため対応不要。
+            if (sessionInfo.TerminalType == TerminalType.Grok &&
                 sessionInfo.ProcessingStartTime == null &&
+                IsCliErrorMessage(data, "No session found for current directory") &&
                 sessionInfo.Options.ContainsKey("continue") &&
                 !sessionInfo.HasContinueErrorOccurred)
             {
-                // 制御シーケンスを軽く除去して人間が読めるテキストに寄せる
-                var sanitized = System.Text.RegularExpressions.Regex.Replace(data, "\\[[0-9;?]*[A-Za-z]", "");
-                if (!string.IsNullOrWhiteSpace(sanitized))
+                sessionInfo.HasContinueErrorOccurred = true;
+
+                Logger.LogInformation("'No session found for current directory' エラーを検出しました。セッションを再作成します: SessionId={SessionId}",
+                    sessionId);
+
+                _ = InvokeAsync(async () =>
                 {
-                    Logger.LogInformation("[continue-probe] {TerminalType} 起動直後の出力: SessionId={SessionId} Data={Data}",
-                        sessionInfo.TerminalType, sessionId, sanitized.Trim());
-                }
+                    await RecreateSessionWithoutContinue(sessionId);
+                });
+                return;
             }
 
             // 処理中の場合、アニメーションパターン（スピナー文字）を検出したらタイムアウトを延長

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1043,6 +1043,23 @@
                 return;
             }
 
+            // Antigravity / Grok の -c 失敗パターン調査用ログ（リカバリは未実装）
+            // continue オプションあり & 処理開始前の出力チャンクを記録して、
+            // 「継続対象なし」時の実際のエラー文字列を観測してから検知ロジックを実装する。
+            if ((sessionInfo.TerminalType == TerminalType.Antigravity || sessionInfo.TerminalType == TerminalType.Grok) &&
+                sessionInfo.ProcessingStartTime == null &&
+                sessionInfo.Options.ContainsKey("continue") &&
+                !sessionInfo.HasContinueErrorOccurred)
+            {
+                // 制御シーケンスを軽く除去して人間が読めるテキストに寄せる
+                var sanitized = System.Text.RegularExpressions.Regex.Replace(data, "\\[[0-9;?]*[A-Za-z]", "");
+                if (!string.IsNullOrWhiteSpace(sanitized))
+                {
+                    Logger.LogInformation("[continue-probe] {TerminalType} 起動直後の出力: SessionId={SessionId} Data={Data}",
+                        sessionInfo.TerminalType, sessionId, sanitized.Trim());
+                }
+            }
+
             // 処理中の場合、アニメーションパターン（スピナー文字）を検出したらタイムアウトを延長
             // ジッター対策により、完全なステータス行ではなく部分的な更新（スピナー文字のみ）が送られることがある
             OutputAnalyzerService.CheckAnimationPatternAndResetTimer(data, sessionInfo);

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -27,15 +27,7 @@
                 </label>
             }
 
-            @if (Configuration.GetValue<bool>("ExternalTools:UseGeminiCli", true))
-            {
-                <input type="radio" class="btn-check" name="@($"terminalType{UniqueId}")" id="@($"terminalType3{UniqueId}")"
-                       checked="@(SelectedType == TerminalType.GeminiCLI)"
-                       @onchange="() => OnTerminalTypeChanged(TerminalType.GeminiCLI)" autocomplete="off">
-                <label class="btn btn-outline-primary" for="@($"terminalType3{UniqueId}")">
-                    <i class="bi bi-stars"></i> Gemini CLI
-                </label>
-            }
+            @* Gemini CLI は廃止 (enum 値は既存セッションのデシリアライズ互換のため残す) *@
 
             @if (Configuration.GetValue<bool>("ExternalTools:UseCodexCli", true))
             {
@@ -129,76 +121,6 @@
 
             <CustomCliOptionsSection Options="claudeCustomOptions" States="customOptionStates"
                                      Prefix="@($"claude{UniqueId}")" OnStateChanged="OnCustomOptionToggled" />
-        </div>
-    }
-    else if (SelectedType == TerminalType.GeminiCLI && Configuration.GetValue<bool>("ExternalTools:UseGeminiCli", true))
-    {
-        <div class="mb-3">
-            <label class="form-label">@L["SessionOptions.Gemini.Header"]</label>
-
-            <!-- Approval Mode -->
-            <div class="mt-2">
-                <label class="form-label small text-muted mb-1">@L["SessionOptions.Gemini.ApprovalMode.Label"]</label>
-                <div class="btn-group d-flex" role="group">
-                    <input type="radio" class="btn-check" name="@($"geminiApprovalMode{UniqueId}")" id="@($"geminiModeDefault{UniqueId}")"
-                           checked="@(GeminiOptions.ApprovalMode == "default")"
-                           @onchange=@(() => GeminiOptions.ApprovalMode = "default") autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"geminiModeDefault{UniqueId}")" title="@L["SessionOptions.Gemini.ApprovalMode.DefaultTitle"]">
-                        Default
-                    </label>
-
-                    <input type="radio" class="btn-check" name="@($"geminiApprovalMode{UniqueId}")" id="@($"geminiModeAutoEdit{UniqueId}")"
-                           checked="@(GeminiOptions.ApprovalMode == "auto_edit")"
-                           @onchange=@(() => GeminiOptions.ApprovalMode = "auto_edit") autocomplete="off">
-                    <label class="btn btn-outline-success btn-sm" for="@($"geminiModeAutoEdit{UniqueId}")" title="@L["SessionOptions.Gemini.ApprovalMode.AutoEditTitle"]">
-                        Auto-Edit
-                    </label>
-
-                    <input type="radio" class="btn-check" name="@($"geminiApprovalMode{UniqueId}")" id="@($"geminiModeYolo{UniqueId}")"
-                           checked="@(GeminiOptions.ApprovalMode == "yolo")"
-                           @onchange=@(() => GeminiOptions.ApprovalMode = "yolo") autocomplete="off">
-                    <label class="btn btn-outline-danger btn-sm" for="@($"geminiModeYolo{UniqueId}")" title="@L["SessionOptions.Gemini.ApprovalMode.YoloTitle"]">
-                        YOLO
-                    </label>
-                </div>
-                @if (!string.IsNullOrWhiteSpace(GetGeminiApprovalModeHelp()))
-                {
-                    <div class="form-text small mt-1">@GetGeminiApprovalModeHelp()</div>
-                }
-            </div>
-
-            <!-- Other Options -->
-            <div class="mt-3">
-                <div class="form-check">
-                    <input class="form-check-input" type="checkbox" @bind="GeminiOptions.SandboxMode" id="@($"geminiSandbox{UniqueId}")">
-                    <label class="form-check-label" for="@($"geminiSandbox{UniqueId}")">
-                        @L["SessionOptions.Gemini.Sandbox"]
-                    </label>
-                    <div class="form-text text-muted small mt-0">
-                        <i class="bi bi-info-circle"></i> @L["SessionOptions.Gemini.SandboxHelp"]
-                    </div>
-                </div>
-
-                @if (!DisableContinueOption)
-                {
-                    <div class="form-check mt-2">
-                        <input class="form-check-input" type="checkbox" @bind="GeminiOptions.Continue" id="@($"geminiContinue{UniqueId}")">
-                        <label class="form-check-label" for="@($"geminiContinue{UniqueId}")">
-                            @L["SessionOptions.Gemini.Continue"]
-                        </label>
-                    </div>
-                }
-            </div>
-
-            <div class="mt-3">
-                <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
-                <input type="text" class="form-control form-control-sm" @bind="GeminiOptions.ExtraArgs"
-                       placeholder="@L["SessionOptions.Gemini.ExtraArgsPlaceholder"]" />
-                <div class="form-text small">@L["SessionOptions.Gemini.PassToCli"]</div>
-            </div>
-
-            <CustomCliOptionsSection Options="geminiCustomOptions" States="customOptionStates"
-                                     Prefix="@($"gemini{UniqueId}")" OnStateChanged="OnCustomOptionToggled" />
         </div>
     }
     else if (SelectedType == TerminalType.CodexCLI && Configuration.GetValue<bool>("ExternalTools:UseCodexCli", true))
@@ -336,6 +258,28 @@
             <div class="form-text small mb-2">@L["SessionOptions.Antigravity.Help"]</div>
 
             <div class="mt-2">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" @bind="AntigravityOptions.SkipPermissions" id="@($"antigravitySkip{UniqueId}")">
+                    <label class="form-check-label" for="@($"antigravitySkip{UniqueId}")">
+                        @L["SessionOptions.Antigravity.SkipPermissions"]
+                    </label>
+                    <div class="form-text text-muted small mt-0">
+                        <i class="bi bi-info-circle"></i> @L["SessionOptions.Antigravity.SkipPermissionsHelp"]
+                    </div>
+                </div>
+
+                @if (!DisableContinueOption)
+                {
+                    <div class="form-check mt-2">
+                        <input class="form-check-input" type="checkbox" @bind="AntigravityOptions.Continue" id="@($"antigravityContinue{UniqueId}")">
+                        <label class="form-check-label" for="@($"antigravityContinue{UniqueId}")">
+                            @L["SessionOptions.Antigravity.Continue"]
+                        </label>
+                    </div>
+                }
+            </div>
+
+            <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="AntigravityOptions.ExtraArgs"
                        placeholder="@L["SessionOptions.Antigravity.ExtraArgsPlaceholder"]" />
@@ -353,6 +297,28 @@
             <div class="form-text small mb-2">@L["SessionOptions.Grok.Help"]</div>
 
             <div class="mt-2">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" @bind="GrokOptions.AlwaysApprove" id="@($"grokApprove{UniqueId}")">
+                    <label class="form-check-label" for="@($"grokApprove{UniqueId}")">
+                        @L["SessionOptions.Grok.AlwaysApprove"]
+                    </label>
+                    <div class="form-text text-muted small mt-0">
+                        <i class="bi bi-info-circle"></i> @L["SessionOptions.Grok.AlwaysApproveHelp"]
+                    </div>
+                </div>
+
+                @if (!DisableContinueOption)
+                {
+                    <div class="form-check mt-2">
+                        <input class="form-check-input" type="checkbox" @bind="GrokOptions.Continue" id="@($"grokContinue{UniqueId}")">
+                        <label class="form-check-label" for="@($"grokContinue{UniqueId}")">
+                            @L["SessionOptions.Grok.Continue"]
+                        </label>
+                    </div>
+                }
+            </div>
+
+            <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
                 <input type="text" class="form-control form-control-sm" @bind="GrokOptions.ExtraArgs"
                        placeholder="@L["SessionOptions.Grok.ExtraArgsPlaceholder"]" />
@@ -582,6 +548,14 @@
                 break;
 
             case TerminalType.Antigravity:
+                if (AntigravityOptions.SkipPermissions)
+                {
+                    options["skip-permissions"] = "true";
+                }
+                if (AntigravityOptions.Continue && !DisableContinueOption)
+                {
+                    options["continue"] = "true";
+                }
                 if (!string.IsNullOrWhiteSpace(AntigravityOptions.ExtraArgs))
                 {
                     options["extra-args"] = AntigravityOptions.ExtraArgs.Trim();
@@ -589,6 +563,14 @@
                 break;
 
             case TerminalType.Grok:
+                if (GrokOptions.AlwaysApprove)
+                {
+                    options["always-approve"] = "true";
+                }
+                if (GrokOptions.Continue && !DisableContinueOption)
+                {
+                    options["continue"] = "true";
+                }
                 if (!string.IsNullOrWhiteSpace(GrokOptions.ExtraArgs))
                 {
                     options["extra-args"] = GrokOptions.ExtraArgs.Trim();
@@ -636,11 +618,15 @@
 
     public class AntigravityOptionsData
     {
+        public bool Continue { get; set; } = true;
+        public bool SkipPermissions { get; set; } = false; // --dangerously-skip-permissions
         public string ExtraArgs { get; set; } = "";
     }
 
     public class GrokOptionsData
     {
+        public bool Continue { get; set; } = true;
+        public bool AlwaysApprove { get; set; } = false; // --always-approve
         public string ExtraArgs { get; set; } = "";
     }
     

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -549,7 +549,8 @@
                                     @L["Settings.Commands.Help"]
                                 </small>
 
-                                @foreach (var terminalType in new[] { "Terminal", "ClaudeCode", "GeminiCLI", "CodexCLI", "Antigravity", "Grok" })
+                                @* Gemini CLI は廃止 (タブ非表示、ただし内部の編集データは保全) *@
+                                @foreach (var terminalType in new[] { "Terminal", "ClaudeCode", "CodexCLI", "Antigravity", "Grok" })
                                 {
                                     var type = terminalType;
                                     var displayName = GetTerminalTypeDisplayName(type);

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -107,34 +107,7 @@ namespace TerminalHub.Constants
             return string.Join(" ", args);
         }
 
-        public static string BuildGeminiArgs(Dictionary<string, string> options)
-        {
-            var args = new List<string>();
-
-            if (options.TryGetValue("approval-mode", out var mode) && mode != "default")
-            {
-                args.Add($"--approval-mode {mode}");
-            }
-
-            if (options.ContainsKey("sandbox") && options["sandbox"] == "true")
-            {
-                args.Add("-s");
-            }
-
-            if (options.ContainsKey("continue") && options["continue"] == "true")
-            {
-                args.Add("--resume latest");
-            }
-
-            if (options.TryGetValue("extra-args", out var extraArgs) && !string.IsNullOrWhiteSpace(extraArgs))
-            {
-                args.Add(extraArgs);
-            }
-
-            AppendCustomArgs(args, options);
-
-            return string.Join(" ", args);
-        }
+        // BuildGeminiArgs は廃止 (GeminiCLI 起動経路は撤去済み)
 
         public static string BuildCodexArgs(Dictionary<string, string> options)
         {
@@ -200,11 +173,20 @@ namespace TerminalHub.Constants
             return string.Join(" ", args);
         }
 
-        // Antigravity CLI (agy) は今のところ TerminalHub 側で公式オプションを解釈しない。
-        // ユーザーが extra-args / custom-args で自由に渡せるようにするだけの最小サポート。
+        // Antigravity CLI (agy): 承認スキップと会話継続を Claude/Codex と同じ形で扱う。
         public static string BuildAntigravityArgs(Dictionary<string, string> options)
         {
             var args = new List<string>();
+
+            if (options.ContainsKey("skip-permissions") && options["skip-permissions"] == "true")
+            {
+                args.Add("--dangerously-skip-permissions");
+            }
+
+            if (options.ContainsKey("continue") && options["continue"] == "true")
+            {
+                args.Add("-c");
+            }
 
             if (options.TryGetValue("extra-args", out var extraArgs) && !string.IsNullOrWhiteSpace(extraArgs))
             {
@@ -216,10 +198,21 @@ namespace TerminalHub.Constants
             return string.Join(" ", args);
         }
 
-        // Grok CLI も同様に最小サポート。認証は環境変数 GROK_CODE_XAI_API_KEY か初回ブラウザ OAuth に任せる。
+        // Grok CLI: --always-approve で承認スキップ、--continue で直近会話の継続。
+        // 認証は環境変数 GROK_CODE_XAI_API_KEY か初回ブラウザ OAuth に任せる。
         public static string BuildGrokArgs(Dictionary<string, string> options)
         {
             var args = new List<string>();
+
+            if (options.ContainsKey("always-approve") && options["always-approve"] == "true")
+            {
+                args.Add("--always-approve");
+            }
+
+            if (options.ContainsKey("continue") && options["continue"] == "true")
+            {
+                args.Add("-c");
+            }
 
             if (options.TryGetValue("extra-args", out var extraArgs) && !string.IsNullOrWhiteSpace(extraArgs))
             {

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -397,13 +397,19 @@
 
   <!-- Antigravity CLI Options -->
   <data name="SessionOptions.Antigravity.Header" xml:space="preserve"><value>Antigravity (agy) options</value></data>
-  <data name="SessionOptions.Antigravity.Help" xml:space="preserve"><value>TerminalHub does not yet parse Antigravity-specific options. Type any args you need into the field below.</value></data>
+  <data name="SessionOptions.Antigravity.Help" xml:space="preserve"><value>Type any extra args you need into the field below.</value></data>
+  <data name="SessionOptions.Antigravity.SkipPermissions" xml:space="preserve"><value>Skip approvals (--dangerously-skip-permissions)</value></data>
+  <data name="SessionOptions.Antigravity.SkipPermissionsHelp" xml:space="preserve"><value>Auto-approve all tool permission prompts (YOLO-equivalent).</value></data>
+  <data name="SessionOptions.Antigravity.Continue" xml:space="preserve"><value>Continue last conversation (-c)</value></data>
   <data name="SessionOptions.Antigravity.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --help</value></data>
   <data name="SessionOptions.Antigravity.PassToCli" xml:space="preserve"><value>Passed as-is to agy</value></data>
 
   <!-- Grok CLI Options -->
   <data name="SessionOptions.Grok.Header" xml:space="preserve"><value>Grok CLI options</value></data>
-  <data name="SessionOptions.Grok.Help" xml:space="preserve"><value>TerminalHub does not yet parse Grok-specific options. Auth is left to the GROK_CODE_XAI_API_KEY env var or first-run browser OAuth.</value></data>
+  <data name="SessionOptions.Grok.Help" xml:space="preserve"><value>Auth is left to the GROK_CODE_XAI_API_KEY env var or first-run browser OAuth.</value></data>
+  <data name="SessionOptions.Grok.AlwaysApprove" xml:space="preserve"><value>Skip approvals (--always-approve)</value></data>
+  <data name="SessionOptions.Grok.AlwaysApproveHelp" xml:space="preserve"><value>Skip interactive approval prompts (intended for CI; use with care).</value></data>
+  <data name="SessionOptions.Grok.Continue" xml:space="preserve"><value>Continue last conversation (-c)</value></data>
   <data name="SessionOptions.Grok.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --help</value></data>
   <data name="SessionOptions.Grok.PassToCli" xml:space="preserve"><value>Passed as-is to grok</value></data>
 

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -397,13 +397,19 @@
 
   <!-- Antigravity CLI Options -->
   <data name="SessionOptions.Antigravity.Header" xml:space="preserve"><value>Antigravity (agy) オプション</value></data>
-  <data name="SessionOptions.Antigravity.Help" xml:space="preserve"><value>現時点では TerminalHub 側で公式オプションを解析しません。必要な引数は下の欄に直接入力してください。</value></data>
+  <data name="SessionOptions.Antigravity.Help" xml:space="preserve"><value>必要な追加引数は下の欄に直接入力してください。</value></data>
+  <data name="SessionOptions.Antigravity.SkipPermissions" xml:space="preserve"><value>承認をスキップ (--dangerously-skip-permissions)</value></data>
+  <data name="SessionOptions.Antigravity.SkipPermissionsHelp" xml:space="preserve"><value>全てのツール承認プロンプトを自動で許可します（YOLO 相当）。</value></data>
+  <data name="SessionOptions.Antigravity.Continue" xml:space="preserve"><value>直近の会話を継続する (-c)</value></data>
   <data name="SessionOptions.Antigravity.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --help</value></data>
   <data name="SessionOptions.Antigravity.PassToCli" xml:space="preserve"><value>そのまま agy に渡します</value></data>
 
   <!-- Grok CLI Options -->
   <data name="SessionOptions.Grok.Header" xml:space="preserve"><value>Grok CLI オプション</value></data>
-  <data name="SessionOptions.Grok.Help" xml:space="preserve"><value>現時点では TerminalHub 側で公式オプションを解析しません。認証は環境変数 GROK_CODE_XAI_API_KEY か初回ブラウザ OAuth に任せます。</value></data>
+  <data name="SessionOptions.Grok.Help" xml:space="preserve"><value>認証は環境変数 GROK_CODE_XAI_API_KEY か初回ブラウザ OAuth に任せます。</value></data>
+  <data name="SessionOptions.Grok.AlwaysApprove" xml:space="preserve"><value>承認をスキップ (--always-approve)</value></data>
+  <data name="SessionOptions.Grok.AlwaysApproveHelp" xml:space="preserve"><value>対話的な承認プロンプトをスキップします（CI 用途向け、注意して使用）。</value></data>
+  <data name="SessionOptions.Grok.Continue" xml:space="preserve"><value>直近の会話を継続する (-c)</value></data>
   <data name="SessionOptions.Grok.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --help</value></data>
   <data name="SessionOptions.Grok.PassToCli" xml:space="preserve"><value>そのまま grok に渡します</value></data>
 

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -186,12 +186,7 @@ namespace TerminalHub.Services
                         return ("cmd.exe", args);
                     }
 
-                case TerminalType.GeminiCLI:
-                    var geminiArgs = TerminalConstants.BuildGeminiArgs(options);
-                    var geminiArgsString = string.IsNullOrWhiteSpace(geminiArgs)
-                        ? "/k gemini"
-                        : $"/k gemini {geminiArgs}";
-                    return ("cmd.exe", geminiArgsString);
+                // GeminiCLI は廃止: 既存セッションは default 分岐で通常ターミナルとして起動する
 
                 case TerminalType.CodexCLI:
                     var codexArgs = TerminalConstants.BuildCodexArgs(options);
@@ -287,7 +282,6 @@ namespace TerminalHub.Services
                 string errorMessage = terminalType switch
                 {
                     TerminalType.ClaudeCode => $"Claude Codeの起動に失敗しました。Claude Codeがインストールされているか確認してください。",
-                    TerminalType.GeminiCLI => $"Gemini CLIの起動に失敗しました。Gemini CLIがインストールされているか確認してください。",
                     TerminalType.CodexCLI => $"Codex CLIの起動に失敗しました。Codex CLIがインストールされているか確認してください。",
                     TerminalType.Antigravity => $"Antigravity CLI (agy) の起動に失敗しました。インストールされているか確認してください。",
                     TerminalType.Grok => $"Grok CLI (grok) の起動に失敗しました。インストールされているか確認してください。",
@@ -756,7 +750,6 @@ namespace TerminalHub.Services
                 sessionInfo.DisplayName = terminalType switch
                 {
                     TerminalType.ClaudeCode => $"{sessionInfo.FolderName} (Claude)",
-                    TerminalType.GeminiCLI => $"{sessionInfo.FolderName} (Gemini)",
                     TerminalType.CodexCLI => $"{sessionInfo.FolderName} (Codex)",
                     TerminalType.Antigravity => $"{sessionInfo.FolderName} (Antigravity)",
                     TerminalType.Grok => $"{sessionInfo.FolderName} (Grok)",


### PR DESCRIPTION
## Summary

セッション作成 UI から Gemini CLI を撤去（既存セッションのデシリアライズ互換のため enum 値は残す）。
あわせて Antigravity / Grok に「承認スキップ」と「直近の会話を継続」のチェックボックスを Claude/Codex と同じ形で追加。

### Gemini CLI 撤去 (ソフト)

- `TerminalType.GeminiCLI` enum と `GeminiOptionsData` クラス、`CustomCliOptionsSettings.GeminiCLI` フィールドは保持 (既存 `app-settings.json` のデシリアライズ事故を防ぐ)
- `SessionOptionsSelector.razor` から Gemini ラジオボタンと設定パネルを削除
- `SessionManager.cs` の Gemini 起動分岐 / 表示名サフィックス / エラーメッセージケースを削除。既存 Gemini 型セッションは default 分岐で通常ターミナル起動する
- `SettingsDialog.razor` のカスタムコマンド Gemini タブを非表示 (タブ生成ループから除外、ロード/セーブパスは維持してデータ保全)
- `TerminalConstants.BuildGeminiArgs` を撤去 (呼出元なし)

### Antigravity オプション追加

- **承認スキップ**: `--dangerously-skip-permissions` (YOLO 相当)
- **直近の会話を継続**: `-c`

### Grok オプション追加

- **承認スキップ**: `--always-approve`
- **直近の会話を継続**: `-c`

両者とも `AntigravityOptionsData` / `GrokOptionsData` にプロパティ追加。`Continue=true` デフォルト、承認スキップは `false` デフォルト (誤爆防止)。\`SubSession\`/\`SessionCreate\` ダイアログで Claude と同じく \`DisableContinueOption\` パラメータが効く。

### 範囲外 (検討してスコープ外と判断)

- Antigravity の `--conversation <id>` / Grok の `--resume <session-id>` 高度な復元機能 → ID 指定 UI が必要なので別途
- Gemini enum 値の完全削除 → 既存ユーザの JSON デシリアライズ事故リスクと天秤、保守的に温存

## Test plan

- [ ] セッション作成ダイアログのターミナルタイプから Gemini が消えていること
- [ ] 設定 → カスタムコマンドのタブから Gemini が消えていること
- [ ] **既存 Gemini 型セッション**が `app-settings.json` にある場合、起動時に通常ターミナルとして起動する（クラッシュ・ロード失敗しない）
- [ ] Antigravity セッション作成時:
  - [ ] 「承認をスキップ」を ON → 起動引数に \`--dangerously-skip-permissions\` が乗る
  - [ ] 「直近の会話を継続する」を ON → 起動引数に \`-c\` が乗る (デフォルト ON)
  - [ ] SubSessionDialog では \`Continue\` が \`DisableContinueOption\` で抑止される
- [ ] Grok セッション作成時:
  - [ ] 「承認をスキップ」を ON → 起動引数に \`--always-approve\` が乗る
  - [ ] 「直近の会話を継続する」を ON → 起動引数に \`-c\` が乗る (デフォルト ON)

ConPty 関連の起動動作確認はユーザー側で実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hb4w6tKo8pj5oxxmR7PNh