### PR TITLE
feat: ターミナルフォントを Cascadia Mono 化＋囲み数字を合成フォントで可読化

### DIFF
--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -2,6 +2,31 @@
    TerminalHub Design System
    =========================================== */
 
+/* --- ターミナル用合成フォント 'TermMix' ---
+   ASCII・記号・罫線は従来どおり Consolas を使い、囲み数字（①②③ 等）の範囲だけ
+   等幅日本語フォントへ差し替えて大きく読みやすく描く。
+   font-family は「グリフを持つ最初のフォント」を使うため、Consolas を先頭に置くだけだと
+   Consolas が囲み数字グリフ（小さい）を持っているので日本語フォントが参照されない。
+   そこで unicode-range で囲み数字の範囲のみ後勝ちで日本語フォントに上書きする。
+   日本語フォントが無い環境では local() が空振りして Consolas にフォールバックする。 */
+@font-face {
+    font-family: 'TermMix';
+    src: local('Consolas');
+}
+@font-face {
+    font-family: 'TermMix';
+    /* 全角四角デザイン（BIZ UDGothic 等）は半角セルからはみ出して隣にかぶるため、
+       グリフ幅が細めの UI/シンボル系フォントを優先して overflow を軽減する。
+       特に ⑫ のような2桁囲み数字のかぶり対策。 */
+    src: local('Segoe UI Symbol'), local('Yu Gothic UI'), local('Meiryo UI'), local('BIZ UDGothic');
+    /* 半角セルからのはみ出し（特に ⑫ 等2桁）を size-adjust で縮めることも可能だが、
+       「小さくて読みにくいより、多少かぶっても大きく」を優先して等倍（100%）のままにする。
+       はみ出しが気になる場合は size-adjust: 85% 等を付ければ抑えられる。 */
+    /* U+2460-24FF: Enclosed Alphanumerics（①②③ ⑫ ⓪ ⑴ ⒈ ⓐ）
+       U+3200-32FF: Enclosed CJK Letters and Months（㉑〜 ㊙ ㈱ 等） */
+    unicode-range: U+2460-24FF, U+3200-32FF;
+}
+
 /* --- カスタムカラーパレット（ライトテーマ） --- */
 :root {
     /* アクセントカラー */

--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -11,7 +11,9 @@
    日本語フォントが無い環境では local() が空振りして Consolas にフォールバックする。 */
 @font-face {
     font-family: 'TermMix';
-    src: local('Consolas');
+    /* 主フォント: Cascadia Mono（MS 純正のターミナル向け等幅・リガチャ無し）。
+       未導入環境では Consolas にフォールバック。 */
+    src: local('Cascadia Mono'), local('Consolas');
 }
 @font-face {
     font-family: 'TermMix';

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -361,9 +361,10 @@ window.terminalFunctions = {
         const term = new Terminal({
             cursorBlink: true,
             fontSize: terminalFontSize,
-            // Consolas は囲み数字（①②③ 等）のグリフが小さく潰れて読みづらいため、
-            // 日本語等幅フォントを fallback に追加して該当グリフだけ補完させる（半角幅は維持）。
-            fontFamily: "Consolas, 'Yu Gothic', 'Meiryo', monospace",
+            // 合成フォント 'TermMix'（app.css の @font-face 参照）。ASCII・罫線は Consolas のまま、
+            // 囲み数字（①②③ 等）の範囲だけ等幅日本語フォントへ差し替えて読みやすくする。
+            // 末尾はフォント未解決時の保険（Consolas → monospace）。
+            fontFamily: "TermMix, Consolas, monospace",
             scrollback: 10000,
             scrollOnInput: true,
             scrollOnOutput: true,

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -361,7 +361,9 @@ window.terminalFunctions = {
         const term = new Terminal({
             cursorBlink: true,
             fontSize: terminalFontSize,
-            fontFamily: 'Consolas, monospace',
+            // Consolas は囲み数字（①②③ 等）のグリフが小さく潰れて読みづらいため、
+            // 日本語等幅フォントを fallback に追加して該当グリフだけ補完させる（半角幅は維持）。
+            fontFamily: "Consolas, 'Yu Gothic', 'Meiryo', monospace",
             scrollback: 10000,
             scrollOnInput: true,
             scrollOnOutput: true,

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -364,7 +364,7 @@ window.terminalFunctions = {
             // 合成フォント 'TermMix'（app.css の @font-face 参照）。ASCII・罫線は Consolas のまま、
             // 囲み数字（①②③ 等）の範囲だけ等幅日本語フォントへ差し替えて読みやすくする。
             // 末尾はフォント未解決時の保険（Consolas → monospace）。
-            fontFamily: "TermMix, Consolas, monospace",
+            fontFamily: "TermMix, 'Cascadia Mono', Consolas, monospace",
             scrollback: 10000,
             scrollOnInput: true,
             scrollOnOutput: true,


### PR DESCRIPTION
## 概要
ターミナル（xterm.js）のフォントまわりを2点改善します。

1. **主フォントを Consolas → Cascadia Mono に変更**（MS 純正のターミナル向け等幅・リガチャ無し。未導入環境では Consolas にフォールバック）
2. **囲み数字（`①②③⑫` 等）の可読性改善**：`@font-face` + `unicode-range` の合成フォント `TermMix` で、囲み数字の範囲だけ視認性の高いフォントへ差し替え

## 背景
- Cascadia Mono は Consolas より視認性が高く、Windows Terminal / VS の既定フォント。
- 囲み数字は Consolas / Cascadia Mono ともグリフが小さく潰れて読みづらい。単純な font-family 追記では、主フォントが囲み数字グリフを持つため fallback が参照されず無効だった。

## 変更
```css
/* app.css: 合成フォント TermMix */
@font-face { font-family:'TermMix'; src:local('Cascadia Mono'), local('Consolas'); }  /* 主フォント */
@font-face { font-family:'TermMix';
  src:local('Segoe UI Symbol'), local('Yu Gothic UI'), local('Meiryo UI'), local('BIZ UDGothic');
  unicode-range:U+2460-24FF, U+3200-32FF; }  /* 囲み数字だけ後勝ちで差し替え */
```
```js
// terminal.js
fontFamily: "TermMix, 'Cascadia Mono', Consolas, monospace"
```

- **ASCII・記号・罫線** → Cascadia Mono（無ければ Consolas）。TUI レイアウトへの影響なし
- **囲み数字**（Enclosed Alphanumerics / Enclosed CJK）→ 視認性の高い UI/シンボル系フォント
- フォント未導入環境では `local()` が空振りして順にフォールバック

## 既知のトレードオフ
囲み数字は East Asian Ambiguous Width で xterm が半角セルを割り当てるため、全角デザインの2桁囲み数字（`⑫` 等）は隣に軽くはみ出す。`size-adjust` で抑制可能だが、「小さくて読みにくいより多少かぶっても大きく」を優先し等倍のままとした（コメントに調整方法明記）。

## テスト
- 実機（VS デバッグ実行）で Cascadia Mono の描画、囲み数字 `①〜⑳` の可読性を目視確認。Cascadia Mono 単体／合成ありを比較し、合成ありを採用。
- JS/CSS のみの変更（C# ビルド対象外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
