### PR TITLE
feat: xterm.js を 6.0.0 に更新し Canvas→WebGL レンダラーへ移行

### DIFF
--- a/TerminalHub/Components/App.razor
+++ b/TerminalHub/Components/App.razor
@@ -27,13 +27,14 @@
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["TerminalHub.styles.css"]" />
 
-    <!-- xterm.js (@xterm/* スコープ版に移行。グローバル名は従来と同一: Terminal / FitAddon.FitAddon / WebLinksAddon.WebLinksAddon / Unicode11Addon.Unicode11Addon / CanvasAddon.CanvasAddon) -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@xterm/xterm@5.5.0/css/xterm.css" />
-    <script src="https://cdn.jsdelivr.net/npm/@@xterm/xterm@5.5.0/lib/xterm.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-fit@0.10.0/lib/addon-fit.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-web-links@0.11.0/lib/addon-web-links.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-unicode11@0.8.0/lib/addon-unicode11.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-canvas@0.7.0/lib/addon-canvas.js"></script>
+    <!-- xterm.js 6.0.0（@xterm/* スコープ版）。グローバル名は従来と同一: Terminal / FitAddon.FitAddon / WebLinksAddon.WebLinksAddon / Unicode11Addon.Unicode11Addon / WebglAddon.WebglAddon
+         6.0 で Canvas レンダラーアドオンが廃止されたため、addon-canvas → addon-webgl（GPU描画）へ移行。 -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@xterm/xterm@6.0.0/css/xterm.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@@xterm/xterm@6.0.0/lib/xterm.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-fit@0.11.0/lib/addon-fit.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-web-links@0.12.0/lib/addon-web-links.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-unicode11@0.9.0/lib/addon-unicode11.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@xterm/addon-webgl@0.19.0/lib/addon-webgl.js"></script>
 
 
     <ImportMap />

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -133,7 +133,7 @@
                              style="display: @(session.SessionId == activeSessionId ? "block" : "none");"></div>
                     }
                 </div>
-                @* xterm の描画が CanvasAddon の不整合で崩れた際の救済用フローティングボタン。
+                @* xterm の描画が WebglAddon の不整合（コンテキスト喪失・スリープ復帰等）で崩れた際の救済用フローティングボタン。
                    通常はほぼ透明、hover で出現する控えめな存在感を狙う。 *@
                 @if (activeSessionId != null)
                 {

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -174,7 +174,7 @@ function setupUrlDetectionFallback(term) {
     // HTTP/HTTPSのURLパターン
     const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
     
-    // xterm.js v5用のregisterLinkProvider実装
+    // registerLinkProvider による手動リンクプロバイダー登録（xterm.js 6.0 でも利用可能）
     if (typeof term.registerLinkProvider === 'function') {
         const linkProvider = {
             provideLinks: (bufferLineNumber, callback) => {
@@ -392,7 +392,7 @@ window.terminalFunctions = {
             // xterm.js 6.0 で windowsMode は廃止。ConPTY 前提の Windows ヒューリスティクスは windowsPty で指定する。
             // buildNumber 未指定（= reflow無効・非空白終端行を折返し扱い）で旧 windowsMode: true 相当の挙動を維持。
             windowsPty: { backend: 'conpty' },
-            allowProposedApi: true  // 提案中のAPIを許可（スクロールバック保持のため）
+            allowProposedApi: true  // 提案中のAPIを許可（windowsPty・スクロールバック保持等で必要）
         });
         
         // FitAddonを使う
@@ -766,7 +766,7 @@ window.terminalFunctions = {
                             terminal.appendChild(termObj.terminal.element);
                         }
                         
-                        // Canvas描画の復元（スリープ復帰等でコンテキストが失われた場合の対策）
+                        // 表示復帰時の再描画トリガー（WebGL コンテキスト喪失時は onContextLoss で DOM レンダラーへフォールバック済み。ここではサイズ同期のみ）
                         // fit()でサイズが変わった場合はonResizeイベント経由でC#側にログが記録される
                         if (termObj.fitAddon) {
                             termObj.fitAddon.fit();

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -389,7 +389,9 @@ window.terminalFunctions = {
             cols: 120,  // 固定列数
             rows: 30,   // 固定行数
             convertEol: true,
-            windowsMode: true,  // Windows環境用の設定
+            // xterm.js 6.0 で windowsMode は廃止。ConPTY 前提の Windows ヒューリスティクスは windowsPty で指定する。
+            // buildNumber 未指定（= reflow無効・非空白終端行を折返し扱い）で旧 windowsMode: true 相当の挙動を維持。
+            windowsPty: { backend: 'conpty' },
             allowProposedApi: true  // 提案中のAPIを許可（スクロールバック保持のため）
         });
         
@@ -525,14 +527,20 @@ window.terminalFunctions = {
                 }
             }
 
-            // CanvasAddonをロード（ブロック文字をCanvas描画で正確にレンダリング）
-            if (typeof CanvasAddon !== 'undefined' && CanvasAddon.CanvasAddon) {
+            // WebglAddonをロード（GPU描画。xterm.js 6.0 で廃止された CanvasAddon の後継）
+            // WebGLコンテキストは GPU リセットやスリープ復帰、コンテキスト数上限超過で失われることがある。
+            // onContextLoss でアドオンを破棄すると xterm.js が自動的に DOM レンダラーへフォールバックする。
+            if (typeof WebglAddon !== 'undefined' && WebglAddon.WebglAddon) {
                 try {
-                    const canvasAddon = new CanvasAddon.CanvasAddon();
-                    term.loadAddon(canvasAddon);
-                    console.log('[CanvasAddon] CanvasAddon loaded successfully');
+                    const webglAddon = new WebglAddon.WebglAddon();
+                    webglAddon.onContextLoss(() => {
+                        console.warn('[WebglAddon] WebGLコンテキスト喪失を検出。アドオンを破棄しDOMレンダラーへフォールバック');
+                        try { webglAddon.dispose(); } catch (e) { /* 破棄失敗は無視 */ }
+                    });
+                    term.loadAddon(webglAddon);
+                    console.log('[WebglAddon] WebglAddon loaded successfully');
                 } catch (error) {
-                    console.error('[CanvasAddon] Failed to load CanvasAddon:', error);
+                    console.error('[WebglAddon] Failed to load WebglAddon:', error);
                 }
             }
             
