### PR TITLE
feat: セッション専用カスタムコマンドを追加できるようにする

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -164,7 +164,7 @@
                                  WorkingDirectory="@bottomPanelSession.FolderPath"
                                  DotNetRef="@dotNetRef"
                                  ShellPanelRefs="@shellPanelRefs"
-                                 CustomCommands="@GetCustomCommandsForSession(bottomPanelSession.TerminalType)"
+                                 CustomCommands="@GetCustomCommandsForSession(bottomPanelSession)"
                                  OnSendInput="HandleTextInputSend"
                                  OnSendCustomKey="SendCustomKey"
                                  OnCtrlC="SendCtrlC"
@@ -1747,13 +1747,19 @@
         };
     }
 
-    private List<CustomCommand> GetCustomCommandsForSession(TerminalType terminalType)
+    private List<CustomCommand> GetCustomCommandsForSession(SessionInfo session)
     {
         var settings = AppSettingsService.GetSettings();
-        var key = terminalType.ToString();
-        if (settings.Commands.CommandsByTerminalType.TryGetValue(key, out var commands))
-            return commands;
-        return new();
+        var key = session.TerminalType.ToString();
+        var result = settings.Commands.CommandsByTerminalType.TryGetValue(key, out var commands)
+            ? new List<CustomCommand>(commands)
+            : new List<CustomCommand>();
+
+        // セッション専用コマンドはグローバル分の後ろに連結する。
+        if (session.SessionCommands.Count > 0)
+            result.AddRange(session.SessionCommands);
+
+        return result;
     }
 
     private string claudeModeSwitchKey = "altM";

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -132,6 +132,72 @@
                                           GrokOptions="grokOptions"
                                           DisableContinueOption="false" />
 
