### PR TITLE
feat: workflow_dispatch で先行テスト版インストーラーを Artifact 配布

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,10 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           else
-            # workflow_dispatch 時はコミット SHA で識別可能なバージョン文字列にする
-            SHORT_SHA="${GITHUB_SHA:0:7}"
-            echo "VERSION=0.0.0-preview-${SHORT_SHA}" >> $GITHUB_OUTPUT
+            # workflow_dispatch 時は csproj の現行バージョンを読み取って使用
+            # （ビルドコミットは Actions の実行ページから辿れるため、suffix は付けない）
+            BASE=$(grep -oP '(?<=<Version>)[^<]+' TerminalHub/TerminalHub.csproj | head -1)
+            echo "VERSION=${BASE}" >> $GITHUB_OUTPUT
           fi
 
       - name: Update version in installer script

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,12 @@ on:
   push:
     tags:
       - 'v*'  # v1.0.0 などのタグがプッシュされたときに実行
-  workflow_dispatch:  # 手動実行用（ビルド確認のみ、リリース作成なし）
+  workflow_dispatch:  # 手動実行用（先行テスト版ビルド: GitHub Release は作らず Artifact のみ保存）
+    inputs:
+      build_installer:
+        description: 'Inno Setup インストーラー .exe も生成する'
+        type: boolean
+        default: true
 
 permissions:
   contents: write  # リリース作成に必要
@@ -29,11 +34,13 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           else
-            echo "VERSION=0.0.0-dev" >> $GITHUB_OUTPUT
+            # workflow_dispatch 時はコミット SHA で識別可能なバージョン文字列にする
+            SHORT_SHA="${GITHUB_SHA:0:7}"
+            echo "VERSION=0.0.0-preview-${SHORT_SHA}" >> $GITHUB_OUTPUT
           fi
 
       - name: Update version in installer script
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.build_installer == true
         shell: pwsh
         run: |
           $version = "${{ steps.get_version.outputs.VERSION }}"
@@ -63,7 +70,7 @@ jobs:
         run: dotnet publish TerminalHub/TerminalHub.csproj -c Release -r win-x64 --self-contained true -o ./publish /p:Version=${{ steps.get_version.outputs.VERSION }}
 
       - name: Install Inno Setup
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.build_installer == true
         shell: pwsh
         run: |
           # Inno Setupをダウンロード
@@ -75,7 +82,7 @@ jobs:
           Start-Process -FilePath $output -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-" -Wait
 
       - name: Build installer
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.build_installer == true
         shell: pwsh
         run: |
           # 出力ディレクトリを作成
@@ -84,12 +91,19 @@ jobs:
           # Inno Setupでビルド
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" "installer/TerminalHub.iss"
 
-      - name: Upload build artifact
+      - name: Upload build artifact (publish output)
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         uses: actions/upload-artifact@v4
         with:
           name: TerminalHub-dev-build
           path: ./publish/
+
+      - name: Upload installer artifact (workflow_dispatch のみ)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') && inputs.build_installer == true }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: TerminalHub-installer-preview
+          path: installer/output/*.exe
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary

Actions タブの **Run workflow** ボタンから手動実行で、Inno Setup インストーラー .exe を含むビルド成果物を **Workflow Artifact** として配布できるようにする。

### 動機

タグも作らず Release も作らず Discord 通知も飛ばさず、書込権限保持者だけが取れる先行テスト版が欲しい。Pre-release バッジ付きで公開する semver suffix 方式より、運用が軽い。

### 変更点

- `workflow_dispatch` に `build_installer` 入力 (boolean, デフォルト `true`) を追加
- インストーラー関連ステップ (Update version / Install Inno Setup / Build installer) の `if:` 条件を `startsWith(github.ref, 'refs/tags/v') || inputs.build_installer == true` に拡張
- 手動実行時のバージョン文字列は **csproj の `<Version>` をそのまま使用** (例: `1.0.59`)。Inno Setup の AppVersion / VS_VERSIONINFO 互換を保つため semver suffix は付けない
- どのコミットのビルドかは **Actions の実行ページ** (Run details に commit SHA が表示される) から辿る
- 新規 Artifact `TerminalHub-installer-preview` にインストーラー .exe を upload (90 日保持)
- `Create Release` ステップはタグ時のみのまま維持 (手動実行で誤ってリリース化されない)

### 使い方

1. Actions タブ → "Build and Release" → **Run workflow**
2. ブランチを指定 (master 以外でも可)
3. "Inno Setup インストーラー .exe も生成する" は ON のまま
4. **Run workflow** クリック
5. 完了後、ワークフローの実行ページに `TerminalHub-installer-preview` Artifact が出る
6. ダウンロード → ローカルで実行

### 注意点

- インストーラーのファイル名は `TerminalHub-Setup-<csproj バージョン>.exe`。タグ release の同バージョンと同名になる可能性がある
- ビルド対象コミットは Artifact ではなく Actions の実行ページ (Run #N の commit リンク) から確認する

## Test plan

- [ ] このブランチを master にマージ後、Actions タブから手動実行
- [ ] `TerminalHub-installer-preview` Artifact がダウンロード可能
- [ ] .exe を実行してインストール → 起動確認
- [ ] csproj の `<Version>` 値がインストーラーのバージョンに反映されていること (Windows ファイルプロパティで確認可)
- [ ] タグ push (`vX.X.X`) 経由の通常リリースは引き続き正常に動くこと (回帰テスト)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hb4w6tKo8pj5oxxmR7PNh