### PR TITLE
fix: アプリ再起動でセッション専用コマンドが消える不具合（復元漏れ・主因）

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -559,6 +559,15 @@
                             createdSession.IsPinned = sessionInfo.IsPinned;
                             createdSession.PinPriority = sessionInfo.PinPriority;
 
+                            // セッション専用コマンドを復元。
+                            // CreateSessionAsync は空の SessionCommands で新規 SessionInfo を作るため、
+                            // ここでコピーし忘れると、アプリ再起動後に in-memory が空になり、
+                            // 直後の hook 由来の保存で DB からも消えてしまう（＝再起動で毎回消える不具合）。
+                            if (sessionInfo.SessionCommands != null && sessionInfo.SessionCommands.Count > 0)
+                            {
+                                createdSession.SessionCommands = sessionInfo.SessionCommands;
+                            }
+
                             await SessionManager.SaveSessionInfoAsync(createdSession);
                         }
 


### PR DESCRIPTION
## 概要
**アプリを再起動するたびにセッション専用コマンド（`SessionInfo.SessionCommands`）が全消失する**不具合を修正します。専用コマンド消失の**主因**です（PR #85 は副因の修正でした）。

## 原因
起動時のセッション復元（`Root.razor` の `LoadSessionsAsync` 後のループ）で、DB から読んだ `sessionInfo` には `SessionCommands` が入っているのに、**`CreateSessionAsync` で新しい `SessionInfo` を作り直し**、そこへ一部フィールド（CreatedAt / LastAccessedAt / Memo / CheckedScripts / 親子関係 / Pin）だけ手でコピーしていた。**`SessionCommands` のコピーが漏れていた**ため：

1. 復元後の in-memory セッションは `SessionCommands` が空。
2. 稼働中セッションは hook 由来の `SaveSessionAsync`（`HookNotificationService` / `OutputAnalyzerService`）で頻繁に保存される。
3. → 空の `SessionCommands` が **DB に即上書き**され、消える。

### 実機ログでの裏取り
```
10:47:37  専用コマンド2件を保存（DB=2件）
10:49:06  アプリ再起動（MemoSnapshot/MQTT 起動）
10:49:09  DB から復元（この時点で DB は 2件）→ 復元漏れで in-memory は空
10:49:39  text送信→hook保存 → DB が空に
```

## 変更
`Root.razor` の復元ブロックに `createdSession.SessionCommands = sessionInfo.SessionCommands;` を追加（他フィールドの復元と同じ場所）。

## PR #85 との関係
- **#85**（マージ済み）: 設定ダイアログの編集中に再描画で編集バッファが上書きされる副因を修正。
- **本PR**: アプリ再起動時の復元漏れ（主因）を修正。
- 両方入って、専用コマンドが「編集中に消える」「再起動で消える」双方を解消。

## テスト
- `dotnet build` 成功（警告0 / エラー0）。
- 手動検証（推奨）: 専用コマンドを登録・保存 → **アプリを再起動** → クイック送信バーに残っていること、`sessions.db` の当該行 `SessionCommands` が保持されていることを確認。

## 補足
既に消えた分は復旧不可（要再登録）。**この修正が入ったビルドで**再登録してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
