### PR TITLE
feat: カーソルパッド(D-pad)を独立タブ化 — ＋メニューから追加する方式に変更

### DIFF
--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -71,8 +71,8 @@
             </li>
             <li>
                 <button class="dropdown-item" type="button"
-                   @onclick="AddGamepadTab">
-                    <i class="bi bi-controller me-2"></i>@L["BottomPanel.AddGamepad"]
+                   @onclick="AddCursorPadTab">
+                    <i class="bi bi-controller me-2"></i>@L["BottomPanel.AddCursorPad"]
                 </button>
             </li>
         </ul>
@@ -115,9 +115,9 @@
                        Body="@GetMemoBody(memoId)"
                        BodyChanged="@(body => OnMemoBodyChanged(memoId, body))" />
         }
-        else if (tab.Type == BottomPanelTabType.Gamepad)
+        else if (tab.Type == BottomPanelTabType.CursorPad)
         {
-            <GamepadPanel OnSendCustomKey="OnSendCustomKey" />
+            <CursorPadPanel OnSendCustomKey="OnSendCustomKey" />
         }
     </div>
 }
@@ -266,10 +266,10 @@
         StateHasChanged();
     }
 
-    private void AddGamepadTab()
+    private void AddCursorPadTab()
     {
-        // ゲームパッドは複数あっても意味がないので、既存タブがあればそれを選択するだけ
-        var existing = Tabs.FirstOrDefault(t => t.Type == BottomPanelTabType.Gamepad);
+        // カーソルパッドは複数あっても意味がないので、既存タブがあればそれを選択するだけ
+        var existing = Tabs.FirstOrDefault(t => t.Type == BottomPanelTabType.CursorPad);
         if (existing != null)
         {
             ActiveTabId = existing.Id;
@@ -280,8 +280,8 @@
         var newTab = new BottomPanelTabInfo
         {
             Id = Guid.NewGuid().ToString(),
-            Type = BottomPanelTabType.Gamepad,
-            DisplayName = L["BottomPanel.Tab.Gamepad"],
+            Type = BottomPanelTabType.CursorPad,
+            DisplayName = L["BottomPanel.Tab.CursorPad"],
             IsDefault = false
         };
         Tabs.Add(newTab);
@@ -377,7 +377,7 @@
             BottomPanelTabType.TextInput => "bi-chat-left-text",
             BottomPanelTabType.PowerShell => "bi-terminal-fill",
             BottomPanelTabType.Memo => "bi-journal-text",
-            BottomPanelTabType.Gamepad => "bi-controller",
+            BottomPanelTabType.CursorPad => "bi-controller",
             _ => "bi-terminal"
         };
     }

--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -69,6 +69,12 @@
                     <i class="bi bi-journal-text me-2"></i>@L["BottomPanel.AddMemo"]
                 </button>
             </li>
+            <li>
+                <button class="dropdown-item" type="button"
+                   @onclick="AddGamepadTab">
+                    <i class="bi bi-controller me-2"></i>@L["BottomPanel.AddGamepad"]
+                </button>
+            </li>
         </ul>
     </li>
 </ul>
@@ -108,6 +114,10 @@
             <MemoPanel MemoId="@memoId"
                        Body="@GetMemoBody(memoId)"
                        BodyChanged="@(body => OnMemoBodyChanged(memoId, body))" />
+        }
+        else if (tab.Type == BottomPanelTabType.Gamepad)
+        {
+            <GamepadPanel OnSendCustomKey="OnSendCustomKey" />
         }
     </div>
 }
@@ -256,6 +266,29 @@
         StateHasChanged();
     }
 
+    private void AddGamepadTab()
+    {
+        // ゲームパッドは複数あっても意味がないので、既存タブがあればそれを選択するだけ
+        var existing = Tabs.FirstOrDefault(t => t.Type == BottomPanelTabType.Gamepad);
+        if (existing != null)
+        {
+            ActiveTabId = existing.Id;
+            StateHasChanged();
+            return;
+        }
+
+        var newTab = new BottomPanelTabInfo
+        {
+            Id = Guid.NewGuid().ToString(),
+            Type = BottomPanelTabType.Gamepad,
+            DisplayName = L["BottomPanel.Tab.Gamepad"],
+            IsDefault = false
+        };
+        Tabs.Add(newTab);
+        ActiveTabId = newTab.Id;
+        StateHasChanged();
+    }
+
     private async Task AddMemoTab()
     {
         if (!CurrentSessionId.HasValue) return;
@@ -344,6 +377,7 @@
             BottomPanelTabType.TextInput => "bi-chat-left-text",
             BottomPanelTabType.PowerShell => "bi-terminal-fill",
             BottomPanelTabType.Memo => "bi-journal-text",
+            BottomPanelTabType.Gamepad => "bi-controller",
             _ => "bi-terminal"
         };
     }

