### PR TITLE
fix: Stop でも IsCompacting を倒す（PostCompact 取りこぼし保険）

### DIFF
--- a/TerminalHub/Services/HookNotificationService.cs
+++ b/TerminalHub/Services/HookNotificationService.cs
@@ -186,6 +186,13 @@ public class HookNotificationService : IHookNotificationService
         session.ProcessingElapsedSeconds = null;
         session.LastProcessingUpdateTime = null;
         session.IsWaitingForUserInput = false;
+
+        // compact 中フラグを倒す保険。auto-compact がブロック/中断され PostCompact が
+        // 飛ばないケースがあり（公式仕様上、PreCompact がブロックされると PostCompact は来ない）、
+        // その場合 IsCompacting が立ったままになる。Stop（＝ターン完了）でも必ず倒して、
+        // 「コンパクト中」バッジの出っぱなしと「完了 + コンパクト中」の同時表示を防ぐ。
+        // （従来は UserPromptSubmit でしか倒しておらず、次プロンプトまで残っていた）
+        session.IsCompacting = false;
     }
 
     /// <summary>


### PR DESCRIPTION
## 概要
`Stop`（ターン完了）でも `IsCompacting` を倒す保険を追加し、コンパクト中バッジの「出っぱなし」と「完了 + コンパクト中」の同時表示を解消します。

## 背景（実機で確認した事象）
あるセッションで auto-compact が **`PreCompact` だけ発火し `PostCompact` が来ない**ケースを確認しました。

```
00:10:26  UserPromptSubmit
00:10:27  PreCompact        ← 対応する PostCompact が無い
00:11:06  Stop
00:12:07  UserPromptSubmit  ← ここでようやく（従来の保険で）IsCompacting が倒れる
```

- 公式 hooks 仕様上、`PreCompact` がブロックされる（`decision:block` / exit 2）と `PostCompact` は発火しない。auto-compact の中断・例外でも同様に `PreCompact` 単独になりうる。
- 従来は `UserPromptSubmit` でしか `IsCompacting` を倒していなかったため、**次のプロンプトを送るまでバッジが残存**。途中の `Stop`（完了）と合わさり「完了 + コンパクト中」の矛盾表示になっていた。
- 手動 `/compact` は `PreCompact`+`PostCompact` が完走する（TerminalHub の hook はブロックしていない）ことを確認済み。今回の事象は Claude Code 側の挙動で、TerminalHub は受信した hook 名をそのまま流しているだけ。

## 変更
`HookNotificationService.HandleStopEventAsync` の状態リセットブロックに `session.IsCompacting = false;` を追加。`Stop` を「PostCompact 取りこぼし全般への保険」として扱う。

## 効果
- `PostCompact` が来なくても `Stop` 時点でコンパクト中バッジが消える
- 「完了 + コンパクト中」の同時表示が解消
- 既存の `UserPromptSubmit` 側の保険はそのまま（二重の保険）

## テスト
- `dotnet build` 成功（警告0 / エラー0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