+                    <hr />
+
+                    <!-- このセッション専用のカスタムコマンド -->
+                    <div class="mb-3">
+                        <div class="d-flex justify-content-between align-items-center mb-1">
+                            <label class="form-label fw-bold mb-0">
+                                <i class="bi bi-terminal me-1"></i>@L["SessionSettings.Commands.Header"]
+                            </label>
+                            <button type="button" class="btn btn-outline-primary btn-sm" @onclick="OpenAddSessionCommand">
+                                <i class="bi bi-plus-lg me-1"></i>@L["Settings.Commands.AddNew"]
+                            </button>
+                        </div>
+                        <small class="form-text text-muted d-block mb-2">@L["SessionSettings.Commands.Help"]</small>
+
+                        @if (editingSessionCommands.Any())
+                        {
+                            <ul class="list-group list-group-sm">
+                                @for (var i = 0; i < editingSessionCommands.Count; i++)
+                                {
+                                    var idx = i;
+                                    var cmd = editingSessionCommands[i];
+                                    var isKey = cmd.Type == CustomCommandType.KeySequence;
+                                    var bodyText = isKey
+                                        ? (KeySequencePresets.GetDisplayName(cmd.KeyName) ?? cmd.KeyName ?? "?")
+                                        : SummarizeCommandText(cmd.CommandText);
+                                    <li class="list-group-item d-flex justify-content-between align-items-center py-1 px-2">
+                                        <small class="d-flex align-items-center" style="min-width: 0; flex: 1;">
+                                            @if (isKey)
+                                            {
+                                                <i class="bi bi-keyboard me-1 text-muted"></i>
+                                            }
+                                            @if (!string.IsNullOrEmpty(cmd.GroupName))
+                                            {
+                                                <span class="badge bg-secondary bg-opacity-25 text-muted me-2" style="font-weight: normal;">@cmd.GroupName</span>
+                                            }
+                                            @if (!string.IsNullOrEmpty(cmd.Title))
+                                            {
+                                                <strong>@cmd.Title</strong>
+                                                <span class="text-muted ms-2 text-truncate">@bodyText</span>
+                                            }
+                                            else
+                                            {
+                                                <span class="text-truncate">@bodyText</span>
+                                            }
+                                        </small>
+                                        <div class="d-flex align-items-center gap-1">
+                                            <button class="btn btn-outline-secondary btn-sm border-0" type="button"
+                                                    title="@L["Settings.Commands.Edit"]"
+                                                    @onclick="() => OpenEditSessionCommand(idx)" style="font-size: 0.75rem;">
+                                                <i class="bi bi-pencil"></i>
+                                            </button>
+                                            <button class="btn btn-outline-danger btn-sm border-0" type="button"
+                                                    @onclick="() => RemoveSessionCommand(idx)" style="font-size: 0.7rem;">
+                                                <i class="bi bi-x-lg"></i>
+                                            </button>
+                                        </div>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                        else
+                        {
+                            <p class="text-muted small mb-0 fst-italic">@L["Settings.Commands.Empty"]</p>
+                        }
+                    </div>
+
                     <ErrorAlert @bind-ErrorMessage="errorMessage" />
                 }
                 else
@@ -165,6 +231,13 @@
                       OnClose="CloseMemoManagement"
                       OnMemoRestored="HandleMemoRestored" />
 
+<CommandEditDialog IsVisible="commandEditDialogVisible"
+                   IsVisibleChanged="OnSessionCommandDialogVisibleChanged"
+                   IsNew="commandEditDialogIsNew"
+                   TerminalTypeLabel="@commandEditDialogTerminalLabel"
+                   Command="commandEditDialogSource"
+                   OnSave="HandleSessionCommandSave" />
+
 @code {
     [Parameter] public bool IsVisible { get; set; }
     [Parameter] public Guid? SessionId { get; set; }
@@ -175,6 +248,14 @@
 
     private bool showMemoManagement = false;
     private bool anyMemoExists = false;
+
+    // セッション専用コマンドの編集用バッファ（保存時に sessionInfo へ書き戻す）
+    private List<CustomCommand> editingSessionCommands = new();
+    private bool commandEditDialogVisible = false;
+    private bool commandEditDialogIsNew = false;
+    private int? commandEditDialogIndex = null;
+    private CustomCommand? commandEditDialogSource = null;
+    private string? commandEditDialogTerminalLabel = null;
 
     private SessionOptionsSelector? optionsSelector;
     private SessionInfo? sessionInfo;
@@ -252,6 +333,19 @@
             isPinned = sessionInfo.IsPinned;
             pinPriority = sessionInfo.PinPriority;
             selectedType = sessionInfo.TerminalType;
+
+            // セッション専用コマンドをディープコピーして編集バッファへ（キャンセル時に元を壊さない）
+            editingSessionCommands = sessionInfo.SessionCommands
+                .Select(c => new CustomCommand
+                {
+                    Title = c.Title,
+                    CommandText = c.CommandText,
+                    Type = c.Type,
+                    KeyName = c.KeyName,
+                    GroupName = c.GroupName,
+                    SendMode = c.SendMode
+                })
+                .ToList();
 
             // オプションを解析
             var options = sessionInfo.Options;
@@ -338,6 +432,9 @@
             // オプションを更新
             sessionInfo.Options = optionsSelector.GetOptions();
 
+            // セッション専用コマンドを書き戻す
+            sessionInfo.SessionCommands = editingSessionCommands;
+
             // 保存
             await SessionManager.SaveSessionInfoAsync(sessionInfo);
 
@@ -415,6 +512,79 @@
         {
             await OnCreateSubSession.InvokeAsync(SessionId.Value);
         }
+    }
+
+    // ===== セッション専用コマンドの編集 =====
+
+    private void OpenAddSessionCommand()
+    {
+        commandEditDialogTerminalLabel = GetTerminalTypeDisplayName(selectedType);
+        commandEditDialogIndex = null;
+        commandEditDialogSource = null;
+        commandEditDialogIsNew = true;
+        commandEditDialogVisible = true;
+    }
+
+    private void OpenEditSessionCommand(int index)
+    {
+        if (index < 0 || index >= editingSessionCommands.Count)
+            return;
+
+        commandEditDialogTerminalLabel = GetTerminalTypeDisplayName(selectedType);
+        commandEditDialogIndex = index;
+        commandEditDialogSource = editingSessionCommands[index];
+        commandEditDialogIsNew = false;
+        commandEditDialogVisible = true;
+    }
+
+    private void HandleSessionCommandSave(CustomCommand command)
+    {
+        if (commandEditDialogIndex is int idx && idx >= 0 && idx < editingSessionCommands.Count)
+        {
+            editingSessionCommands[idx] = command; // 編集：既存位置に上書き
+        }
+        else
+        {
+            editingSessionCommands.Add(command); // 新規：末尾に追加
+        }
+        // ダイアログ側が Close を呼び OnSessionCommandDialogVisibleChanged 経由で state クリア
+    }
+
+    private void OnSessionCommandDialogVisibleChanged(bool visible)
+    {
+        commandEditDialogVisible = visible;
+        if (!visible)
+        {
+            commandEditDialogIndex = null;
+            commandEditDialogSource = null;
+            commandEditDialogTerminalLabel = null;
+        }
+    }
+
+    private void RemoveSessionCommand(int index)
+    {
+        if (index >= 0 && index < editingSessionCommands.Count)
+        {
+            editingSessionCommands.RemoveAt(index);
+        }
+    }
+
+    private static string GetTerminalTypeDisplayName(TerminalType type) => type switch
+    {
+        TerminalType.ClaudeCode => "Claude Code",
+        TerminalType.GeminiCLI => "Gemini CLI",
+        TerminalType.CodexCLI => "Codex CLI",
+        TerminalType.Antigravity => "Antigravity",
+        TerminalType.Grok => "Grok",
+        _ => "Terminal"
+    };
+
+    /// <summary>一覧の行に出すコマンド本文の表示用要約。複数行は先頭行 + "…" で短縮する。</summary>
+    private static string SummarizeCommandText(string commandText)
+    {
+        if (string.IsNullOrEmpty(commandText)) return commandText;
+        var newline = commandText.IndexOfAny(new[] { '\r', '\n' });
+        return newline < 0 ? commandText : commandText.Substring(0, newline) + " …";
     }
 
 }

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -61,23 +61,27 @@
                         </div>
                     </div>
 
