### PR TITLE
fix: セッション保存失敗のログ化 & envBlock のリーク防止（Codexレビュー #3/#4）

### DIFF
--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -242,22 +242,28 @@ namespace TerminalHub.Services
             // XTerm互換のための環境変数を設定
             var envBlock = CreateEnvironmentBlock();
             
-            var result = CreateProcess(
-                null,
-                cmdline,
-                IntPtr.Zero,
-                IntPtr.Zero,
-                false,
-                ConPtyTerminalConstants.ExtendedStartupinfoPresent | CREATE_UNICODE_ENVIRONMENT,
-                envBlock,
-                workingDirectory,
-                ref startupInfo,
-                out processInfo);
-                
-            // 環境変数ブロックを解放
-            if (envBlock != IntPtr.Zero)
-                Marshal.FreeHGlobal(envBlock);
-                
+            bool result;
+            try
+            {
+                result = CreateProcess(
+                    null,
+                    cmdline,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    false,
+                    ConPtyTerminalConstants.ExtendedStartupinfoPresent | CREATE_UNICODE_ENVIRONMENT,
+                    envBlock,
+                    workingDirectory,
+                    ref startupInfo,
+                    out processInfo);
+            }
+            finally
+            {
+                // 環境変数ブロックを確実に解放（例外時のリークも防ぐ）
+                if (envBlock != IntPtr.Zero)
+                    Marshal.FreeHGlobal(envBlock);
+            }
+
             if (!result)
             {
                 var error = Marshal.GetLastWin32Error();

--- a/TerminalHub/Services/HookNotificationService.cs
+++ b/TerminalHub/Services/HookNotificationService.cs
@@ -170,7 +170,15 @@ public class HookNotificationService : IHookNotificationService
         // 最終利用時刻を更新（ソート用）
         _logger.LogInformation("[LastAccessedAt更新] きっかけ: HookNotificationService(Stop イベント), セッション: {SessionName}", session.GetDisplayName());
         session.LastAccessedAt = DateTime.Now;
-        try { await _sessionRepository.SaveSessionAsync(session); } catch { }
+        try
+        {
+            await _sessionRepository.SaveSessionAsync(session);
+        }
+        catch (Exception ex)
+        {
+            // 保存失敗を黙殺すると並び順(LastAccessedAt)や状態復元の不具合を追えなくなるため、警告として残す
+            _logger.LogWarning(ex, "Stop イベント後のセッション保存に失敗: {SessionName}", session.GetDisplayName());
+        }
 
         // 処理状態を完全にリセット（SessionTimeoutと同じ項目をクリア）
         _logger.LogInformation(

--- a/TerminalHub/Services/OutputAnalyzerService.cs
+++ b/TerminalHub/Services/OutputAnalyzerService.cs
@@ -222,7 +222,10 @@ namespace TerminalHub.Services
                     // 最終利用時刻を更新（ソート用）
                     _logger.LogInformation("[LastAccessedAt更新] きっかけ: OutputAnalyzerService(処理完了検出), セッション: {SessionName}", session.GetDisplayName());
                     session.LastAccessedAt = DateTime.Now;
-                    try { _ = _sessionRepository.SaveSessionAsync(session); } catch { }
+                    // fire-and-forget だが、失敗を黙殺せず faulted 時に警告を残す（診断のため）
+                    _ = _sessionRepository.SaveSessionAsync(session).ContinueWith(
+                        t => _logger.LogWarning(t.Exception, "処理完了時のセッション保存に失敗: {SessionName}", session.GetDisplayName()),
+                        TaskContinuationOptions.OnlyOnFaulted);
 
                     // セッション情報をクリア
                     session.ProcessingStartTime = null;


### PR DESCRIPTION
## 概要
Codex の全般レビュー指摘のうち、**安全・高価値な2件**を対応します（ConPTY のインジェクション/Win32戻り値/Dispose 非同期化などリスク高・大リファクタ系は今回見送り）。

## #4 セッション保存失敗の黙殺をやめる
保存失敗が並び順（`LastAccessedAt`）や状態復元の不具合として現れても追えるよう、ログを残す。
- **`HookNotificationService`**（Stop 後の保存）: `catch { }` → `LogWarning`。
- **`OutputAnalyzerService`**（処理完了時の fire-and-forget 保存）: 従来の `try { _ = ...; } catch { }` は**同期例外しか拾えなかった**ため、`ContinueWith(..., OnlyOnFaulted)` で非同期失敗を警告ログに残す形へ変更。

> 補足: 今回のセッション専用コマンド消失の調査でも、この手の「静かな保存失敗」は原因追跡を難しくする要因だった。

## #3 ConPtyService の環境変数ブロックのリーク防止
`CreateEnvironmentBlock()` で確保した `envBlock` を、`CreateProcess` を囲む **try/finally の finally で `FreeHGlobal`** するよう変更。例外時や将来の変更でのリークを防ぐ。**成功パスの挙動は不変**（解放タイミング・回数は同じ、保証されるだけ）。

## テスト
- `dotnet build` 成功（警告0 / エラー0）。
- ⚠️ #3 は ConPtyService を触るため、**VS デバッグ実行でセッション（Claude/Terminal 等）が従来どおり起動できることの確認をお願いします**（Claude 経由では ConPTY を検証できないため）。挙動非破壊の変更なので影響は無い想定です。

## 見送った指摘（参考）
- #1 `cmd.exe /c` の引用（リスク大・実害小、ローカル利用前提）
- #2 Win32 戻り値チェック（220行の1回目 Init は「わざと失敗」パターンのため要注意。別途検討）
- #6 Dispose の `IAsyncDisposable` 化（大リファクタ）
- #5 `Console.WriteLine` → ILogger（些末）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
