### PR TITLE
feat: 専用コマンドのサブダイアログを即時保存に変更

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -62,7 +62,8 @@
                        OnSettingsSaved="OnSessionSettingsSaved"
                        OnCancel="() => showSessionSettingsDialog = false"
                        OnCreateSubSession="HandleCreateSubSessionFromSettings"
-                       OnMemoRestored="HandleMemoRestoredFromSettings" />
+                       OnMemoRestored="HandleMemoRestoredFromSettings"
+                       OnSessionCommandsChanged="OnSessionCommandsChanged" />
 <ArchivedSessionsDialog IsVisible="showArchivedSessionsDialog"
                         ArchivedSessions="@GetArchivedSessions()"
                         OnRestoreSession="RestoreArchivedSession"
@@ -2257,6 +2258,25 @@
         {
             await bottomPanel.ReloadMemosForCurrentSessionAsync();
         }
+    }
+
+    // 専用コマンドの即時保存: 設定ダイアログのサブダイアログで追加/編集/削除された都度呼ばれる。
+    // 本体ダイアログの「保存」を待たず、その場で当該セッションを DB へ永続化し、
+    // クイック送信バーの表示も更新する。
+    private async Task OnSessionCommandsChanged()
+    {
+        if (settingsSessionId.HasValue)
+        {
+            var session = SessionManager.GetSessionInfo(settingsSessionId.Value);
+            if (session != null)
+            {
+                await SaveSessionToStorageAsync(session);
+            }
+        }
+
+        // クイック送信バー等の表示を更新
+        sessions = SessionManager.GetAllSessions().ToList();
+        StateHasChanged();
     }
 
     private async Task OnSessionSettingsSaved()

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -2270,7 +2270,17 @@
             var session = SessionManager.GetSessionInfo(settingsSessionId.Value);
             if (session != null)
             {
-                await SaveSessionToStorageAsync(session);
+                // 即時保存は編集の都度 DB 書き込みが走るため、hook 由来の保存と競合して
+                // SQLITE_BUSY 等の例外が出る可能性がある。ここで握りつぶして Circuit 切断を防ぐ
+                // （in-memory の SessionCommands は反映済みなので、次の保存機会で DB へ再反映される）。
+                try
+                {
+                    await SaveSessionToStorageAsync(session);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(ex, "専用コマンドの即時保存に失敗: {SessionId}", session.SessionId);
+                }
             }
         }
 

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -262,6 +262,8 @@
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback<Guid> OnCreateSubSession { get; set; }
     [Parameter] public EventCallback OnMemoRestored { get; set; }
+    // 専用コマンドの即時保存通知（追加/編集/削除の都度、呼び出し元が DB へ永続化する）
+    [Parameter] public EventCallback OnSessionCommandsChanged { get; set; }
 
     private bool showMemoManagement = false;
     private bool anyMemoExists = false;
@@ -580,7 +582,7 @@
         commandEditDialogVisible = true;
     }
 
-    private void HandleSessionCommandSave(CustomCommand command)
+    private async Task HandleSessionCommandSave(CustomCommand command)
     {
         if (commandEditDialogIndex is int idx && idx >= 0 && idx < editingSessionCommands.Count)
         {
@@ -591,6 +593,7 @@
             editingSessionCommands.Add(command); // 新規：末尾に追加
         }
         // ダイアログ側が Close を呼び OnSessionCommandDialogVisibleChanged 経由で state クリア
+        await PersistSessionCommandsAsync(); // 即時保存
     }
 
     private void OnSessionCommandDialogVisibleChanged(bool visible)
@@ -604,12 +607,39 @@
         }
     }
 
-    private void RemoveSessionCommand(int index)
+    private async Task RemoveSessionCommand(int index)
     {
         if (index >= 0 && index < editingSessionCommands.Count)
         {
             editingSessionCommands.RemoveAt(index);
+            await PersistSessionCommandsAsync(); // 即時保存
         }
+    }
+
+    /// <summary>
+    /// 専用コマンドの編集内容を実セッション（sessionInfo）へ反映し、呼び出し元に永続化を依頼する。
+    /// サブダイアログでの追加/編集/削除を「その場で保存」するために使う（本体ダイアログの保存を待たない）。
+    /// </summary>
+    private async Task PersistSessionCommandsAsync()
+    {
+        if (sessionInfo == null)
+            return;
+
+        // editingSessionCommands をディープコピーして実セッションへ反映（以降の編集で相互に壊さないため）
+        sessionInfo.SessionCommands = editingSessionCommands
+            .Select(c => new CustomCommand
+            {
+                Title = c.Title,
+                CommandText = c.CommandText,
+                Type = c.Type,
+                KeyName = c.KeyName,
+                GroupName = c.GroupName,
+                SendMode = c.SendMode
+            })
+            .ToList();
+
+        // 呼び出し元（Root）が DB 永続化とクイック送信バーの更新を行う
+        await OnSessionCommandsChanged.InvokeAsync();
     }
 
     private static string GetTerminalTypeDisplayName(TerminalType type) => type switch

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -440,7 +440,7 @@
   <data name="SessionSettings.Commands.Header" xml:space="preserve"><value>Commands for this session only</value></data>
   <data name="SessionSettings.Commands.Help" xml:space="preserve"><value>These commands appear in the quick-send bar for this session only (after the global commands).</value></data>
   <data name="SessionSettings.Commands.ManageButton" xml:space="preserve"><value>Commands</value></data>