--- a/TerminalHub/Components/Shared/BottomPanels/CursorPadPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/CursorPadPanel.razor
@@ -1,12 +1,12 @@
 @using Microsoft.Extensions.Localization
 
-@* ゲームパッド（D-pad）タブ: カーソル移動 / Esc / Enter をアクティブセッションの ConPTY へ生キー送信する。
+@* カーソルパッドタブ: カーソル移動 / Esc / Enter をアクティブセッションの ConPTY へ生キー送信する。
    ＋メニューから必要なときだけ追加して使う（テキスト入力欄と場所を食い合わないよう独立タブ）。
    各キーは KeySequence 名（"ArrowUp" 等）を渡すだけで、親（Root.SendCustomKey）が
    KeySequencePresets 経由で生エスケープシーケンスを WriteAsync する。 *@
 
 <div class="p-3 h-100 d-flex align-items-center justify-content-center">
-    <div class="dpad-bar gamepad-panel-bar">
+    <div class="dpad-bar cursor-pad-bar">
         <div class="dpad-cross">
             <button type="button" class="btn btn-secondary dpad-btn dpad-up" @onclick='() => SendKey("ArrowUp")' aria-label="↑"><i class="bi bi-caret-up-fill"></i></button>
             <button type="button" class="btn btn-secondary dpad-btn dpad-left" @onclick='() => SendKey("ArrowLeft")' aria-label="←"><i class="bi bi-caret-left-fill"></i></button>

--- a/TerminalHub/Components/Shared/BottomPanels/GamepadPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/GamepadPanel.razor
@@ -1,0 +1,31 @@
+@using Microsoft.Extensions.Localization
+
+@* ゲームパッド（D-pad）タブ: カーソル移動 / Esc / Enter をアクティブセッションの ConPTY へ生キー送信する。
+   ＋メニューから必要なときだけ追加して使う（テキスト入力欄と場所を食い合わないよう独立タブ）。
+   各キーは KeySequence 名（"ArrowUp" 等）を渡すだけで、親（Root.SendCustomKey）が
+   KeySequencePresets 経由で生エスケープシーケンスを WriteAsync する。 *@
+
+<div class="p-3 h-100 d-flex align-items-center justify-content-center">
+    <div class="dpad-bar gamepad-panel-bar">
+        <div class="dpad-cross">
+            <button type="button" class="btn btn-secondary dpad-btn dpad-up" @onclick='() => SendKey("ArrowUp")' aria-label="↑"><i class="bi bi-caret-up-fill"></i></button>
+            <button type="button" class="btn btn-secondary dpad-btn dpad-left" @onclick='() => SendKey("ArrowLeft")' aria-label="←"><i class="bi bi-caret-left-fill"></i></button>
+            <button type="button" class="btn btn-secondary dpad-btn dpad-right" @onclick='() => SendKey("ArrowRight")' aria-label="→"><i class="bi bi-caret-right-fill"></i></button>
+            <button type="button" class="btn btn-secondary dpad-btn dpad-down" @onclick='() => SendKey("ArrowDown")' aria-label="↓"><i class="bi bi-caret-down-fill"></i></button>
+        </div>
+        <div class="dpad-actions">
+            <button type="button" class="btn btn-secondary dpad-action" @onclick='() => SendKey("Tab")'>Tab</button>
+            <button type="button" class="btn btn-secondary dpad-action" @onclick='() => SendKey("Escape")'>Esc</button>
+            <button type="button" class="btn btn-primary dpad-action" @onclick='() => SendKey("Enter")' aria-label="Enter"><i class="bi bi-arrow-return-left"></i></button>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback<string> OnSendCustomKey { get; set; }
+
+    private async Task SendKey(string keyName)
+    {
+        await OnSendCustomKey.InvokeAsync(keyName);
+    }
+}

