### PR TITLE
chore: SQLitePCLRaw を 3.x に上書きして CVE-2025-6965 警告を解消

### DIFF
--- a/TerminalHub/TerminalHub.csproj
+++ b/TerminalHub/TerminalHub.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
+    <!-- CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) を回避するため、SQLitePCLRaw を 3.x にオーバーライド -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />


### PR DESCRIPTION
## Summary

ビルド時の NU1903 警告（SQLitePCLRaw.lib.e_sqlite3 2.1.11 = CVE-2025-6965 / GHSA-2m69-gcr7-jv3q）を解消する。

### 背景

- Microsoft.Data.Sqlite 10.0.2 が transitive で SQLitePCLRaw 2.1.11 を引っ張る
- SQLitePCLRaw.lib.e_sqlite3 2.1.11 に SQLite aggregate term 処理のメモリ破損脆弱性
- 公式アドバイザリには **パッチ版なし**。パッケージ ID 自体が \`SourceGear.sqlite3\` にリネーム移行中

### 対応

\`SQLitePCLRaw.bundle_e_sqlite3\` 3.0.3 を csproj に明示参照することで、依存解決を 3.x ライン (\`SourceGear.sqlite3\` 3.50.4.5) に切替。

### Before / After

| パッケージ | Before | After |
|---|---|---|
| \`SQLitePCLRaw.bundle_e_sqlite3\` | 2.1.11 (transitive) | **3.0.3** (explicit) |
| \`SQLitePCLRaw.core\` | 2.1.11 | **3.0.3** |
| \`SQLitePCLRaw.provider.e_sqlite3\` | 2.1.11 | **3.0.3** |
| \`SQLitePCLRaw.lib.e_sqlite3\` 2.1.11 | 依存あり（脆弱） | **依存ツリーから消滅** → \`SourceGear.sqlite3 3.50.4.5\` に置換 |
| \`Microsoft.Data.Sqlite\` | 10.0.2 | 10.0.2（変更なし） |

ビルド結果: **0 警告 / 0 エラー**（NU1903 消滅）

## 動作確認 (ローカル実機)

- [x] アプリ起動時のセッションのロード／セーブ
- [x] 再起動後、変更が保持されていること（SessionRepository / SessionMemoRepository の DB ラウンドトリップ確認）

## Test plan

- [x] \`dotnet build\` が 0 警告 / 0 エラー
- [x] SQLite 関連 4 ファイル (\`SessionDbContext\` / \`SessionRepository\` / \`SessionMemoRepository\` / \`SessionMemoSnapshotRepository\`) の起動時マイグレーション
- [x] セッション CRUD ラウンドトリップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hb4w6tKo8pj5oxxmR7PNh