### PR TITLE
feat: 通知ベルを状態別アイコンで区別（停止=ベル/確認=盾/選択=ラジオ）

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -262,6 +262,24 @@
         _notificationPendingSessions[sessionId] = kind;
     }
 
+    /// <summary>
+    /// Notification イベントの message から通知ベル種別を判別する。
+    /// Notification は許可待ち(permission)・アイドル(idle)・認証成功 等で発火するため、
+    /// 一律 Confirm（盾＝許可待ち）にすると idle/認証まで「許可待ち」と誤表示してしまう。
+    /// message に "permission" を含むものだけ確認（盾）とし、それ以外は停止（ベル）扱いにする。
+    /// 例: 許可待ち="Claude needs your permission to use Bash" / idle="Claude is waiting for your input"。
+    /// （Claude Code 側の文言変更に弱い substring 判定だが、外れても Stopped に倒れるだけで害は小さい）
+    /// </summary>
+    private static SessionBellKind ClassifyNotificationBell(string? message)
+    {
+        if (!string.IsNullOrEmpty(message)
+            && message.Contains("permission", StringComparison.OrdinalIgnoreCase))
+        {
+            return SessionBellKind.Confirm;
+        }
+        return SessionBellKind.Stopped;
+    }
+
     // SessionManagerイベントハンドラー
     private EventHandler? _sessionsChangedHandler;
 
@@ -2185,20 +2203,21 @@
 
             case HookEventType.Notification:
             case HookEventType.PreToolUse:
-                // Notification（許可待ち）/ PreToolUse（AskUserQuestion=ユーザーへの質問）は
+                // Notification / PreToolUse（AskUserQuestion=ユーザーへの質問）は
                 // 「ユーザーの入力が必要」な状態。非アクティブセッションならベル（通知マーク）を立てて、
                 // 別セッションを見ている時でも気づけるようにする。
                 // 解除は不要: 入力するにはそのセッションへ切り替える＝SelectSession でベルが自然に消える。
-                //   - Notification → 確認（許可待ち, bi-shield-exclamation）
                 //   - PreToolUse   → 選択（質問, bi-ui-radios）
+                //   - Notification → message で判別。許可待ちのみ確認（盾）、
+                //                    idle/認証成功等は停止（ベル）にして「許可待ち」を誤表示しない。
                 if (activeSessionId != notification.SessionId)
                 {
                     var bellKind = eventType == HookEventType.PreToolUse
                         ? SessionBellKind.Select
-                        : SessionBellKind.Confirm;
+                        : ClassifyNotificationBell(notification.Message);
                     Logger.LogInformation(
-                        "[通知マーク ON] きっかけ: OnHookNotification({Event}), 種別: {Kind}, セッション: {SessionName}",
-                        eventType, bellKind, session.GetDisplayName());
+                        "[通知マーク ON] きっかけ: OnHookNotification({Event}), 種別: {Kind}, Message={Message}, セッション: {SessionName}",
+                        eventType, bellKind, notification.Message, session.GetDisplayName());
                     SetNotificationBell(notification.SessionId, bellKind);
                     StateHasChanged();
                 }

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -239,8 +239,8 @@
     private System.Globalization.CultureInfo? _circuitCulture;
     private System.Globalization.CultureInfo? _circuitUiCulture;
 
-    // 通知対象セッションID（インスタンスごとに独立して管理）
-    // セッションごとの通知ベル種別（停止/確認/選択）。色は共通の赤で、SessionList 側がアイコンを出し分ける。
+    // セッションごとの通知ベル種別（停止/確認/選択）。インスタンスごとに独立して管理。
+    // 色は共通の赤で、SessionList 側がアイコンを出し分ける。
     private Dictionary<Guid, SessionBellKind> _notificationPendingSessions = new();
 
     /// <summary>

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -241,8 +241,26 @@
 
     // 通知対象セッションID（インスタンスごとに独立して管理）
     // セッションごとの通知ベル種別（停止/確認/選択）。色は共通の赤で、SessionList 側がアイコンを出し分ける。
-    // 最新のイベントで上書きする（停止→確認→選択は時系列で排他的に起きるため、直近の状態を出せばよい）。
     private Dictionary<Guid, SessionBellKind> _notificationPendingSessions = new();
