### PR TITLE
fix: セッション専用コマンドが稼働中セッションで消える不具合

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -291,13 +291,34 @@
     private string errorMessage = "";
     private bool restartSession = true;
 
+    // ダイアログ表示状態・ロード済みセッションの追跡。
+    // OnParametersSetAsync は親（Root）の再描画のたびに呼ばれるため、開いている間の
+    // 再描画で LoadSessionInfo を再実行すると編集バッファ（editingSessionCommands 等）を
+    // 上書きしてしまう。稼働中セッションは hook で頻繁に再描画されるため、編集中の
+    // 専用コマンドが消え、空リストで保存 → hook 保存で DB からも消える不具合になっていた。
+    // そのため「開いた瞬間／対象セッションが変わった時」だけロードするようガードする。
+    private bool _wasVisible;
+    private Guid? _loadedSessionId;
+
     protected override async Task OnParametersSetAsync()
     {
         if (IsVisible && SessionId.HasValue)
         {
-            LoadSessionInfo();
-            await RefreshMemoExistsAsync();
+            // 開いた瞬間、または対象セッションが変わった時だけロード（再描画では上書きしない）
+            if (!_wasVisible || _loadedSessionId != SessionId)
+            {
+                LoadSessionInfo();
+                await RefreshMemoExistsAsync();
+                _loadedSessionId = SessionId;
+            }
         }
+        else if (!IsVisible)
+        {
+            // 閉じたら次回開いた時に確実に再ロードさせる
+            _loadedSessionId = null;
+        }
+
+        _wasVisible = IsVisible;
     }
 
     private async Task RefreshMemoExistsAsync()

--- a/TerminalHub/Services/SessionRepository.cs
+++ b/TerminalHub/Services/SessionRepository.cs
@@ -366,10 +366,10 @@ namespace TerminalHub.Services
                         INSERT OR REPLACE INTO Sessions
                         (SessionId, DisplayName, FolderPath, FolderName, CreatedAt, LastAccessedAt,
                          IsActive, TerminalType, Memo, IsArchived, ArchivedAt, ParentSessionId,
-                         IsPinned, PinPriority)
+                         IsPinned, PinPriority, SessionCommands)
                         VALUES (@sessionId, @displayName, @folderPath, @folderName, @createdAt, @lastAccessedAt,
                                 @isActive, @terminalType, @memo, @isArchived, @archivedAt, @parentSessionId,
-                                @isPinned, @pinPriority)",
+                                @isPinned, @pinPriority, @sessionCommands)",
                         ("@sessionId", session.SessionId.ToString()),
                         ("@displayName", session.DisplayName),
                         ("@folderPath", session.FolderPath),
@@ -383,7 +383,9 @@ namespace TerminalHub.Services
                         ("@archivedAt", session.ArchivedAt?.ToString("o")),
                         ("@parentSessionId", session.ParentSessionId?.ToString()),
                         ("@isPinned", session.IsPinned ? 1 : 0),
-                        ("@pinPriority", session.PinPriority.HasValue ? (object)session.PinPriority.Value : DBNull.Value));
+                        ("@pinPriority", session.PinPriority.HasValue ? (object)session.PinPriority.Value : DBNull.Value),
+                        // localStorage 移行時も専用コマンドを取りこぼさない（列漏れで消えるのを防ぐ）
+                        ("@sessionCommands", SerializeSessionCommands(session.SessionCommands)));
 
                     // オプションを保存
                     await SaveSessionOptionsAsync(connection, session.SessionId, session.Options);


### PR DESCRIPTION
## 概要
セッション専用コマンド（`SessionInfo.SessionCommands`）が、**稼働中の（hook が頻繁に飛ぶ）セッションで消える**不具合を修正します。

## 症状
特定セッションに登録した専用コマンド（例: `/preview` `/release`）が、いつの間にか消える。グローバルのカスタムコマンド（`app-settings.json`）は無事で、消えるのはセッション専用（SQLite `Sessions.SessionCommands` 列）のみ。

## 原因（調査結果）
`SessionSettingsDialog.razor` の `OnParametersSetAsync` が**ガード無し**で、`IsVisible` の間は**親(Root)の再描画のたびに `LoadSessionInfo()` を再実行**し、編集バッファ `editingSessionCommands` を `sessionInfo.SessionCommands` で上書きしていた。

稼働中の ClaudeCode セッションは **hook が数秒ごとに発火 → Root が `StateHasChanged`（100ms デバウンス）で頻繁に再描画**するため、専用コマンドの編集中にバッファが繰り返し上書きされ、**空/古いリストで保存** → hook 由来の `SaveSessionAsync`（`HookNotificationService` / `OutputAnalyzerService`）で **DB からも即消える**状態だった。

切り分けで否定した仮説（参考）:
- 破壊的な localStorage→SQLite 移行（`DELETE FROM Sessions`）→ **ログ上で未実行**。
- スキーマ v8 マイグレーション（`SessionCommands` 列追加）→ 非破壊で正常。
- `RestartSessionAsync` → 同一インスタンス再利用で `SessionCommands` 保持。

## 変更
1. **`SessionSettingsDialog.razor`**: `OnParametersSetAsync` を「**開いた瞬間／対象セッションが変わった時だけ** `LoadSessionInfo()` する」ようガード（`_wasVisible` / `_loadedSessionId` で追跡、閉じたらリセット）。開いている間の再描画では編集バッファを上書きしない。`displayName` / `memo` / オプション等の同根の巻き戻りも同時に解消。
2. **`SessionRepository.cs`（補強）**: `MigrateFromLocalStorageAsync` の再 INSERT に欠落していた `SessionCommands` 列を追加（将来 localStorage 移行時の取りこぼし防止）。

## テスト
- `dotnet build` 成功（警告0 / エラー0）。
- 手動検証（推奨）: hook が頻繁に飛ぶ稼働中 ClaudeCode セッションで設定ダイアログを開き、専用コマンドを追加 → 数秒待って「保存」→ `sessions.db` の当該行 `SessionCommands` に残り、再起動後も保持されること。

## 補足
消失済みのコマンドは全 DB・バックアップに残っておらず**復旧不可**。修正適用後に再登録してください（修正前に再登録しても同じ稼働中セッションでは再度消えます）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
