### PR TITLE
ci: GitHub Actions を Node24 対応版へ更新（Node20 非推奨対応）

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,16 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -94,21 +94,21 @@ jobs:
 
       - name: Upload build artifact (publish output)
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TerminalHub-dev-build
           path: ./publish/
 
       - name: Upload installer artifact (workflow_dispatch のみ)
         if: ${{ !startsWith(github.ref, 'refs/tags/v') && inputs.build_installer == true }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TerminalHub-installer-preview
           path: installer/output/*.exe
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: installer/output/*.exe
           generate_release_notes: true


### PR DESCRIPTION
## 概要

ビルドログに出ていた `Node.js 20 is deprecated. ... being forced to run on Node.js 24` 警告を解消します。各 action を、`action.yml` が `node24` を宣言する最小メジャーへ更新しました。

## 変更

### release.yml（Build and Release）
| action | 旧 | 新 | 理由 |
|---|---|---|---|
| actions/checkout | v4 | v5 | node24 |
| actions/setup-dotnet | v4 | v5 | node24 |
| actions/upload-artifact | v4 | **v6** | v5 はまだ node20 宣言のため v6 |
| softprops/action-gh-release | v2 | v3 | node24（v3 の変更はランタイムのみ） |

### deploy-pages.yml（Deploy Pages）
| action | 旧 | 新 | 理由 |
|---|---|---|---|
| actions/checkout | v4 | v5 | node24 |
| actions/configure-pages | v5 | v6 | node24 |
| actions/upload-pages-artifact | v3 | v5 | composite（内部 action 刷新） |
| actions/deploy-pages | v4 | v5 | node24 |

## 確認

- 各 action の `action.yml` の `runs.using` が node24（または composite）であることを確認済み。
- 基本的な使い方（無引数 checkout / `dotnet-version` / `name`+`path` / `files`+`generate_release_notes` 等）に破壊的変更がないことを各リリースノートで確認。
- GitHub ホストランナー（windows-latest / ubuntu-latest）は Node24 対応済み。

## 検証メモ
- release.yml は本PRマージ後の workflow_dispatch ビルドで「Node20 deprecated」警告が消えることを確認予定。
- deploy-pages.yml は `docs/**` 変更時のみ実行のため、次回 Pages デプロイ時に検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)