### PR TITLE
fix: xterm.js を @xterm/* スコープ版 5.5.0 に更新（全角行の消し残り対策）

### DIFF
--- a/TerminalHub/Components/App.razor
+++ b/TerminalHub/Components/App.razor
@@ -27,13 +27,13 @@
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["TerminalHub.styles.css"]" />
 
-    <!-- xterm.js -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" />
-    <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.9.0/lib/xterm-addon-web-links.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/xterm-addon-unicode11@0.6.0/lib/xterm-addon-unicode11.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/xterm-addon-canvas@0.5.0/lib/xterm-addon-canvas.js"></script>
+    <!-- xterm.js (@xterm/* スコープ版に移行。グローバル名は従来と同一: Terminal / FitAddon.FitAddon / WebLinksAddon.WebLinksAddon / Unicode11Addon.Unicode11Addon / CanvasAddon.CanvasAddon) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@xterm/xterm@5.5.0/css/xterm.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@@xterm/xterm@5.5.0/lib/xterm.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-fit@0.10.0/lib/addon-fit.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-web-links@0.11.0/lib/addon-web-links.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-unicode11@0.8.0/lib/addon-unicode11.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-canvas@0.7.0/lib/addon-canvas.js"></script>
 
 
     <ImportMap />


### PR DESCRIPTION
## 概要

xterm.js を旧 `xterm@5.3.0`（非スコープ・約2年前）から、リネーム後の `@xterm/xterm@5.5.0` とアドオン群へ更新します。

## 背景 / 動機

従来レンダラーで**全角文字を含む行がスクロール・再描画される際に、行頭の全角グリフ（例:「名」）が1つだけ消し残る**アーティファクトが発生していました。

ダウンロードした生バッファ（`GetTerminalBuffer()` = ConPTY 出力をそのまま連結したもの＝xterm.js へ渡す生データ）を解析した結果:

- データ上「名」が**単独で書かれる箇所は0件**、常に「名前」としてまとまって正しく送られている
- TerminalHub / ConPTY 側のデータ破損ではなく、**xterm.js の描画側で全角先頭セルが消し残る**挙動と判断

5.4 / 5.5 に含まれる reflow・全角まわりの修正で改善を狙います。

## 変更内容

| パッケージ | 旧 | 新 |
|---|---|---|
| 本体 | `xterm@5.3.0` | `@xterm/xterm@5.5.0` |
| fit | `xterm-addon-fit@0.8.0` | `@xterm/addon-fit@0.10.0` |
| web-links | `xterm-addon-web-links@0.9.0` | `@xterm/addon-web-links@0.11.0` |
| unicode11 | `xterm-addon-unicode11@0.6.0` | `@xterm/addon-unicode11@0.8.0` |
| canvas | `xterm-addon-canvas@0.5.0` | `@xterm/addon-canvas@0.7.0` |

## 実装メモ

- スコープ版の UMD グローバル名は従来と同一（`Terminal` / `FitAddon.FitAddon` / `WebLinksAddon.WebLinksAddon` / `Unicode11Addon.Unicode11Addon` / `CanvasAddon.CanvasAddon`）のため **`terminal.js` は無修正**。
- 本体を 6.0.0 ではなく **5.5.0** にしたのは、canvas アドオン（block文字描画に使用）の最新 0.7.0 が peer `^5.0.0` 止まりで 6.0 非対応のため。全アドオン互換が取れる 5.5.0 を選択。
- Razor の `@` トランジションと衝突するため、href 内のパッケージ名は `@@xterm` でエスケープ（レンダリング後は `@xterm`）。

## 確認

- [x] `dotnet build` 成功
- [x] 全 CDN URL の 200 到達確認
- [x] ローカル起動で通常動作を確認（入出力・アドオン読込）
- [ ] 全角行スクロール時の消し残りが解消するか（常用で検証予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)