+
+    /// <summary>
+    /// 通知ベルを優先度を考慮して立てる。
+    /// 「確認(許可待ち)」「選択(質問)」＝ユーザー操作が必要 は「停止」より優先度が高い。
+    /// AskUserQuestion 等の待機中に 5 秒タイムアウトが誤爆して Stopped で上書きすると、
+    /// 「質問待ち」が「停止」へ格下げされて見えてしまうため、Stopped は既存の
+    /// Confirm/Select を上書きしない。Confirm/Select は常に上書きする（最新が勝つ）。
+    /// </summary>
+    private void SetNotificationBell(Guid sessionId, SessionBellKind kind)
+    {
+        if (kind == SessionBellKind.Stopped
+            && _notificationPendingSessions.TryGetValue(sessionId, out var existing)
+            && existing != SessionBellKind.Stopped)
+        {
+            // 既に Confirm/Select（要操作）が立っている → 格下げしない
+            return;
+        }
+        _notificationPendingSessions[sessionId] = kind;
+    }
 
     // SessionManagerイベントハンドラー
     private EventHandler? _sessionsChangedHandler;
@@ -2055,7 +2073,7 @@
                 if (activeSessionId != sessionId)
                 {
                     Logger.LogInformation("[通知マーク ON] きっかけ: OnSessionTimeout(タイムアウト完了), セッション: {SessionName}", session.GetDisplayName());
-                    _notificationPendingSessions[sessionId] = SessionBellKind.Stopped;
+                    SetNotificationBell(sessionId, SessionBellKind.Stopped);
                 }
 
                 // 処理完了の通知（アクティブセッションでも通知する）
@@ -2124,7 +2142,7 @@
                 if (activeSessionId != notification.SessionId)
                 {
                     Logger.LogInformation("[通知マーク ON] きっかけ: OnHookNotification(Hook通知), セッション: {SessionName}", session.GetDisplayName());
-                    _notificationPendingSessions[notification.SessionId] = SessionBellKind.Stopped;
+                    SetNotificationBell(notification.SessionId, SessionBellKind.Stopped);
                 }
 
                 // タイマーを停止
@@ -2181,7 +2199,7 @@
                     Logger.LogInformation(
                         "[通知マーク ON] きっかけ: OnHookNotification({Event}), 種別: {Kind}, セッション: {SessionName}",
                         eventType, bellKind, session.GetDisplayName());
-                    _notificationPendingSessions[notification.SessionId] = bellKind;
+                    SetNotificationBell(notification.SessionId, bellKind);
                     StateHasChanged();
                 }
                 break;

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -240,7 +240,9 @@
     private System.Globalization.CultureInfo? _circuitUiCulture;
 
     // 通知対象セッションID（インスタンスごとに独立して管理）
-    private HashSet<Guid> _notificationPendingSessions = new();
+    // セッションごとの通知ベル種別（停止/確認/選択）。色は共通の赤で、SessionList 側がアイコンを出し分ける。
+    // 最新のイベントで上書きする（停止→確認→選択は時系列で排他的に起きるため、直近の状態を出せばよい）。
+    private Dictionary<Guid, SessionBellKind> _notificationPendingSessions = new();
 
     // SessionManagerイベントハンドラー
     private EventHandler? _sessionsChangedHandler;
@@ -2053,7 +2055,7 @@
                 if (activeSessionId != sessionId)
                 {
                     Logger.LogInformation("[通知マーク ON] きっかけ: OnSessionTimeout(タイムアウト完了), セッション: {SessionName}", session.GetDisplayName());
-                    _notificationPendingSessions.Add(sessionId);
+                    _notificationPendingSessions[sessionId] = SessionBellKind.Stopped;
                 }
 
                 // 処理完了の通知（アクティブセッションでも通知する）
@@ -2122,7 +2124,7 @@
                 if (activeSessionId != notification.SessionId)
                 {
                     Logger.LogInformation("[通知マーク ON] きっかけ: OnHookNotification(Hook通知), セッション: {SessionName}", session.GetDisplayName());
-                    _notificationPendingSessions.Add(notification.SessionId);
+                    _notificationPendingSessions[notification.SessionId] = SessionBellKind.Stopped;
                 }
 
                 // タイマーを停止
@@ -2165,16 +2167,21 @@
 
             case HookEventType.Notification:
             case HookEventType.PreToolUse:
-                // Notification（許可待ち等）/ PreToolUse（AskUserQuestion=ユーザーへの質問）は
+                // Notification（許可待ち）/ PreToolUse（AskUserQuestion=ユーザーへの質問）は
                 // 「ユーザーの入力が必要」な状態。非アクティブセッションならベル（通知マーク）を立てて、
                 // 別セッションを見ている時でも気づけるようにする。
                 // 解除は不要: 入力するにはそのセッションへ切り替える＝SelectSession でベルが自然に消える。
+                //   - Notification → 確認（許可待ち, bi-shield-exclamation）
+                //   - PreToolUse   → 選択（質問, bi-ui-radios）
                 if (activeSessionId != notification.SessionId)
                 {
+                    var bellKind = eventType == HookEventType.PreToolUse
+                        ? SessionBellKind.Select
+                        : SessionBellKind.Confirm;
                     Logger.LogInformation(
-                        "[通知マーク ON] きっかけ: OnHookNotification({Event}), セッション: {SessionName}",
-                        eventType, session.GetDisplayName());
-                    _notificationPendingSessions.Add(notification.SessionId);
+                        "[通知マーク ON] きっかけ: OnHookNotification({Event}), 種別: {Kind}, セッション: {SessionName}",
+                        eventType, bellKind, session.GetDisplayName());
+                    _notificationPendingSessions[notification.SessionId] = bellKind;
                     StateHasChanged();
                 }
                 break;

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -16,7 +16,8 @@
         100% { transform: rotate(0); }
     }
 
-    .bi-bell-fill {
+    /* 停止/確認/選択どのアイコンでも注意喚起のため軽く揺らす */
+    .session-bell .bi {
         animation: bell-ring 2s ease-in-out infinite;
     }
 </style>
@@ -96,10 +97,11 @@
                                     <i class="bi bi-pin-fill"></i>
                                 </span>
                             }
-                            @if (NotificationPendingSessions.Contains(session.SessionId))
+                            @if (NotificationPendingSessions.TryGetValue(session.SessionId, out var bellKind))
                             {
-                                <span class="text-danger me-1" title="@L["SessionList.Badge.Notification"]">
-                                    <i class="bi bi-bell-fill"></i>
+                                @* 色は共通(赤)。停止=ベル / 確認=盾 / 選択=ラジオ でアイコンの形を変えて区別する *@
+                                <span class="text-danger me-1 session-bell" title="@BellTitle(bellKind)">
+                                    <i class="bi @BellIcon(bellKind)"></i>
                                 </span>
                             }
                             <span class="@GetConnectionOpacityClass(session)">@session.GetDisplayName()</span>
@@ -221,7 +223,7 @@
     [Parameter] public Guid? ActiveSessionId { get; set; }
     [Parameter] public bool IsAddingSession { get; set; }
     [Parameter] public string SortMode { get; set; } = "lastAccessed"; // "createdAt" or "lastAccessed"
-    [Parameter] public ISet<Guid> NotificationPendingSessions { get; set; } = new HashSet<Guid>();
+    [Parameter] public IReadOnlyDictionary<Guid, SessionBellKind> NotificationPendingSessions { get; set; } = new Dictionary<Guid, SessionBellKind>();
     [Parameter] public bool ShowTerminalType { get; set; } = false;
     [Parameter] public bool ShowGitInfo { get; set; } = false;
     [Parameter] public bool IsMobileOpen { get; set; } = false;
@@ -447,6 +449,26 @@
             ? $"実行中: {string.Join(", ", types)}"
             : $"サブエージェント {session.RunningSubagentCount} 個 実行中";
     }
+
+    /// <summary>
+    /// 通知ベルの種類に応じた Bootstrap Icons クラスを返す（色は共通の赤、形で区別）
+    /// </summary>
+    private string BellIcon(SessionBellKind kind) => kind switch
+    {
+        SessionBellKind.Confirm => "bi-shield-exclamation",   // 許可待ち
+        SessionBellKind.Select => "bi-ui-radios",             // 質問（選択）
+        _ => "bi-bell-fill"                                    // 停止
+    };
+
+    /// <summary>
+    /// 通知ベルの種類に応じたツールチップ文言を返す
+    /// </summary>
+    private string BellTitle(SessionBellKind kind) => kind switch
+    {
+        SessionBellKind.Confirm => L["SessionList.Badge.Confirm"],
+        SessionBellKind.Select => L["SessionList.Badge.Select"],
+        _ => L["SessionList.Badge.Notification"]
+    };
 
     /// <summary>
     /// ConPTY接続状態に応じた透明度クラスを返す