-                    @if (!sessionInfo.ParentSessionId.HasValue || anyMemoExists)
-                    {
-                        <div class="mt-3 d-flex flex-wrap gap-2">
-                            @if (!sessionInfo.ParentSessionId.HasValue)
+                    <div class="mt-3 d-flex flex-wrap gap-2">
+                        @if (!sessionInfo.ParentSessionId.HasValue)
+                        {
+                            <button type="button" class="btn btn-outline-success btn-sm" @onclick="HandleCreateSubSession">
+                                <i class="bi bi-plus-circle me-1"></i>@L["SessionSettings.CreateSubSession"]
+                            </button>
+                        }
+                        @if (anyMemoExists)
+                        {
+                            <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="OpenMemoManagement">
+                                <i class="bi bi-journal-text me-1"></i>@L["SessionSettings.OpenMemoManagement"]
+                            </button>
+                        }
+                        <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="OpenSessionCommandsDialog">
+                            <i class="bi bi-terminal me-1"></i>@L["SessionSettings.Commands.ManageButton"]
+                            @if (editingSessionCommands.Count > 0)
                             {
-                                <button type="button" class="btn btn-outline-success btn-sm" @onclick="HandleCreateSubSession">
-                                    <i class="bi bi-plus-circle me-1"></i>@L["SessionSettings.CreateSubSession"]
-                                </button>
+                                <span class="badge bg-secondary ms-1">@editingSessionCommands.Count</span>
                             }
-                            @if (anyMemoExists)
-                            {
-                                <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="OpenMemoManagement">
-                                    <i class="bi bi-journal-text me-1"></i>@L["SessionSettings.OpenMemoManagement"]
-                                </button>
-                            }
-                        </div>
-                    }
+                        </button>
+                    </div>
 
                     <hr />
 
@@ -132,72 +136,6 @@
                                           GrokOptions="grokOptions"
                                           DisableContinueOption="false" />
 
