### PR TITLE
feat: プレビュー版ビルドにPR番号/SHA/日時のバージョンバッジを表示

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # マージコミットからPR番号を辿るため履歴を全取得
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -39,6 +41,20 @@ jobs:
             BASE=$(grep -oP '(?<=<Version>)[^<]+' TerminalHub/TerminalHub.csproj | head -1)
             echo "VERSION=${BASE}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Compute preview build metadata
+        id: build_meta
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |
+          # 直近の「Merge pull request #NN」からPR番号を抽出（無ければ空）
+          PR=$(git log --grep='Merge pull request #' -1 --pretty=%s | grep -oP '#\K[0-9]+' || true)
+          SHA=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y-%m-%d)
+          echo "PR=${PR}" >> $GITHUB_OUTPUT
+          echo "SHA=${SHA}" >> $GITHUB_OUTPUT
+          echo "DATE=${DATE}" >> $GITHUB_OUTPUT
+          echo "プレビュー版メタデータ: PR=#${PR:-?} SHA=${SHA} DATE=${DATE}"
 
       - name: Update version in installer script
         if: startsWith(github.ref, 'refs/tags/v') || inputs.build_installer == true
@@ -68,7 +84,21 @@ jobs:
           $json | ConvertTo-Json -Depth 10 | Set-Content $settingsPath -NoNewline
 
       - name: Publish application
-        run: dotnet publish TerminalHub/TerminalHub.csproj -c Release -r win-x64 --self-contained true -o ./publish /p:Version=${{ steps.get_version.outputs.VERSION }}
+        shell: bash
+        run: |
+          # vタグ = 正式リリース版（チャンネル release、プレビュー情報は埋め込まない）
+          # それ以外 = プレビュー版（PR番号/SHA/日時を AssemblyMetadata に注入）
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            CHANNEL="release"
+          else
+            CHANNEL="preview"
+          fi
+          dotnet publish TerminalHub/TerminalHub.csproj -c Release -r win-x64 --self-contained true -o ./publish \
+            /p:Version=${{ steps.get_version.outputs.VERSION }} \
+            /p:BuildChannel=${CHANNEL} \
+            /p:BuildPr=${{ steps.build_meta.outputs.PR }} \
+            /p:BuildCommit=${{ steps.build_meta.outputs.SHA }} \
+            /p:BuildDate=${{ steps.build_meta.outputs.DATE }}
 
       - name: Install Inno Setup
         if: startsWith(github.ref, 'refs/tags/v') || inputs.build_installer == true

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -203,9 +203,20 @@
 
                                 <div class="mb-4">
                                     <h6 class="mb-2">@L["Settings.General.Version.Header"]</h6>
-                                    <div class="d-flex align-items-center mb-2">
+                                    <div class="d-flex align-items-center mb-2 flex-wrap">
                                         <span class="me-2">@L["Settings.General.Version.Current"]</span>
                                         <span class="badge bg-secondary">v@(currentVersion)</span>
+                                        @if (previewBuild != null)
+                                        {
+                                            <span class="badge bg-warning text-dark ms-2" title="@L["Settings.General.Version.PreviewHint"]">
+                                                <i class="bi bi-cone-striped me-1"></i>@L["Settings.General.Version.PreviewLabel"]
+                                            </span>
+                                            <a href="@previewBuild.CommitUrl" target="_blank" class="ms-2 small text-decoration-none"
+                                               title="@L["Settings.General.Version.PreviewHint"]">
+                                                @previewBuild.DisplayText
+                                                <i class="bi bi-box-arrow-up-right ms-1"></i>
+                                            </a>
+                                        }
                                     </div>
 
                                     @if (isCheckingVersion)
@@ -1162,6 +1173,7 @@
 
     // バージョンチェック関連
     private string currentVersion = "";
+    private PreviewBuildInfo? previewBuild = null;
     private VersionCheckResult? versionCheckResult = null;
     private bool isCheckingVersion = false;
     private string? versionCheckError = null;