--- a/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
@@ -5,7 +5,6 @@
 @inject ILogger<TextInputPanel> Logger
 @inject IJSRuntime JS
 @inject IStringLocalizer<SharedResource> L
-@inject ILocalStorageService LocalStorage
 @implements IAsyncDisposable
 
 <div class="p-3 h-100 d-flex flex-column">
@@ -115,34 +114,11 @@
                         <i class="bi bi-mic"></i>
                     </button>
                 }
-                <button class="btn btn-secondary d-md-none @(showDpad ? "active" : "")"
-                        @onclick="ToggleDpad"
-                        title="@L["TextInput.Dpad.Toggle"]">
-                    <i class="bi bi-controller"></i>
-                </button>
                 <button class="btn btn-primary" @onclick="OnSendClick">
                     <i class="bi bi-send d-none d-md-inline"></i> @L["TextInput.Send"]
                 </button>
             </div>
         </div>
-
-        @* モバイル用ゲームパッド（カーソル移動 / Esc / Enter を ConPTY へ生キー送信）。
-           左＝十字カーソル（中央は空）、右＝[Esc][Enter]（外側が Enter）。d-md-none でモバイルのみ表示。 *@
-        @if (showDpad)
-        {
-            <div class="dpad-bar d-md-none mt-2">
-                <div class="dpad-cross">
-                    <button type="button" class="btn btn-secondary dpad-btn dpad-up" @onclick='() => SendKey("ArrowUp")' aria-label="↑"><i class="bi bi-caret-up-fill"></i></button>
-                    <button type="button" class="btn btn-secondary dpad-btn dpad-left" @onclick='() => SendKey("ArrowLeft")' aria-label="←"><i class="bi bi-caret-left-fill"></i></button>
-                    <button type="button" class="btn btn-secondary dpad-btn dpad-right" @onclick='() => SendKey("ArrowRight")' aria-label="→"><i class="bi bi-caret-right-fill"></i></button>
-                    <button type="button" class="btn btn-secondary dpad-btn dpad-down" @onclick='() => SendKey("ArrowDown")' aria-label="↓"><i class="bi bi-caret-down-fill"></i></button>
-                </div>
-                <div class="dpad-actions">
-                    <button type="button" class="btn btn-secondary dpad-action" @onclick='() => SendKey("Escape")'>Esc</button>
-                    <button type="button" class="btn btn-primary dpad-action" @onclick='() => SendKey("Enter")' aria-label="Enter"><i class="bi bi-arrow-return-left"></i></button>
-                </div>
-            </div>
-        }
     </div>
 </div>
 
@@ -182,23 +158,6 @@
     private bool isVoiceRecording = false;
     private DotNetObjectReference<TextInputPanel>? dotNetRef;
     private bool voiceInitialized = false;