--- a/TerminalHub/Models/SessionBellKind.cs
+++ b/TerminalHub/Models/SessionBellKind.cs
@@ -1,0 +1,17 @@
+namespace TerminalHub.Models;
+
+/// <summary>
+/// セッションリストに表示する通知ベルの種類。
+/// 色は共通（赤）で、状態の違いはアイコンの形で区別する。
+/// </summary>
+public enum SessionBellKind
+{
+    /// <summary>停止: ターンが終わって次の入力待ちで止まっている（bi-bell-fill）</summary>
+    Stopped,
+
+    /// <summary>確認: 許可待ち（Notification / permission_prompt）。「実行していい?」（bi-shield-exclamation）</summary>
+    Confirm,
+
+    /// <summary>選択: 質問（PreToolUse / AskUserQuestion）。3択など選んでほしい（bi-ui-radios）</summary>
+    Select
+}

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -494,6 +494,8 @@
   <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>Archived sessions</value></data>
   <data name="SessionList.Badge.Pinned" xml:space="preserve"><value>Pinned</value></data>
   <data name="SessionList.Badge.Notification" xml:space="preserve"><value>Processing completed</value></data>
+  <data name="SessionList.Badge.Confirm" xml:space="preserve"><value>Waiting for permission (confirmation needed)</value></data>
+  <data name="SessionList.Badge.Select" xml:space="preserve"><value>Waiting for selection (please answer the question)</value></data>
   <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git branch</value></data>
   <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>Uncommitted changes</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>Remote control connected</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -494,6 +494,8 @@
   <data name="SessionList.ArchivedTooltip" xml:space="preserve"><value>アーカイブ済みセッション</value></data>
   <data name="SessionList.Badge.Pinned" xml:space="preserve"><value>ピン留め</value></data>
   <data name="SessionList.Badge.Notification" xml:space="preserve"><value>処理が完了しました</value></data>
+  <data name="SessionList.Badge.Confirm" xml:space="preserve"><value>許可待ち（確認が必要です）</value></data>
+  <data name="SessionList.Badge.Select" xml:space="preserve"><value>選択待ち（質問に回答してください）</value></data>
   <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git ブランチ</value></data>
   <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>未コミットの変更があります</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>リモートコントロール接続中</value></data>


### PR DESCRIPTION
## 概要
非アクティブセッションの通知ベルが全て同じ赤ベルで、「停止」「許可待ち」「質問」の区別がつかなかった。**色は赤のまま、アイコンの形で3状態を区別**します。

## 状態とアイコン（すべて赤）
| 状態 | きっかけ | アイコン | 意味 |
|---|---|---|---|
| **停止** | Stop | `bi-bell-fill`（維持） | ターン終了・入力待ちで停止 |
| **確認** | Notification（許可待ち） | `bi-shield-exclamation` | 「これ実行していい？」 |
| **選択** | PreToolUse（AskUserQuestion） | `bi-ui-radios` | 3択など選んでほしい |

形がベル／盾／ラジオで全く違うので、一覧でパッと見分けられます。赤ベルだけ探せば「本当に止まっている」セッションが分かります。

## 実装
- `SessionBellKind` enum を追加（Stopped / Confirm / Select）
- `_notificationPendingSessions` を `HashSet<Guid>` → `Dictionary<Guid, SessionBellKind>` に変更し、種別を保持（最新イベントで上書き。3状態は時系列で排他的に起きるため）
- `OnHookNotification` で Notification→確認 / PreToolUse→選択 に振り分け（Stop・タイムアウトは停止）
- `SessionList` に `BellIcon` / `BellTitle` ヘルパー追加。注意喚起アニメーションを全アイコン共通（`.session-bell .bi`）に
- ツールチップ用 resx キー（`Badge.Confirm` / `Badge.Select`）を ja/en に追加

## 確認
- `dotnet build`: 0 警告 / 0 エラー
- 解除は従来通り「そのセッションを選択（SelectSession）すると消える」挙動を維持
- 実機での見た目はプレビュー版で確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