@@ -1337,6 +1349,7 @@
 
             // バージョン情報を取得
             currentVersion = VersionCheckService.CurrentVersion;
+            previewBuild = VersionCheckService.PreviewBuild;
 
             // 設定画面を開いた時にバージョンチェック実行
             _ = CheckForUpdatesAsync();

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -96,6 +96,8 @@
   <data name="Settings.General.Version.NewAvailableHtml" xml:space="preserve"><value>A new version &lt;strong&gt;v{0}&lt;/strong&gt; is available</value></data>
   <data name="Settings.General.Version.CheckOnGitHub" xml:space="preserve"><value>Check on GitHub</value></data>
   <data name="Settings.General.Version.UpToDate" xml:space="preserve"><value>You're on the latest version</value></data>
+  <data name="Settings.General.Version.PreviewLabel" xml:space="preserve"><value>Preview</value></data>
+  <data name="Settings.General.Version.PreviewHint" xml:space="preserve"><value>Local pre-release build. Includes changes up to the PR number / commit shown. Click to open the commit on GitHub.</value></data>
   <data name="Settings.General.Community.Header" xml:space="preserve"><value>Community</value></data>
   <data name="Settings.General.Community.JoinDiscord" xml:space="preserve"><value>Join the Discord server</value></data>
   <data name="Settings.General.Community.Help" xml:space="preserve"><value>Bug reports, feature requests, and questions are welcome there.</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -96,6 +96,8 @@
   <data name="Settings.General.Version.NewAvailableHtml" xml:space="preserve"><value>新しいバージョン &lt;strong&gt;v{0}&lt;/strong&gt; があります</value></data>
   <data name="Settings.General.Version.CheckOnGitHub" xml:space="preserve"><value>GitHubで確認</value></data>
   <data name="Settings.General.Version.UpToDate" xml:space="preserve"><value>最新バージョンです</value></data>
+  <data name="Settings.General.Version.PreviewLabel" xml:space="preserve"><value>プレビュー版</value></data>
+  <data name="Settings.General.Version.PreviewHint" xml:space="preserve"><value>先行テスト用のローカルビルドです。表示のPR番号／コミットまでの変更が含まれます。クリックでGitHubのコミットを開きます。</value></data>
   <data name="Settings.General.Community.Header" xml:space="preserve"><value>コミュニティ</value></data>
   <data name="Settings.General.Community.JoinDiscord" xml:space="preserve"><value>Discord サーバーに参加</value></data>
   <data name="Settings.General.Community.Help" xml:space="preserve"><value>バグ報告、機能リクエスト、質問などはこちらで受け付けています。</value></data>

--- a/TerminalHub/Services/VersionCheckService.cs
+++ b/TerminalHub/Services/VersionCheckService.cs
@@ -26,6 +26,44 @@ public class VersionCheckResult
 }
 
 /// <summary>
+/// プレビュー版（CI の workflow_dispatch）ビルドに埋め込まれる追加情報。
+/// 正式リリース版・ローカル dotnet run では null。
+/// </summary>
+public class PreviewBuildInfo
+{
+    /// <summary>適用済み最新PR番号（例: "88"）。取得できない場合は null</summary>
+    public string? PrNumber { get; set; }
+
+    /// <summary>ビルド元コミットの短縮SHA（例: "e83b47f"）</summary>
+    public string? Commit { get; set; }
+
+    /// <summary>ビルド日時（UTC, "yyyy-MM-dd"）</summary>
+    public string? Date { get; set; }
+
+    /// <summary>コミットSHAへのGitHubリンク（SHAが無い場合はリポジトリトップ）</summary>
+    public string CommitUrl => string.IsNullOrWhiteSpace(Commit)
+        ? "https://github.com/zio3/TerminalHub"
+        : $"https://github.com/zio3/TerminalHub/commit/{Commit}";
+
+    /// <summary>バッジ等に表示する整形済みテキスト（例: "PR #88 / e83b47f (2026-07-02)"）</summary>
+    public string DisplayText
+    {
+        get
+        {
+            var parts = new List<string>();
+            if (!string.IsNullOrWhiteSpace(PrNumber)) parts.Add($"PR #{PrNumber}");
+            if (!string.IsNullOrWhiteSpace(Commit)) parts.Add(Commit!);
+            var main = string.Join(" / ", parts);
+            if (!string.IsNullOrWhiteSpace(Date))
+            {
+                main = string.IsNullOrEmpty(main) ? Date! : $"{main} ({Date})";
+            }
+            return main;
+        }
+    }
+}
+
+/// <summary>
 /// GitHub Releases API レスポンス
 /// </summary>
 internal class GitHubRelease