-
-    // モバイル用ゲームパッド（D-pad）の開閉状態。全パネル共通・LocalStorage に記憶する。
-    private bool showDpad = false;
-    private const string DpadStateKey = "terminalHub_dpadOpen";
-
-    private async Task ToggleDpad()
-    {
-        showDpad = !showDpad;
-        await LocalStorage.SetAsync(DpadStateKey, showDpad);
-    }
-
-    // D-pad の各キーは KeySequence 名（"ArrowUp" 等）を渡すだけ。
-    // 親（Root.SendCustomKey）が KeySequencePresets 経由で ConPTY に生エスケープを WriteAsync する。
-    private async Task SendKey(string keyName)
-    {
-        await OnSendCustomKey.InvokeAsync(keyName);
-    }
 
     private async Task OnTextAreaKeyDown(KeyboardEventArgs e)
     {
@@ -402,24 +361,6 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
-        {
-            // D-pad の開閉状態を復元（記憶されていれば開いた状態で開始）
-            try
-            {
-                var saved = await LocalStorage.GetAsync<bool?>(DpadStateKey);
-                if (saved == true)
-                {
-                    showDpad = true;
-                    StateHasChanged();
-                }
-            }
-            catch
-            {
-                // JSInterop 未確立/切断時は無視（既定は閉じた状態）
-            }
-        }
-
         if (firstRender && VoiceInputEnabled)
         {
             await InitVoiceInput();

--- a/TerminalHub/Models/SessionInfo.cs
+++ b/TerminalHub/Models/SessionInfo.cs
@@ -20,8 +20,8 @@ namespace TerminalHub.Models
         CommandPrompt,
         PowerShell,
         Memo,
-        /// <summary>ゲームパッド（D-pad）: カーソル/Tab/Esc/Enter をアクティブセッションへ生キー送信</summary>
-        Gamepad
+        /// <summary>カーソルパッド: カーソル/Tab/Esc/Enter をアクティブセッションへ生キー送信</summary>
+        CursorPad
     }
 
     public class BottomPanelTabInfo

--- a/TerminalHub/Models/SessionInfo.cs
+++ b/TerminalHub/Models/SessionInfo.cs
@@ -19,7 +19,9 @@ namespace TerminalHub.Models
         TextInput,
         CommandPrompt,
         PowerShell,
-        Memo
+        Memo,
+        /// <summary>ゲームパッド（D-pad）: カーソル/Tab/Esc/Enter をアクティブセッションへ生キー送信</summary>
+        Gamepad
     }
 
     public class BottomPanelTabInfo

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -539,7 +539,6 @@
   <data name="TextInput.KeyHints.History" xml:space="preserve"><value>History</value></data>
   <data name="TextInput.VoiceInput.Tooltip" xml:space="preserve"><value>Voice input (hold to record)</value></data>
   <data name="TextInput.Send" xml:space="preserve"><value>Send</value></data>
-  <data name="TextInput.Dpad.Toggle" xml:space="preserve"><value>Cursor pad (arrows / Esc / Enter)</value></data>
   <data name="TextInput.ModeSwitch.TooltipFormat" xml:space="preserve"><value>Mode switch ({0})</value></data>
 
   <!-- BottomPanels: MemoPanel -->
@@ -550,12 +549,14 @@
   <data name="BottomPanel.AddCommandPrompt" xml:space="preserve"><value>Add Command Prompt</value></data>
   <data name="BottomPanel.AddPowerShell" xml:space="preserve"><value>Add PowerShell</value></data>
   <data name="BottomPanel.AddMemo" xml:space="preserve"><value>Add Memo</value></data>
+  <data name="BottomPanel.AddGamepad" xml:space="preserve"><value>Add Gamepad</value></data>
   <data name="BottomPanel.Tab.TextInputDefault" xml:space="preserve"><value>Text input</value></data>
   <data name="BottomPanel.Tab.TextInputFormat" xml:space="preserve"><value>Text input ({0})</value></data>
   <data name="BottomPanel.Tab.CommandPromptFormat" xml:space="preserve"><value>Command Prompt ({0})</value></data>
   <data name="BottomPanel.Tab.PowerShellFormat" xml:space="preserve"><value>PowerShell ({0})</value></data>
   <data name="BottomPanel.Tab.GenericFormat" xml:space="preserve"><value>Tab ({0})</value></data>
   <data name="BottomPanel.Tab.MemoFormat" xml:space="preserve"><value>Memo ({0})</value></data>
+  <data name="BottomPanel.Tab.Gamepad" xml:space="preserve"><value>Gamepad</value></data>
 
   <!-- Root page -->
   <data name="Root.NoSessionSelected" xml:space="preserve"><value>Select a session from the left sidebar</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -549,14 +549,14 @@
   <data name="BottomPanel.AddCommandPrompt" xml:space="preserve"><value>Add Command Prompt</value></data>
   <data name="BottomPanel.AddPowerShell" xml:space="preserve"><value>Add PowerShell</value></data>
   <data name="BottomPanel.AddMemo" xml:space="preserve"><value>Add Memo</value></data>
-  <data name="BottomPanel.AddGamepad" xml:space="preserve"><value>Add Gamepad</value></data>
+  <data name="BottomPanel.AddCursorPad" xml:space="preserve"><value>Add Cursor Pad</value></data>
   <data name="BottomPanel.Tab.TextInputDefault" xml:space="preserve"><value>Text input</value></data>
   <data name="BottomPanel.Tab.TextInputFormat" xml:space="preserve"><value>Text input ({0})</value></data>
   <data name="BottomPanel.Tab.CommandPromptFormat" xml:space="preserve"><value>Command Prompt ({0})</value></data>
   <data name="BottomPanel.Tab.PowerShellFormat" xml:space="preserve"><value>PowerShell ({0})</value></data>
   <data name="BottomPanel.Tab.GenericFormat" xml:space="preserve"><value>Tab ({0})</value></data>
   <data name="BottomPanel.Tab.MemoFormat" xml:space="preserve"><value>Memo ({0})</value></data>