-                    <hr />
-
-                    <!-- このセッション専用のカスタムコマンド -->
-                    <div class="mb-3">
-                        <div class="d-flex justify-content-between align-items-center mb-1">
-                            <label class="form-label fw-bold mb-0">
-                                <i class="bi bi-terminal me-1"></i>@L["SessionSettings.Commands.Header"]
-                            </label>
-                            <button type="button" class="btn btn-outline-primary btn-sm" @onclick="OpenAddSessionCommand">
-                                <i class="bi bi-plus-lg me-1"></i>@L["Settings.Commands.AddNew"]
-                            </button>
-                        </div>
-                        <small class="form-text text-muted d-block mb-2">@L["SessionSettings.Commands.Help"]</small>
-
-                        @if (editingSessionCommands.Any())
-                        {
-                            <ul class="list-group list-group-sm">
-                                @for (var i = 0; i < editingSessionCommands.Count; i++)
-                                {
-                                    var idx = i;
-                                    var cmd = editingSessionCommands[i];
-                                    var isKey = cmd.Type == CustomCommandType.KeySequence;
-                                    var bodyText = isKey
-                                        ? (KeySequencePresets.GetDisplayName(cmd.KeyName) ?? cmd.KeyName ?? "?")
-                                        : SummarizeCommandText(cmd.CommandText);
-                                    <li class="list-group-item d-flex justify-content-between align-items-center py-1 px-2">
-                                        <small class="d-flex align-items-center" style="min-width: 0; flex: 1;">
-                                            @if (isKey)
-                                            {
-                                                <i class="bi bi-keyboard me-1 text-muted"></i>
-                                            }
-                                            @if (!string.IsNullOrEmpty(cmd.GroupName))
-                                            {
-                                                <span class="badge bg-secondary bg-opacity-25 text-muted me-2" style="font-weight: normal;">@cmd.GroupName</span>
-                                            }
-                                            @if (!string.IsNullOrEmpty(cmd.Title))
-                                            {
-                                                <strong>@cmd.Title</strong>
-                                                <span class="text-muted ms-2 text-truncate">@bodyText</span>
-                                            }
-                                            else
-                                            {
-                                                <span class="text-truncate">@bodyText</span>
-                                            }
-                                        </small>
-                                        <div class="d-flex align-items-center gap-1">
-                                            <button class="btn btn-outline-secondary btn-sm border-0" type="button"
-                                                    title="@L["Settings.Commands.Edit"]"
-                                                    @onclick="() => OpenEditSessionCommand(idx)" style="font-size: 0.75rem;">
-                                                <i class="bi bi-pencil"></i>
-                                            </button>
-                                            <button class="btn btn-outline-danger btn-sm border-0" type="button"
-                                                    @onclick="() => RemoveSessionCommand(idx)" style="font-size: 0.7rem;">
-                                                <i class="bi bi-x-lg"></i>
-                                            </button>
-                                        </div>
-                                    </li>
-                                }
-                            </ul>
-                        }
-                        else
-                        {
-                            <p class="text-muted small mb-0 fst-italic">@L["Settings.Commands.Empty"]</p>
-                        }
-                    </div>
-
                     <ErrorAlert @bind-ErrorMessage="errorMessage" />
                 }
                 else
@@ -231,6 +169,85 @@
                       OnClose="CloseMemoManagement"
                       OnMemoRestored="HandleMemoRestored" />
 