@@ -49,6 +87,12 @@ public interface IVersionCheckService
     /// 現在のアプリケーションバージョン
     /// </summary>
     string CurrentVersion { get; }
+
+    /// <summary>
+    /// プレビュー版ビルドの追加情報（PR番号 / コミットSHA / ビルド日時）。
+    /// 正式リリース版・ローカルビルドでは null。
+    /// </summary>
+    PreviewBuildInfo? PreviewBuild { get; }
 
     /// <summary>
     /// GitHubで新しいバージョンがあるかチェック
@@ -91,6 +135,39 @@ public class VersionCheckService : IVersionCheckService
             }
 
             return version;
+        }
+    }
+
+    public PreviewBuildInfo? PreviewBuild
+    {
+        get
+        {
+            var metadata = Assembly.GetExecutingAssembly()
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Where(a => !string.IsNullOrEmpty(a.Key))
+                .GroupBy(a => a.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.First().Value, StringComparer.OrdinalIgnoreCase);
+
+            // "preview" チャンネルのビルドのときだけ表示（正式版・ローカルビルドは null）
+            if (!metadata.TryGetValue("BuildChannel", out var channel) ||
+                !string.Equals(channel, "preview", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            metadata.TryGetValue("BuildPr", out var pr);
+            metadata.TryGetValue("BuildCommit", out var commit);
+            metadata.TryGetValue("BuildDate", out var date);
+
+            var info = new PreviewBuildInfo
+            {
+                PrNumber = string.IsNullOrWhiteSpace(pr) ? null : pr,
+                Commit = string.IsNullOrWhiteSpace(commit) ? null : commit,
+                Date = string.IsNullOrWhiteSpace(date) ? null : date,
+            };
+
+            // 表示できる中身が何もなければ null（チャンネルだけ preview で他が空のケース）
+            return string.IsNullOrEmpty(info.DisplayText) ? null : info;
         }
     }
 

--- a/TerminalHub/TerminalHub.csproj
+++ b/TerminalHub/TerminalHub.csproj
@@ -9,6 +9,15 @@
     <UserSecretsId>d24c2b6b-274a-45ae-9889-2950682fff62</UserSecretsId>
   </PropertyGroup>
 
+  <!-- プレビュー版（workflow_dispatch）ビルド時に CI から注入されるビルドメタデータ。
+       ローカル dotnet run / 正式リリース(vタグ)ビルドでは空のままなので埋め込まれない。 -->
+  <ItemGroup>
+    <AssemblyMetadata Include="BuildChannel" Value="$(BuildChannel)" Condition="'$(BuildChannel)' != ''" />
+    <AssemblyMetadata Include="BuildPr" Value="$(BuildPr)" Condition="'$(BuildPr)' != ''" />
+    <AssemblyMetadata Include="BuildCommit" Value="$(BuildCommit)" Condition="'$(BuildCommit)' != ''" />
+    <AssemblyMetadata Include="BuildDate" Value="$(BuildDate)" Condition="'$(BuildDate)' != ''" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
     <!-- CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) を回避するため、SQLitePCLRaw を 3.x にオーバーライド -->

--- a/TerminalHub/TerminalHub.csproj
+++ b/TerminalHub/TerminalHub.csproj
@@ -9,8 +9,11 @@
     <UserSecretsId>d24c2b6b-274a-45ae-9889-2950682fff62</UserSecretsId>
   </PropertyGroup>
 
-  <!-- プレビュー版（workflow_dispatch）ビルド時に CI から注入されるビルドメタデータ。
-       ローカル dotnet run / 正式リリース(vタグ)ビルドでは空のままなので埋め込まれない。 -->
+  <!-- CI から注入されるビルドメタデータ。
+       BuildChannel は CI ビルドでは常に release(vタグ) / preview(workflow_dispatch) が入る。
+       BuildPr / BuildCommit / BuildDate はプレビュー版ビルドのみ設定される。
+       ローカル dotnet run では全て未設定 → Condition が false になり埋め込まれない。
+       プレビュー版バッジの表示可否は BuildChannel=="preview" で判定する（VersionCheckService）。 -->
   <ItemGroup>
     <AssemblyMetadata Include="BuildChannel" Value="$(BuildChannel)" Condition="'$(BuildChannel)' != ''" />
     <AssemblyMetadata Include="BuildPr" Value="$(BuildPr)" Condition="'$(BuildPr)' != ''" />


### PR DESCRIPTION
## 背景
開発用のローカルインストーラー（`workflow_dispatch` プレビュービルド）とタグ版の正式リリースは、csproj のバージョン番号が同じ（例 `v1.0.61`）で**見た目で区別が付かない**。「このインストーラーはどのPRまで適用したビルドか？」を設定画面から分かるようにしたい、という要望への対応。

## やったこと
設定画面のバージョン欄に、**プレビュー版ビルドのときだけ**「プレビュー版」バッジと `PR #88 / e83b47f (2026-07-02)` を表示する（SHA はクリックで GitHub コミットを開く）。

| ファイル | 内容 |
|---|---|
| `TerminalHub.csproj` | CI から渡す `BuildChannel/BuildPr/BuildCommit/BuildDate` を `AssemblyMetadata` に注入（空なら埋め込まない） |
| `VersionCheckService.cs` | `PreviewBuildInfo` クラス＋`PreviewBuild` プロパティ追加。チャンネルが `preview` のときだけ値を返す |
| `SettingsDialog.razor` | バージョンバッジ横にプレビュー情報を表示 |
| `SharedResource.ja/en.resx` | `PreviewLabel` / `PreviewHint` を追加 |
| `.github/workflows/release.yml` | `fetch-depth:0`、マージコミットからPR番号抽出、publish に `/p:Build*` を注入。vタグ版は `release` チャンネルでプレビュー情報を埋め込まない |

## 表示の切り分け（検証済み）
- **ローカル `dotnet run`** → メタデータ無し → バッジ非表示（従来通り `v1.0.61` のみ）
- **プレビュー版（workflow_dispatch）** → `preview` チャンネル → バッジ表示
- **正式版（vタグ）** → `release` チャンネル → 非表示（スッキリ）

## 検証
- `dotnet build` 成功（0 警告 / 0 エラー）
- `/p:BuildChannel=preview /p:BuildPr=88 ...` 付きビルドで生成される `TerminalHub.AssemblyInfo.cs` に `[assembly: AssemblyMetadata(...)]` が4つ出力されることを確認
- プロパティ無しの通常ビルドではメタデータが埋め込まれない（＝ローカル/正式版は無印）ことを確認

## トレードオフ・補足
- PR番号は「直近の `Merge pull request #NN`」から抽出。マージコミット運用の間は正確だが、将来 squash マージに変えると空振りする。その場合も **SHA と日時は常に正確**。
- SHA はアセンブリに元々含まれていた情報のため、埋め込みコストはほぼゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)