### PR TITLE
feat: モバイル用ゲームパッド(D-pad)を入力タブに追加

### DIFF
--- a/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
@@ -5,6 +5,7 @@
 @inject ILogger<TextInputPanel> Logger
 @inject IJSRuntime JS
 @inject IStringLocalizer<SharedResource> L
+@inject ILocalStorageService LocalStorage
 @implements IAsyncDisposable
 
 <div class="p-3 h-100 d-flex flex-column">
@@ -114,11 +115,34 @@
                         <i class="bi bi-mic"></i>
                     </button>
                 }
+                <button class="btn btn-secondary d-md-none @(showDpad ? "active" : "")"
+                        @onclick="ToggleDpad"
+                        title="@L["TextInput.Dpad.Toggle"]">
+                    <i class="bi bi-controller"></i>
+                </button>
                 <button class="btn btn-primary" @onclick="OnSendClick">
                     <i class="bi bi-send d-none d-md-inline"></i> @L["TextInput.Send"]
                 </button>
             </div>
         </div>
+
+        @* モバイル用ゲームパッド（カーソル移動 / Esc / Enter を ConPTY へ生キー送信）。
+           左＝十字カーソル（中央は空）、右＝[Esc][Enter]（外側が Enter）。d-md-none でモバイルのみ表示。 *@
+        @if (showDpad)
+        {
+            <div class="dpad-bar d-md-none mt-2">
+                <div class="dpad-cross">
+                    <button type="button" class="btn btn-secondary dpad-btn dpad-up" @onclick='() => SendKey("ArrowUp")' aria-label="↑"><i class="bi bi-caret-up-fill"></i></button>
+                    <button type="button" class="btn btn-secondary dpad-btn dpad-left" @onclick='() => SendKey("ArrowLeft")' aria-label="←"><i class="bi bi-caret-left-fill"></i></button>
+                    <button type="button" class="btn btn-secondary dpad-btn dpad-right" @onclick='() => SendKey("ArrowRight")' aria-label="→"><i class="bi bi-caret-right-fill"></i></button>
+                    <button type="button" class="btn btn-secondary dpad-btn dpad-down" @onclick='() => SendKey("ArrowDown")' aria-label="↓"><i class="bi bi-caret-down-fill"></i></button>
+                </div>
+                <div class="dpad-actions">
+                    <button type="button" class="btn btn-secondary dpad-action" @onclick='() => SendKey("Escape")'>Esc</button>
+                    <button type="button" class="btn btn-primary dpad-action" @onclick='() => SendKey("Enter")' aria-label="Enter"><i class="bi bi-arrow-return-left"></i></button>
+                </div>
+            </div>
+        }
     </div>
 </div>
 
@@ -158,6 +182,23 @@
     private bool isVoiceRecording = false;
     private DotNetObjectReference<TextInputPanel>? dotNetRef;
     private bool voiceInitialized = false;
+
+    // モバイル用ゲームパッド（D-pad）の開閉状態。全パネル共通・LocalStorage に記憶する。
+    private bool showDpad = false;
+    private const string DpadStateKey = "terminalHub_dpadOpen";
+
+    private async Task ToggleDpad()
+    {
+        showDpad = !showDpad;
+        await LocalStorage.SetAsync(DpadStateKey, showDpad);
+    }
+
+    // D-pad の各キーは KeySequence 名（"ArrowUp" 等）を渡すだけ。
+    // 親（Root.SendCustomKey）が KeySequencePresets 経由で ConPTY に生エスケープを WriteAsync する。
+    private async Task SendKey(string keyName)
+    {
+        await OnSendCustomKey.InvokeAsync(keyName);
+    }
 
     private async Task OnTextAreaKeyDown(KeyboardEventArgs e)
     {
@@ -361,6 +402,24 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            // D-pad の開閉状態を復元（記憶されていれば開いた状態で開始）
+            try
+            {
+                var saved = await LocalStorage.GetAsync<bool?>(DpadStateKey);
+                if (saved == true)
+                {
+                    showDpad = true;
+                    StateHasChanged();
+                }
+            }
+            catch
+            {
+                // JSInterop 未確立/切断時は無視（既定は閉じた状態）
+            }
+        }
+
         if (firstRender && VoiceInputEnabled)
         {
             await InitVoiceInput();

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -537,6 +537,7 @@
   <data name="TextInput.KeyHints.History" xml:space="preserve"><value>History</value></data>
   <data name="TextInput.VoiceInput.Tooltip" xml:space="preserve"><value>Voice input (hold to record)</value></data>
   <data name="TextInput.Send" xml:space="preserve"><value>Send</value></data>
+  <data name="TextInput.Dpad.Toggle" xml:space="preserve"><value>Cursor pad (arrows / Esc / Enter)</value></data>
   <data name="TextInput.ModeSwitch.TooltipFormat" xml:space="preserve"><value>Mode switch ({0})</value></data>
 
   <!-- BottomPanels: MemoPanel -->

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -537,6 +537,7 @@
   <data name="TextInput.KeyHints.History" xml:space="preserve"><value>履歴</value></data>
   <data name="TextInput.VoiceInput.Tooltip" xml:space="preserve"><value>音声入力（押している間録音）</value></data>
   <data name="TextInput.Send" xml:space="preserve"><value>送信</value></data>
+  <data name="TextInput.Dpad.Toggle" xml:space="preserve"><value>カーソルパッド（矢印 / Esc / Enter）</value></data>
   <data name="TextInput.ModeSwitch.TooltipFormat" xml:space="preserve"><value>モード切替 ({0})</value></data>
 
   <!-- BottomPanels: MemoPanel -->

--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -705,6 +705,57 @@ h1:focus {
     }
 }
 