+<!-- セッション専用コマンド管理ダイアログ（編集バッファ editingSessionCommands を直接操作。本体ダイアログの保存で確定） -->
+<div class="modal fade @(showSessionCommandsDialog ? "show" : "")" tabindex="-1" style="display: @(showSessionCommandsDialog ? "block" : "none"); background-color: var(--th-surface-overlay);">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">
+                    <i class="bi bi-terminal me-2"></i>@L["SessionSettings.Commands.Header"]
+                </h5>
+                <button type="button" class="btn-close" @onclick="CloseSessionCommandsDialog"></button>
+            </div>
+            <div class="modal-body">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <small class="text-muted">@L["SessionSettings.Commands.Help"]</small>
+                    <button type="button" class="btn btn-outline-primary btn-sm flex-shrink-0 ms-2" @onclick="OpenAddSessionCommand">
+                        <i class="bi bi-plus-lg me-1"></i>@L["Settings.Commands.AddNew"]
+                    </button>
+                </div>
+
+                @if (editingSessionCommands.Any())
+                {
+                    <ul class="list-group list-group-sm">
+                        @for (var i = 0; i < editingSessionCommands.Count; i++)
+                        {
+                            var idx = i;
+                            var cmd = editingSessionCommands[i];
+                            var isKey = cmd.Type == CustomCommandType.KeySequence;
+                            var bodyText = isKey
+                                ? (KeySequencePresets.GetDisplayName(cmd.KeyName) ?? cmd.KeyName ?? "?")
+                                : SummarizeCommandText(cmd.CommandText);
+                            <li class="list-group-item d-flex justify-content-between align-items-center py-1 px-2">
+                                <small class="d-flex align-items-center" style="min-width: 0; flex: 1;">
+                                    @if (isKey)
+                                    {
+                                        <i class="bi bi-keyboard me-1 text-muted"></i>
+                                    }
+                                    @if (!string.IsNullOrEmpty(cmd.GroupName))
+                                    {
+                                        <span class="badge bg-secondary bg-opacity-25 text-muted me-2" style="font-weight: normal;">@cmd.GroupName</span>
+                                    }
+                                    @if (!string.IsNullOrEmpty(cmd.Title))
+                                    {
+                                        <strong>@cmd.Title</strong>
+                                        <span class="text-muted ms-2 text-truncate">@bodyText</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-truncate">@bodyText</span>
+                                    }
+                                </small>
+                                <div class="d-flex align-items-center gap-1">
+                                    <button class="btn btn-outline-secondary btn-sm border-0" type="button"
+                                            title="@L["Settings.Commands.Edit"]"
+                                            @onclick="() => OpenEditSessionCommand(idx)" style="font-size: 0.75rem;">
+                                        <i class="bi bi-pencil"></i>
+                                    </button>
+                                    <button class="btn btn-outline-danger btn-sm border-0" type="button"
+                                            @onclick="() => RemoveSessionCommand(idx)" style="font-size: 0.7rem;">
+                                        <i class="bi bi-x-lg"></i>
+                                    </button>
+                                </div>
+                            </li>
+                        }
+                    </ul>
+                }
+                else
+                {
+                    <p class="text-muted small mb-0 fst-italic">@L["Settings.Commands.Empty"]</p>
+                }
+                <small class="form-text text-muted d-block mt-2">@L["SessionSettings.Commands.SaveHint"]</small>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" @onclick="CloseSessionCommandsDialog">
+                    @L["Common.Close"]
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <CommandEditDialog IsVisible="commandEditDialogVisible"
                    IsVisibleChanged="OnSessionCommandDialogVisibleChanged"
                    IsNew="commandEditDialogIsNew"
@@ -250,6 +267,7 @@
     private bool anyMemoExists = false;
 
     // セッション専用コマンドの編集用バッファ（保存時に sessionInfo へ書き戻す）
+    private bool showSessionCommandsDialog = false;
     private List<CustomCommand> editingSessionCommands = new();
     private bool commandEditDialogVisible = false;
     private bool commandEditDialogIsNew = false;
@@ -515,6 +533,10 @@
     }
 
     // ===== セッション専用コマンドの編集 =====