-  <data name="SessionSettings.Commands.SaveHint" xml:space="preserve"><value>Changes are applied when you Save the session settings.</value></data>
+  <data name="SessionSettings.Commands.SaveHint" xml:space="preserve"><value>Additions, edits, and deletions are saved immediately.</value></data>
   <data name="SessionSettings.Loading" xml:space="preserve"><value>Loading session info...</value></data>
   <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>Apply changes immediately (restart session)</value></data>
   <data name="SessionSettings.Save" xml:space="preserve"><value>Save</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -440,7 +440,7 @@
   <data name="SessionSettings.Commands.Header" xml:space="preserve"><value>このセッション専用のコマンド</value></data>
   <data name="SessionSettings.Commands.Help" xml:space="preserve"><value>このセッションでだけクイック送信バーに表示されるコマンドです（全体設定のコマンドの後ろに並びます）</value></data>
   <data name="SessionSettings.Commands.ManageButton" xml:space="preserve"><value>専用コマンド</value></data>
-  <data name="SessionSettings.Commands.SaveHint" xml:space="preserve"><value>変更はセッション設定の「保存」で確定します。</value></data>
+  <data name="SessionSettings.Commands.SaveHint" xml:space="preserve"><value>追加・編集・削除は即時保存されます。</value></data>
   <data name="SessionSettings.Loading" xml:space="preserve"><value>セッション情報を読み込み中…</value></data>
   <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>変更を即座に適用（セッションを再起動）</value></data>
   <data name="SessionSettings.Save" xml:space="preserve"><value>保存</value></data>


### PR DESCRIPTION
## 概要
セッション専用コマンドのサブダイアログでの**追加・編集・削除を「即時保存」**に変更します。これまでは本体（セッション設定）ダイアログの「保存」を押すまで反映されず、「サブダイアログで追加したのに戻って保存しないと適用されない」という分かりにくさがありました。

## 背景
専用コマンドはバッファ（`editingSessionCommands`）方式で、本体ダイアログの「保存」→ `OnSettingsSaved` 経由でまとめて確定していた。専用コマンドはターミナル種別・オプション・再起動と違い**独立した設定で再起動も不要**なため、その場で確定してよい。

## 変更
- **`SessionSettingsDialog.razor`**
  - `OnSessionCommandsChanged` コールバックと `PersistSessionCommandsAsync()` を追加。
  - `HandleSessionCommandSave` / `RemoveSessionCommand` を `async` 化し、変更の都度 `editingSessionCommands` を `sessionInfo.SessionCommands` へ反映 → 呼び出し元へ永続化を依頼。
- **`Root.razor`**
  - `OnSessionCommandsChanged` を配線。当該セッションを `SaveSessionToStorageAsync` で DB 保存し、クイック送信バー表示を更新。
- **resx（ja/en）**
  - 注意書きを「追加・編集・削除は即時保存されます。」に変更。

## 挙動
- サブダイアログで追加/編集/削除 → **その場で DB 保存**、クイック送信バーへ即反映。本体「保存」を待たない。
- 本体ダイアログの「保存」は従来どおり（種別・オプション・再起動等）。専用コマンドは既に保存済みなので二重でも無害。

## テスト
- `dotnet build` 成功（警告0 / エラー0）。
- 手動検証（VS デバッグで可）: サブダイアログで専用コマンドを追加 → 本体「保存」を押さずに閉じる → クイック送信バーに出る＆`sessions.db`/`sessions-dev7.db` に保存されていること。削除も即反映されること。

## 関連
専用コマンド消失の修正（#85 編集時クロバー / #86 再起動時の復元漏れ）と同じ領域の UX 改善。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
