### PR TITLE
fix(ci): Publish ステップを pwsh に戻して /p: の先頭スラッシュ剥がれを回避

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,20 +84,16 @@ jobs:
           $json | ConvertTo-Json -Depth 10 | Set-Content $settingsPath -NoNewline
 
       - name: Publish application
-        shell: bash
+        shell: pwsh
         run: |
-          # vタグ = 正式リリース版（チャンネル release、プレビュー情報は埋め込まない）
-          # それ以外 = プレビュー版（PR番号/SHA/日時を AssemblyMetadata に注入）
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            CHANNEL="release"
-          else
-            CHANNEL="preview"
-          fi
-          dotnet publish TerminalHub/TerminalHub.csproj -c Release -r win-x64 --self-contained true -o ./publish \
-            /p:Version=${{ steps.get_version.outputs.VERSION }} \
-            /p:BuildChannel=${CHANNEL} \
-            /p:BuildPr=${{ steps.build_meta.outputs.PR }} \
-            /p:BuildCommit=${{ steps.build_meta.outputs.SHA }} \
+          # vタグ = 正式リリース版（channel=release）/ それ以外 = プレビュー版（channel=preview）
+          # ※ Git Bash だと MSYS のパス変換で "/p:" の先頭スラッシュが剥がれて MSBuild が失敗するため pwsh を使う
+          $channel = if ($env:GITHUB_REF -like 'refs/tags/v*') { 'release' } else { 'preview' }
+          dotnet publish TerminalHub/TerminalHub.csproj -c Release -r win-x64 --self-contained true -o ./publish `
+            /p:Version=${{ steps.get_version.outputs.VERSION }} `
+            /p:BuildChannel=$channel `
+            /p:BuildPr=${{ steps.build_meta.outputs.PR }} `
+            /p:BuildCommit=${{ steps.build_meta.outputs.SHA }} `
             /p:BuildDate=${{ steps.build_meta.outputs.DATE }}
 
       - name: Install Inno Setup


### PR DESCRIPTION
## 背景
#89 で `Publish application` ステップを `shell: bash`（channel 分岐のため）に変更したところ、master の workflow_dispatch ビルド（Run 28554637276）が失敗した。

## 原因
Git Bash (MSYS) のパス変換により、引数の `/p:Version=...` の**先頭スラッシュが剥がれて** `p:Version=...` になり、MSBuild が引数を「2つ目のプロジェクト指定」と誤認 → `MSB1008: Only one project can be specified.` で失敗。

元の Publish ステップは `shell:` 未指定（Windows 既定の pwsh）だったため `/p:` が正しく渡っていた。

## 修正
`shell: pwsh` に戻し、channel（release/preview）判定を PowerShell で行う。`/p:` はそのまま維持（backtick 行継続）。

```pwsh
$channel = if ($env:GITHUB_REF -like 'refs/tags/v*') { 'release' } else { 'preview' }
dotnet publish ... `
  /p:Version=... `
  /p:BuildChannel=$channel `
  /p:BuildPr=... `
  /p:BuildCommit=... `
  /p:BuildDate=...
```

## 検証
マージ後に `/preview`（workflow_dispatch）を回して緑になることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)