+
+    private void OpenSessionCommandsDialog() => showSessionCommandsDialog = true;
+
+    private void CloseSessionCommandsDialog() => showSessionCommandsDialog = false;
 
     private void OpenAddSessionCommand()
     {

--- a/TerminalHub/Models/SessionInfo.cs
+++ b/TerminalHub/Models/SessionInfo.cs
@@ -47,6 +47,10 @@ namespace TerminalHub.Models
         public Dictionary<string, string> Options { get; set; } = new();
         public string Memo { get; set; } = string.Empty;
 
+        // このセッションでだけ表示・送信できるカスタムコマンド（グローバル設定の Commands とは別管理）。
+        // クイック送信バーではグローバル分の後ろに連結して表示する。DB には JSON で永続化。
+        public List<CustomCommand> SessionCommands { get; set; } = new();
+
         // ピン留め状態
         public bool IsPinned { get; set; } = false;
         public int? PinPriority { get; set; }

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -436,6 +436,8 @@
   <data name="SessionSettings.Memo.Label" xml:space="preserve"><value>Memo</value></data>
   <data name="SessionSettings.Memo.Placeholder" xml:space="preserve"><value>e.g., Working on auth refactor</value></data>
   <data name="SessionSettings.Memo.Help" xml:space="preserve"><value>Shown in session details.</value></data>
+  <data name="SessionSettings.Commands.Header" xml:space="preserve"><value>Commands for this session only</value></data>
+  <data name="SessionSettings.Commands.Help" xml:space="preserve"><value>These commands appear in the quick-send bar for this session only (after the global commands).</value></data>
   <data name="SessionSettings.Loading" xml:space="preserve"><value>Loading session info...</value></data>
   <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>Apply changes immediately (restart session)</value></data>
   <data name="SessionSettings.Save" xml:space="preserve"><value>Save</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -438,6 +438,8 @@
   <data name="SessionSettings.Memo.Help" xml:space="preserve"><value>Shown in session details.</value></data>
   <data name="SessionSettings.Commands.Header" xml:space="preserve"><value>Commands for this session only</value></data>
   <data name="SessionSettings.Commands.Help" xml:space="preserve"><value>These commands appear in the quick-send bar for this session only (after the global commands).</value></data>
+  <data name="SessionSettings.Commands.ManageButton" xml:space="preserve"><value>Commands</value></data>
+  <data name="SessionSettings.Commands.SaveHint" xml:space="preserve"><value>Changes are applied when you Save the session settings.</value></data>
   <data name="SessionSettings.Loading" xml:space="preserve"><value>Loading session info...</value></data>
   <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>Apply changes immediately (restart session)</value></data>
   <data name="SessionSettings.Save" xml:space="preserve"><value>Save</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -438,6 +438,8 @@
   <data name="SessionSettings.Memo.Help" xml:space="preserve"><value>このセッションに関する任意のメモを記入できます</value></data>
   <data name="SessionSettings.Commands.Header" xml:space="preserve"><value>このセッション専用のコマンド</value></data>
   <data name="SessionSettings.Commands.Help" xml:space="preserve"><value>このセッションでだけクイック送信バーに表示されるコマンドです（全体設定のコマンドの後ろに並びます）</value></data>
+  <data name="SessionSettings.Commands.ManageButton" xml:space="preserve"><value>専用コマンド</value></data>
+  <data name="SessionSettings.Commands.SaveHint" xml:space="preserve"><value>変更はセッション設定の「保存」で確定します。</value></data>
   <data name="SessionSettings.Loading" xml:space="preserve"><value>セッション情報を読み込み中…</value></data>
   <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>変更を即座に適用（セッションを再起動）</value></data>
   <data name="SessionSettings.Save" xml:space="preserve"><value>保存</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -436,6 +436,8 @@
   <data name="SessionSettings.Memo.Label" xml:space="preserve"><value>メモ</value></data>
   <data name="SessionSettings.Memo.Placeholder" xml:space="preserve"><value>セッションに関するメモ</value></data>
   <data name="SessionSettings.Memo.Help" xml:space="preserve"><value>このセッションに関する任意のメモを記入できます</value></data>
+  <data name="SessionSettings.Commands.Header" xml:space="preserve"><value>このセッション専用のコマンド</value></data>
+  <data name="SessionSettings.Commands.Help" xml:space="preserve"><value>このセッションでだけクイック送信バーに表示されるコマンドです（全体設定のコマンドの後ろに並びます）</value></data>
   <data name="SessionSettings.Loading" xml:space="preserve"><value>セッション情報を読み込み中…</value></data>
   <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>変更を即座に適用（セッションを再起動）</value></data>
   <data name="SessionSettings.Save" xml:space="preserve"><value>保存</value></data>

--- a/TerminalHub/Services/SessionDbContext.cs
+++ b/TerminalHub/Services/SessionDbContext.cs
@@ -10,7 +10,7 @@ namespace TerminalHub.Services
     {
         private readonly string _connectionString;
         private readonly ILogger<SessionDbContext> _logger;
-        private const int CurrentSchemaVersion = 4;
+        private const int CurrentSchemaVersion = 8;
 
         private readonly SemaphoreSlim _initLock = new(1, 1);
         private bool _initialized = false;
@@ -229,6 +229,27 @@ namespace TerminalHub.Services
                 await CreateSessionMemoSnapshotsTableAsync();
                 await SetSchemaVersionAsync(7);
                 _logger.LogInformation("[DB][マイグレーション] v7 適用完了");
+            }
+
+            if (currentVersion < 8)
+            {
+                // v8: セッション専用カスタムコマンドを保持する SessionCommands カラム (JSON) を追加
+                _logger.LogInformation("[DB][マイグレーション] v8 適用開始: Sessions に SessionCommands カラムを追加");
+                await using var connection = new SqliteConnection(_connectionString);
+                await connection.OpenAsync();
+
+                if (!await ColumnExistsAsync(connection, "Sessions", "SessionCommands"))
+                {
+                    await connection.ExecuteNonQueryAsync("ALTER TABLE Sessions ADD COLUMN SessionCommands TEXT");
+                    _logger.LogInformation("[DB][マイグレーション] v8: SessionCommands カラムを追加");
+                }
+                else
+                {
+                    _logger.LogInformation("[DB][マイグレーション] v8: SessionCommands カラムは既存のためスキップ");
+                }
+
+                await SetSchemaVersionAsync(8);
+                _logger.LogInformation("[DB][マイグレーション] v8 適用完了");
             }
 
             _logger.LogInformation("[DB][マイグレーション] 完了");

--- a/TerminalHub/Services/SessionRepository.cs
+++ b/TerminalHub/Services/SessionRepository.cs
@@ -37,7 +37,7 @@ namespace TerminalHub.Services
             await using var reader = await connection.ExecuteReaderAsync(@"
                 SELECT SessionId, DisplayName, FolderPath, FolderName, CreatedAt, LastAccessedAt,
                        IsActive, TerminalType, Memo, IsArchived, ArchivedAt, ParentSessionId,
-                       IsPinned, PinPriority
+                       IsPinned, PinPriority, SessionCommands
                 FROM Sessions
                 ORDER BY LastAccessedAt DESC");
 
@@ -58,7 +58,8 @@ namespace TerminalHub.Services
                     ArchivedAt = reader.IsDBNull(10) ? null : DateTime.Parse(reader.GetString(10)),
                     ParentSessionId = reader.IsDBNull(11) ? null : Guid.Parse(reader.GetString(11)),
                     IsPinned = !reader.IsDBNull(12) && reader.GetInt64(12) == 1,
-                    PinPriority = reader.IsDBNull(13) ? null : (int)reader.GetInt64(13)
+                    PinPriority = reader.IsDBNull(13) ? null : (int)reader.GetInt64(13),
+                    SessionCommands = DeserializeSessionCommands(reader.IsDBNull(14) ? null : reader.GetString(14))
                 };
                 sessions.Add(session);
             }