@@ -837,7 +845,7 @@ window.terminalFunctions = {
                 try {
                     window.multiSessionTerminals[sessionId].terminal.dispose();
                 } catch (e) {
-                    // CanvasAddonの内部レンダラーが不整合な状態（スリープ復帰後等）でも安全に破棄
+                    // WebglAddonの内部レンダラーが不整合な状態（スリープ復帰後・コンテキスト喪失後等）でも安全に破棄
                     console.log(`[JS] cleanupTerminal: dispose()エラー（無視）: ${e.message}`);
                 }
                 console.log(`[JS] cleanupTerminal: ターミナル ${sessionId} を破棄`);


### PR DESCRIPTION
## 概要

xterm.js を `5.5.0`（#70）から最新の `@xterm/xterm@6.0.0` へ更新し、Canvas レンダラーアドオンから **WebGL レンダラー**へ移行します。

## 背景

6.0 で **Canvas レンダラーアドオンが廃止**されました（`addon-canvas` は 2024-04 の 0.7.0 で更新停止・peer `^5.0.0` 止まり）。一方 GPU 描画は `addon-webgl` が後継として 6.0 対応版（0.19.0）を出しているため、こちらへ移行します。あわせて全角行スクロール時の消し残りアーティファクトの更なる改善も期待。

## 破壊的変更への対応

| 破壊的変更 | 対応 |
|---|---|
| `windowsMode` オプション削除 | `windowsPty: { backend: 'conpty' }` へ置換。buildNumber 未指定で reflow 無効・非空白終端を折返し扱いとし、**旧 `windowsMode: true` 相当の挙動を維持** |
| Canvas レンダラーアドオン廃止 | `addon-canvas` → `addon-webgl@0.19.0` |

### WebGL コンテキスト喪失対策

WebGL はスリープ復帰・GPU リセット・コンテキスト数上限超過でコンテキストを喪失しうるため、`onContextLoss` でアドオンを `dispose()` し **DOM レンダラーへ自動フォールバック**する処理を追加（xterm.js 公式推奨パターン）。

このフォールバックは一時的で、セッション切替・再描画ボタン・再読込でターミナルが再生成される際に **WebGL へ復帰**します（`TerminalService.InitializeTerminalAsync` が毎回 cleanup→create するため）。

## バージョン更新

| パッケージ | 旧(5.5.0世代) | 新(6.0.0世代) |
|---|---|---|
| 本体 | `@xterm/xterm@5.5.0` | `@xterm/xterm@6.0.0` |
| fit | 0.10.0 | 0.11.0 |
| web-links | 0.11.0 | 0.12.0 |
| unicode11 | 0.8.0 | 0.9.0 |
| renderer | addon-canvas@0.7.0 | **addon-webgl@0.19.0** |

## 実装メモ

- グローバル名は従来同様（`Terminal` / `FitAddon.FitAddon` / `WebLinksAddon.WebLinksAddon` / `Unicode11Addon.Unicode11Addon` / `WebglAddon.WebglAddon`）。
- 使用 API（`convertEol` / `allowProposedApi` / `scrollback` / `attachCustomKeyEventHandler` / `registerLinkProvider` / `unicode.activeVersion`）は 6.0 typings で存続を確認済み。
- terminal.js の破棄時コメント、Root.razor の再描画ボタンのコメントを Canvas→WebGL 文言へ更新。

## 確認

- [x] `dotnet build` 成功
- [x] 全 CDN URL 200 到達確認
- [x] ローカル起動で通常動作・WebGL ロード・ブロック文字描画を確認
- [x] セッション切替/再読込で WebGL 再アタッチを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)