-  <data name="BottomPanel.Tab.Gamepad" xml:space="preserve"><value>Gamepad</value></data>
+  <data name="BottomPanel.Tab.CursorPad" xml:space="preserve"><value>Cursor Pad</value></data>
 
   <!-- Root page -->
   <data name="Root.NoSessionSelected" xml:space="preserve"><value>Select a session from the left sidebar</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -549,14 +549,14 @@
   <data name="BottomPanel.AddCommandPrompt" xml:space="preserve"><value>コマンドプロンプトを追加</value></data>
   <data name="BottomPanel.AddPowerShell" xml:space="preserve"><value>PowerShell を追加</value></data>
   <data name="BottomPanel.AddMemo" xml:space="preserve"><value>メモを追加</value></data>
-  <data name="BottomPanel.AddGamepad" xml:space="preserve"><value>ゲームパッドを追加</value></data>
+  <data name="BottomPanel.AddCursorPad" xml:space="preserve"><value>カーソルパッドを追加</value></data>
   <data name="BottomPanel.Tab.TextInputDefault" xml:space="preserve"><value>テキスト入力</value></data>
   <data name="BottomPanel.Tab.TextInputFormat" xml:space="preserve"><value>テキスト入力({0})</value></data>
   <data name="BottomPanel.Tab.CommandPromptFormat" xml:space="preserve"><value>コマンドプロンプト({0})</value></data>
   <data name="BottomPanel.Tab.PowerShellFormat" xml:space="preserve"><value>PowerShell({0})</value></data>
   <data name="BottomPanel.Tab.GenericFormat" xml:space="preserve"><value>タブ({0})</value></data>
   <data name="BottomPanel.Tab.MemoFormat" xml:space="preserve"><value>メモ({0})</value></data>
-  <data name="BottomPanel.Tab.Gamepad" xml:space="preserve"><value>ゲームパッド</value></data>
+  <data name="BottomPanel.Tab.CursorPad" xml:space="preserve"><value>カーソルパッド</value></data>
 
   <!-- Root page -->
   <data name="Root.NoSessionSelected" xml:space="preserve"><value>左側からセッションを選択してください</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -539,7 +539,6 @@
   <data name="TextInput.KeyHints.History" xml:space="preserve"><value>履歴</value></data>
   <data name="TextInput.VoiceInput.Tooltip" xml:space="preserve"><value>音声入力（押している間録音）</value></data>
   <data name="TextInput.Send" xml:space="preserve"><value>送信</value></data>
-  <data name="TextInput.Dpad.Toggle" xml:space="preserve"><value>カーソルパッド（矢印 / Esc / Enter）</value></data>
   <data name="TextInput.ModeSwitch.TooltipFormat" xml:space="preserve"><value>モード切替 ({0})</value></data>
 
   <!-- BottomPanels: MemoPanel -->
@@ -550,12 +549,14 @@
   <data name="BottomPanel.AddCommandPrompt" xml:space="preserve"><value>コマンドプロンプトを追加</value></data>
   <data name="BottomPanel.AddPowerShell" xml:space="preserve"><value>PowerShell を追加</value></data>
   <data name="BottomPanel.AddMemo" xml:space="preserve"><value>メモを追加</value></data>
+  <data name="BottomPanel.AddGamepad" xml:space="preserve"><value>ゲームパッドを追加</value></data>
   <data name="BottomPanel.Tab.TextInputDefault" xml:space="preserve"><value>テキスト入力</value></data>
   <data name="BottomPanel.Tab.TextInputFormat" xml:space="preserve"><value>テキスト入力({0})</value></data>
   <data name="BottomPanel.Tab.CommandPromptFormat" xml:space="preserve"><value>コマンドプロンプト({0})</value></data>
   <data name="BottomPanel.Tab.PowerShellFormat" xml:space="preserve"><value>PowerShell({0})</value></data>
   <data name="BottomPanel.Tab.GenericFormat" xml:space="preserve"><value>タブ({0})</value></data>
   <data name="BottomPanel.Tab.MemoFormat" xml:space="preserve"><value>メモ({0})</value></data>