@@ -81,7 +82,7 @@ namespace TerminalHub.Services
             await using var reader = await connection.ExecuteReaderAsync(@"
                 SELECT SessionId, DisplayName, FolderPath, FolderName, CreatedAt, LastAccessedAt,
                        IsActive, TerminalType, Memo, IsArchived, ArchivedAt, ParentSessionId,
-                       IsPinned, PinPriority
+                       IsPinned, PinPriority, SessionCommands
                 FROM Sessions
                 WHERE SessionId = @sessionId",
                 ("@sessionId", sessionId.ToString()));
@@ -106,7 +107,8 @@ namespace TerminalHub.Services
                 ArchivedAt = reader.IsDBNull(10) ? null : DateTime.Parse(reader.GetString(10)),
                 ParentSessionId = reader.IsDBNull(11) ? null : Guid.Parse(reader.GetString(11)),
                 IsPinned = !reader.IsDBNull(12) && reader.GetInt64(12) == 1,
-                PinPriority = reader.IsDBNull(13) ? null : (int)reader.GetInt64(13)
+                PinPriority = reader.IsDBNull(13) ? null : (int)reader.GetInt64(13),
+                SessionCommands = DeserializeSessionCommands(reader.IsDBNull(14) ? null : reader.GetString(14))
             };
 
             await reader.CloseAsync();
@@ -134,10 +136,10 @@ namespace TerminalHub.Services
                     INSERT INTO Sessions
                     (SessionId, DisplayName, FolderPath, FolderName, CreatedAt, LastAccessedAt,
                      IsActive, TerminalType, Memo, IsArchived, ArchivedAt, ParentSessionId,
-                     IsPinned, PinPriority)
+                     IsPinned, PinPriority, SessionCommands)
                     VALUES (@sessionId, @displayName, @folderPath, @folderName, @createdAt, @lastAccessedAt,
                             @isActive, @terminalType, @memo, @isArchived, @archivedAt, @parentSessionId,
-                            @isPinned, @pinPriority)
+                            @isPinned, @pinPriority, @sessionCommands)
                     ON CONFLICT(SessionId) DO UPDATE SET
                         DisplayName = excluded.DisplayName,
                         FolderPath = excluded.FolderPath,