+/* ===== モバイル用ゲームパッド（D-pad） =====
+   左＝十字カーソル（3×3 グリッド、中央は空）、右＝[Esc][Enter]（外側が Enter）。
+   表示/非表示は Blazor 側の d-md-none と showDpad で制御するため、ここはレイアウトのみ。
+   各ボタンは btn/btn-secondary/btn-primary を併用してテーマ色に追従させる。 */
+.dpad-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.dpad-cross {
+    display: grid;
+    grid-template-columns: repeat(3, 44px);
+    grid-template-rows: repeat(3, 44px);
+    gap: 4px;
+}
+
+.dpad-btn {
+    padding: 0;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.15rem;
+}
+
+.dpad-btn:active {
+    transform: scale(0.92);
+}
+
+.dpad-up    { grid-column: 2; grid-row: 1; }
+.dpad-left  { grid-column: 1; grid-row: 2; }
+.dpad-right { grid-column: 3; grid-row: 2; }
+.dpad-down  { grid-column: 2; grid-row: 3; }
+
+.dpad-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.dpad-action {
+    min-width: 60px;
+    height: 44px;
+    font-size: 1.05rem;
+}
+
+.dpad-action:active {
+    transform: scale(0.95);
+}
+
 /* ===========================================
    スモールモバイル対応 (480px以下)
    =========================================== */


### PR DESCRIPTION
## 概要

モバイルで CLI の選択メニュー（↑↓ で選んで Enter で確定）を操作しづらい問題を解消するため、入力タブに **カーソルパッド（D-pad）** を追加する。

モバイルのソフトキーボードには矢印キー / Enter / Esc が無く、Claude Code 等の選択メニューをタッチで操作できなかった。既存の `OnSendCustomKey`（`KeySequencePresets` → ConPTY へ生エスケープ送信）と、レスポンシブ出し分けの仕組みにそのまま乗せている。

## 挙動

- 入力タブに **🎮 トグルボタン（モバイルのみ `d-md-none`）** を追加。押すとカーソルパッドを展開/収納。
- レイアウト：**左＝十字カーソル（↑↓←→、中央は空）／ 右＝[Esc][Enter]（外側が Enter）** のゲームパッド配置。
- 各キーは `SendKey → OnSendCustomKey` 経由で `WriteAsync`（↑=`\x1b[A` 等 / Esc=`\x1b` / Enter=`\r`）。**テキスト欄を経由せず**選択メニューを直接操作できる。
- 開閉状態は LocalStorage（`terminalHub_dpadOpen`）に記憶し、初回レンダーで復元。

## スコープ外（次段）

- hook 由来のステート連携（`PreToolUse`=質問待ちを検知して自動表示 / 選択肢のタップ化）は含まない。まずは常設トグルのみの最小実装。

## 変更ファイル

- `TextInputPanel.razor` … トグルボタン＋D-pad UI＋状態管理・復元
- `app.css` … D-pad レイアウト（3×3 グリッド）。ボタンは Bootstrap クラス併用でテーマ追従
- `SharedResource.ja/en.resx` … トグルの title

## 確認事項

- ビルド: 成功（0 エラー / 0 警告）
- **実機（モバイル）での見た目・タップ操作、および ConPTY へのキー送信は未検証**（ConPTY は Claude Code ツール経由起動だと壊れるため、実機確認をお願いします）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)