+  <data name="BottomPanel.Tab.Gamepad" xml:space="preserve"><value>ゲームパッド</value></data>
 
   <!-- Root page -->
   <data name="Root.NoSessionSelected" xml:space="preserve"><value>左側からセッションを選択してください</value></data>

--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -713,9 +713,9 @@ h1:focus {
     }
 }
 
-/* ===== ゲームパッド（D-pad）タブ =====
+/* ===== カーソルパッド（D-pad）タブ =====
    左＝十字カーソル（3×3 グリッド、中央は空）、右＝[Tab][Esc][Enter]。
-   ＋メニューから追加する独立タブ（GamepadPanel.razor）として表示する。
+   ＋メニューから追加する独立タブ（CursorPadPanel.razor）として表示する。
    各ボタンは btn/btn-secondary/btn-primary を併用してテーマ色に追従させる。 */
 .dpad-bar {
     display: flex;
@@ -726,7 +726,7 @@ h1:focus {
 
 /* タブ内表示用: 中央寄せ＋左右ブロックの間隔を広めに。
    幅が足りない端末（縦持ちスマホ等）では折り返して縦積みになる */
-.gamepad-panel-bar {
+.cursor-pad-bar {
     justify-content: center;
     gap: 1.5rem 2.5rem;
     flex-wrap: wrap;

--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -713,15 +713,23 @@ h1:focus {
     }
 }
 
-/* ===== モバイル用ゲームパッド（D-pad） =====
-   左＝十字カーソル（3×3 グリッド、中央は空）、右＝[Esc][Enter]（外側が Enter）。
-   表示/非表示は Blazor 側の d-md-none と showDpad で制御するため、ここはレイアウトのみ。
+/* ===== ゲームパッド（D-pad）タブ =====
+   左＝十字カーソル（3×3 グリッド、中央は空）、右＝[Tab][Esc][Enter]。
+   ＋メニューから追加する独立タブ（GamepadPanel.razor）として表示する。
    各ボタンは btn/btn-secondary/btn-primary を併用してテーマ色に追従させる。 */
 .dpad-bar {
     display: flex;
     justify-content: space-between;
     align-items: center;
     gap: 0.5rem;
+}
+
+/* タブ内表示用: 中央寄せ＋左右ブロックの間隔を広めに。
+   幅が足りない端末（縦持ちスマホ等）では折り返して縦積みになる */
+.gamepad-panel-bar {
+    justify-content: center;
+    gap: 1.5rem 2.5rem;
+    flex-wrap: wrap;
 }
 
 .dpad-cross {


### PR DESCRIPTION
## 背景
PR #92 のゲームパッドは「テキスト入力タブ内の埋め込みトグル（モバイル幅限定）」だったが、
- テキスト入力欄と場所を食い合う
- まれな入力時に使う用途なので常時表示は不要
- `d-md-none` のため見つけにくい（デスクトップでは存在自体が見えない）

という理由で、**コマンドプロンプト／メモと同様の「＋メニューから必要なときだけ追加する独立タブ」**に変更する。

## 変更
- `BottomPanelTabType` に `Gamepad` を追加
- **`GamepadPanel.razor` 新設**: 十字カーソル＋ **Tab / Esc / Enter**（Tab キーを追加）。opt-in タブになったので画面幅制限（`d-md-none`）は撤廃し、デスクトップでも使用可能
- ＋メニューに「ゲームパッドを追加」— 既存タブがあれば選択のみ（重複作成しない）
- **TextInputPanel から埋め込み D-pad を撤去**（トグルボタン・LocalStorage 開閉記憶・関連コードすべて）
- CSS: タブ内表示用の中央寄せ＋狭い端末では縦積みに折り返し
- resx: `BottomPanel.AddGamepad` / `BottomPanel.Tab.Gamepad` 追加、`TextInput.Dpad.Toggle` 削除

キー送信経路は従来どおり `OnSendCustomKey` → `Root.SendCustomKey` → `KeySequencePresets` → ConPTY（変更なし）。

## 検証
- ビルド 0警告0エラー
- 実機（モバイル）確認は次回プレビューで実施予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)