@@ -151,7 +153,8 @@ namespace TerminalHub.Services
                         ArchivedAt = excluded.ArchivedAt,
                         ParentSessionId = excluded.ParentSessionId,
                         IsPinned = excluded.IsPinned,
-                        PinPriority = excluded.PinPriority",
+                        PinPriority = excluded.PinPriority,
+                        SessionCommands = excluded.SessionCommands",
                     ("@sessionId", session.SessionId.ToString()),
                     ("@displayName", session.DisplayName),
                     ("@folderPath", session.FolderPath),
@@ -165,7 +168,8 @@ namespace TerminalHub.Services
                     ("@archivedAt", session.ArchivedAt?.ToString("o")),
                     ("@parentSessionId", session.ParentSessionId?.ToString()),
                     ("@isPinned", session.IsPinned ? 1 : 0),
-                    ("@pinPriority", session.PinPriority.HasValue ? (object)session.PinPriority.Value : DBNull.Value));
+                    ("@pinPriority", session.PinPriority.HasValue ? (object)session.PinPriority.Value : DBNull.Value),
+                    ("@sessionCommands", SerializeSessionCommands(session.SessionCommands)));
 
                 // オプションを保存
                 await SaveSessionOptionsAsync(connection, session.SessionId, session.Options);
@@ -179,6 +183,28 @@ namespace TerminalHub.Services
             {
                 transaction.Rollback();
                 throw;
+            }
+        }
+
+        // セッション専用コマンドは Sessions.SessionCommands カラムに JSON 文字列として保存する。
+        private static object SerializeSessionCommands(List<CustomCommand>? commands)
+        {
+            if (commands == null || commands.Count == 0)
+                return DBNull.Value;
+            return JsonSerializer.Serialize(commands);
+        }
+
+        private static List<CustomCommand> DeserializeSessionCommands(string? json)
+        {
+            if (string.IsNullOrEmpty(json))
+                return new List<CustomCommand>();
+            try
+            {
+                return JsonSerializer.Deserialize<List<CustomCommand>>(json) ?? new List<CustomCommand>();
+            }
+            catch
+            {
+                return new List<CustomCommand>();
             }
         }
 


### PR DESCRIPTION
## 概要
セッション設定ダイアログから、**そのセッションでだけ**クイック送信バーに出るカスタムコマンドを追加/編集/削除できるようにします。最小構成（ON/OFFトグル・フォルダ単位スコープは含めない）。

## 仕様
- グローバル設定 `Commands` とは独立管理。クイックバーでは **グローバル分の後ろにセッション専用を連結**して表示。
- セッションごとに DB（SQLite）へ永続化。

## 変更
| 層 | 変更 |
|---|---|
| Model | `SessionInfo.SessionCommands : List<CustomCommand>` を追加 |
| DB | マイグレーション **v8**: `Sessions` に `SessionCommands` カラム(JSON, idempotent ALTER) を追加。`SessionRepository` の SELECT/UPSERT で読み書き（System.Text.Json） |
| 描画 | `Root.GetCustomCommandsForSession` をセッション渡しに変更し、グローバル＋セッション専用を連結 |
| UI | `SessionSettingsDialog` に「このセッション専用のコマンド」セクション（追加/編集/削除）。既存 `CommandEditDialog` を再利用。保存は既存の `OnSettingsSaved → SaveSessionToStorageAsync` 経路にそのまま乗る |
| i18n | `SessionSettings.Commands.Header` / `.Help` を ja/en に追加（操作系は既存 `Settings.Commands.*` を流用） |

## 永続化チェーン
ダイアログ保存 → `sessionInfo.SessionCommands` 更新（in-memory）→ Root `OnSessionSettingsSaved` → `_storageService.SaveSessionAsync` → `SessionRepository`（新カラム JSON 書き込み）

## 確認
- `dotnet build`: 0 警告 / 0 エラー
- マイグレーションは `ColumnExistsAsync` ガード付きで冪等。新規 DB は v1→…→v8 の順次適用でカラムが入る（新規DB shortcut を作らない既存方針に準拠）
- 実機確認はプレビュー版で予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
