### PR TITLE
fix: セッション切替時の表示崩れを根絶＋スクロールバック意味論をWT/xterm準拠に

### DIFF
--- a/TerminalHub.Terminal.Tests/Dup3DiagnosticTests.cs
+++ b/TerminalHub.Terminal.Tests/Dup3DiagnosticTests.cs
@@ -1,0 +1,142 @@
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TerminalHub.Terminal.Tests;
+
+/// <summary>
+/// 3つ目の実キャプチャ（dup3-20260703-074713.raw）の診断。
+/// セッション切替→復帰でリプレイ後の表示が1行ズレて重複した事象の切り分け。
+/// リプレイのラウンドトリップ（A→serialize→B）が完全一致するかを検証する（一時診断）。
+/// </summary>
+public class Dup3DiagnosticTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public Dup3DiagnosticTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static string? TryLoad()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "local", "dup3-20260703-074713.raw");
+        return File.Exists(path) ? File.ReadAllText(path, Encoding.UTF8) : null;
+    }
+
+    private static string RowText(Cell[] row)
+    {
+        var sb = new StringBuilder();
+        foreach (var cell in row)
+        {
+            if (cell.IsWideTrailer) continue;
+            sb.Append(cell.Text ?? " ");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    [SkippableTheory]
+    [InlineData(120, 67)]
+    [InlineData(160, 67)]
+    [InlineData(200, 67)]
+    [InlineData(120, 40)]
+    public void Roundtrip_replay_is_identical(int cols, int rows)
+    {
+        var stream = TryLoad();
+        Skip.If(stream == null, "ローカルキャプチャ dup3 が無いためスキップ");
+
+        var a = new EmulatedStateBuffer(cols, rows);
+        a.Append(stream!);
+        var replay = a.SerializeForReplay();
+
+        var b = new EmulatedStateBuffer(cols, rows);
+        b.Append(replay);
+
+        _output.WriteLine($"grid {cols}x{rows}: A.scrollback={a.Grid.Scrollback.Count}, B.scrollback={b.Grid.Scrollback.Count}, " +
+                          $"A.cursor=({a.Grid.CursorRow},{a.Grid.CursorCol}), B.cursor=({b.Grid.CursorRow},{b.Grid.CursorCol})");
+
+        int mismatches = 0;
+
+        // スクロールバック行数と内容
+        if (a.Grid.Scrollback.Count != b.Grid.Scrollback.Count)
+        {
+            _output.WriteLine($"!! scrollback行数不一致: A={a.Grid.Scrollback.Count} B={b.Grid.Scrollback.Count}");
+            mismatches++;
+        }
+        int sbCount = Math.Min(a.Grid.Scrollback.Count, b.Grid.Scrollback.Count);
+        for (int i = 0; i < sbCount; i++)
+        {
+            var ta = RowText(a.Grid.Scrollback[i]);
+            var tb = RowText(b.Grid.Scrollback[i]);
+            if (ta != tb && mismatches < 10)
+            {
+                _output.WriteLine($"!! scrollback[{i}]:\n  A: {ta}\n  B: {tb}");
+                mismatches++;
+            }
+        }
+
+        // 画面行の内容
+        for (int r = 0; r < rows; r++)
+        {
+            var ta = RowText(a.Grid.Screen[r]);
+            var tb = RowText(b.Grid.Screen[r]);
+            if (ta != tb && mismatches < 20)
+            {
+                _output.WriteLine($"!! screen[{r}]:\n  A: {ta}\n  B: {tb}");
+                mismatches++;
+            }
+        }
+
+        // カーソル位置
+        if (a.Grid.CursorRow != b.Grid.CursorRow || a.Grid.CursorCol != b.Grid.CursorCol)
+        {
+            _output.WriteLine($"!! cursor不一致: A=({a.Grid.CursorRow},{a.Grid.CursorCol}) B=({b.Grid.CursorRow},{b.Grid.CursorCol})");
+            mismatches++;
+        }
+
+        Assert.Equal(0, mismatches);
+    }
+
+    /// <summary>
+    /// 実際の切替復帰シナリオ: キャプチャ前半で切替（リプレイ）、後半をライブ出力として
+    /// 「リプレイから再構築した端末(B)」と「連続して見ていた端末(A)」の最終画面が一致するか。
+    /// </summary>
+    [SkippableTheory]
+    [InlineData(160, 67)]
+    public void Switchback_midstream_replay_then_live_matches(int cols, int rows)
+    {
+        var stream = TryLoad();
+        Skip.If(stream == null, "ローカルキャプチャ dup3 が無いためスキップ");
+
+        // 切替ポイントをストリームの中間付近（チャンク境界を意識せず素朴に半分）にする
+        int mid = stream!.Length / 2;
+        var first = stream.Substring(0, mid);
+        var rest = stream.Substring(mid);
+
+        // A: ずっと接続していた端末（連続適用）
+        var a = new EmulatedStateBuffer(cols, rows);
+        a.Append(stream);
+
+        // B: 前半まで見た状態でリプレイ復元し、後半をライブで受けた端末
+        var recorder = new EmulatedStateBuffer(cols, rows);
+        recorder.Append(first);
+        var replay = recorder.SerializeForReplay();
+        var b = new EmulatedStateBuffer(cols, rows);
+        b.Append(replay);
+        b.Append(rest);
+
+        int mismatches = 0;
+        for (int r = 0; r < rows; r++)
+        {
+            var ta = RowText(a.Grid.Screen[r]);
+            var tb = RowText(b.Grid.Screen[r]);
+            if (ta != tb && mismatches < 20)
+            {
+                _output.WriteLine($"!! screen[{r}]:\n  A: {ta}\n  B: {tb}");
+                mismatches++;
+            }
+        }
+        _output.WriteLine($"A.scrollback={a.Grid.Scrollback.Count} B.scrollback={b.Grid.Scrollback.Count}");
+        Assert.Equal(0, mismatches);
+    }
+}

--- a/TerminalHub.Terminal.Tests/Dup4DiagnosticTests.cs
+++ b/TerminalHub.Terminal.Tests/Dup4DiagnosticTests.cs
@@ -1,0 +1,117 @@
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TerminalHub.Terminal.Tests;
+
+/// <summary>
+/// 4つ目の実キャプチャ（dup4-20260703-080615.raw、切替復帰で行内に文字が混ざる事象）の診断。
+/// 修正前の順序（ライブチャンクがリプレイより先に空のxtermへ書かれる）で表示が壊れること、
+/// 修正後の順序（スナップショット→テール）で壊れないことを、エミュレータをxterm代役として実証する。
+/// </summary>
+public class Dup4DiagnosticTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public Dup4DiagnosticTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static string? TryLoad()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "local", "dup4-20260703-080615.raw");
+        return File.Exists(path) ? File.ReadAllText(path, Encoding.UTF8) : null;
+    }
+
+    private static string RowText(Cell[] row)
+    {
+        var sb = new StringBuilder();
+        foreach (var cell in row)
+        {
+            if (cell.IsWideTrailer) continue;
+            sb.Append(cell.Text ?? " ");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static int CompareScreens(EmulatedStateBuffer a, EmulatedStateBuffer b, int rows, ITestOutputHelper output, int maxReport)
+    {
+        int mismatches = 0;
+        for (int r = 0; r < rows; r++)
+        {
+            var ta = RowText(a.Grid.Screen[r]);
+            var tb = RowText(b.Grid.Screen[r]);
+            if (ta != tb)
+            {
+                if (mismatches < maxReport)
+                {
+                    output.WriteLine($"!! screen[{r}]:\n  正: {ta}\n  誤: {tb}");
+                }
+                mismatches++;
+            }
+        }
+        return mismatches;
+    }
+
+    [SkippableTheory]
+    [InlineData(160, 40)]
+    public void Old_order_live_chunk_before_replay_corrupts_but_fixed_order_does_not(int cols, int rows)
+    {
+        var stream = TryLoad();
+        Skip.If(stream == null, "ローカルキャプチャ dup4 が無いためスキップ");
+
+        // 実際の事象は「切替後は差分描画しか来ない」ため壊れたまま自己修復されない。
+        // それを再現するため、切替ポイントを末尾付近の複数箇所で試す
+        // （切替直後に届くライブチャンク＝レースチャンクの後、残りが少ないケース）
+        int anyBroken = 0;
+        foreach (var fromEnd in new[] { 1024, 2048, 4096, 8192 })
+        {
+            if (stream!.Length <= fromEnd) continue;
+            int split = stream.Length - fromEnd;
+            int chunkLen = Math.Min(1024, stream.Length - split);
+            var beforeSwitch = stream.Substring(0, split);
+            var raceChunk = stream.Substring(split, chunkLen);
+            var afterChunk = stream.Substring(split + chunkLen);
+
+            // 正解: 連続して見ていた端末
+            var truth = new EmulatedStateBuffer(cols, rows);
+            truth.Append(stream);
+
+            // 【修正前の順序】スナップショットを取ってから、空のxtermへ raceChunk → リプレイ → 残り
+            // （beforeSwitch がエスケープ途中で切れていても旧実装はケアしないので素の SerializeForReplay）
+            var oldRecorder = new EmulatedStateBuffer(cols, rows);
+            oldRecorder.Append(beforeSwitch);
+            var oldSnapshot = oldRecorder.SerializeForReplay();
+            var broken = new EmulatedStateBuffer(cols, rows);
+            broken.Append(raceChunk);
+            broken.Append(oldSnapshot);
+            broken.Append(afterChunk);
+            int brokenMismatches = CompareScreens(truth, broken, rows, _output, maxReport: 3);
+            anyBroken += brokenMismatches;
+
+            // 【修正後のフロー】BeginReplay（未確定シーケンスをテールに種付け）→
+            // 復元中に届くライブ出力(raceChunk)はテールへ → スナップショット→テール→残り の順で書き込み
+            var recorder = new EmulatedStateBuffer(cols, rows);
+            recorder.Append(beforeSwitch);
+            var snap = recorder.BeginReplay();
+            Assert.True(recorder.Append(raceChunk)); // 復元中のライブ出力はキャプチャされる
+            var tail = recorder.EndReplay(snap);
+
+            var fixedOrder = new EmulatedStateBuffer(cols, rows);
+            fixedOrder.Append(snap.Content);
+            fixedOrder.Append(tail);
+            fixedOrder.Append(afterChunk);
+            int fixedMismatches = CompareScreens(truth, fixedOrder, rows, _output, maxReport: 3);
+
+            _output.WriteLine($"末尾-{fromEnd}で切替: 修正前順序の不一致行={brokenMismatches}, 修正後順序の不一致行={fixedMismatches}");
+
+            // 修正後の順序はどの分割位置でも壊れないこと（本命のアサーション）
+            Assert.Equal(0, fixedMismatches);
+        }
+
+        _output.WriteLine(anyBroken > 0
+            ? $"→ 修正前順序で表示崩れを再現（計{anyBroken}行）、修正後順序では全位置で一致"
+            : "→ このキャプチャでは修正前順序でも偶然一致（レース窓に依存）");
+    }
+}

--- a/TerminalHub.Terminal.Tests/Dup4DiagnosticTests.cs
+++ b/TerminalHub.Terminal.Tests/Dup4DiagnosticTests.cs
@@ -18,9 +18,9 @@ public class Dup4DiagnosticTests
         _output = output;
     }
 
-    private static string? TryLoad()
+    private static string? TryLoad(string fixture)
     {
-        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "local", "dup4-20260703-080615.raw");
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "local", fixture);
         return File.Exists(path) ? File.ReadAllText(path, Encoding.UTF8) : null;
     }
 
@@ -55,11 +55,13 @@ public class Dup4DiagnosticTests
     }
 
     [SkippableTheory]
-    [InlineData(160, 40)]
-    public void Old_order_live_chunk_before_replay_corrupts_but_fixed_order_does_not(int cols, int rows)
+    [InlineData("dup4-20260703-080615.raw", 160, 40)]
+    [InlineData("dup5-20260703-081708.raw", 160, 40)]
+    [InlineData("dup5-20260703-081708.raw", 160, 67)]
+    public void Old_order_live_chunk_before_replay_corrupts_but_fixed_order_does_not(string fixture, int cols, int rows)
     {
-        var stream = TryLoad();
-        Skip.If(stream == null, "ローカルキャプチャ dup4 が無いためスキップ");
+        var stream = TryLoad(fixture);
+        Skip.If(stream == null, $"ローカルキャプチャ {fixture} が無いためスキップ");
 
         // 実際の事象は「切替後は差分描画しか来ない」ため壊れたまま自己修復されない。
         // それを再現するため、切替ポイントを末尾付近の複数箇所で試す

--- a/TerminalHub.Terminal.Tests/Dup6DiagnosticTests.cs
+++ b/TerminalHub.Terminal.Tests/Dup6DiagnosticTests.cs
@@ -1,0 +1,119 @@
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TerminalHub.Terminal.Tests;
+
+/// <summary>
+/// 6つ目の実キャプチャ（dup6a、修正済みビルドで切替復帰時に Compacting が2行に見えた事象）の診断。
+/// レース修正後も再現したため、エミュレータの保持状態そのものが壊れていないかを検証する。
+/// 特徴: このキャプチャは初回全画面描画を含まず、セル差分描画（CUP＋ESC[1Cスキップ）主体。
+/// </summary>
+public class Dup6DiagnosticTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public Dup6DiagnosticTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static string? TryLoad(string fixture)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "local", fixture);
+        return File.Exists(path) ? File.ReadAllText(path, Encoding.UTF8) : null;
+    }
+
+    private static string RowText(Cell[] row)
+    {
+        var sb = new StringBuilder();
+        foreach (var cell in row)
+        {
+            if (cell.IsWideTrailer) continue;
+            sb.Append(cell.Text ?? " ");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    [SkippableTheory]
+    [InlineData(160, 54)]
+    [InlineData(120, 54)]
+    [InlineData(160, 67)]
+    public void Emulator_state_after_full_stream(int cols, int rows)
+    {
+        var stream = TryLoad("dup6a-20260703-082331.raw");
+        Skip.If(stream == null, "ローカルキャプチャ dup6a が無いためスキップ");
+
+        var emu = new EmulatedStateBuffer(cols, rows);
+        emu.Append(stream!);
+
+        int compactingScreen = 0, compactingScrollback = 0;
+        for (int r = 0; r < rows; r++)
+        {
+            var text = RowText(emu.Grid.Screen[r]);
+            if (text.Contains("Compacting"))
+            {
+                compactingScreen++;
+                _output.WriteLine($"screen[{r}]: {text}");
+            }
+        }
+        for (int i = 0; i < emu.Grid.Scrollback.Count; i++)
+        {
+            var text = RowText(emu.Grid.Scrollback[i]);
+            if (text.Contains("Compacting"))
+            {
+                compactingScrollback++;
+                _output.WriteLine($"scrollback[{i}]: {text}");
+            }
+        }
+        _output.WriteLine($"grid {cols}x{rows}: screen内Compacting={compactingScreen}, scrollback内Compacting={compactingScrollback}, scrollback行数={emu.Grid.Scrollback.Count}");
+
+        // 画面末尾付近も表示（スピナー行周辺の状態確認）
+        for (int r = Math.Max(0, rows - 35); r < rows; r++)
+        {
+            var text = RowText(emu.Grid.Screen[r]);
+            if (text.Length > 0)
+            {
+                _output.WriteLine($"  [{r:D2}] {text}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// 起動直後のサイズ不一致シナリオ: エミュレータが既定サイズのままストリーム前半を解釈し、
+    /// 途中で実サイズに Resize された場合、状態が汚染されて残らないか。
+    /// </summary>
+    [SkippableFact]
+    public void Startup_size_mismatch_then_resize()
+    {
+        var stream = TryLoad("dup6a-20260703-082331.raw");
+        Skip.If(stream == null, "ローカルキャプチャ dup6a が無いためスキップ");
+
+        // 前半3KBを既定サイズ(120x30)で解釈 → 実サイズ(160x54)へリサイズ → 残りを解釈
+        var emu = new EmulatedStateBuffer(120, 30);
+        emu.Append(stream!.Substring(0, 3000));
+        emu.Resize(160, 54);
+        emu.Append(stream.Substring(3000));
+
+        int compacting = 0;
+        for (int r = 0; r < 54; r++)
+        {
+            var text = RowText(emu.Grid.Screen[r]);
+            if (text.Contains("Compacting"))
+            {
+                compacting++;
+                _output.WriteLine($"screen[{r}]: {text}");
+            }
+        }
+        foreach (var row in emu.Grid.Scrollback)
+        {
+            var text = RowText(row);
+            if (text.Contains("Compacting"))
+            {
+                compacting++;
+                _output.WriteLine($"scrollback: {text}");
+            }
+        }
+        _output.WriteLine($"サイズ不一致→リサイズ後のCompacting総数: {compacting}, scrollback行数={emu.Grid.Scrollback.Count}");
+    }
+}

--- a/TerminalHub.Terminal.Tests/Dup9DiagnosticTests.cs
+++ b/TerminalHub.Terminal.Tests/Dup9DiagnosticTests.cs
@@ -1,0 +1,98 @@
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TerminalHub.Terminal.Tests;
+
+/// <summary>
+/// カニ（Claude Code バナー）がスクロールバックに複数残る事象の診断。
+/// 生ストリームには全画面再描画によりバナーが12回含まれるが、
+/// エミュレータの最終状態では1回に畳まれているべき。
+/// 複数回残る場合、「再描画と再描画の間のスクロール」で上端行が
+/// 繰り返しアーカイブされている（畳み込みの構造的な穴）。
+/// </summary>
+public class Dup9DiagnosticTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public Dup9DiagnosticTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static string? TryLoad(string fixture)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "local", fixture);
+        return File.Exists(path) ? File.ReadAllText(path, Encoding.UTF8) : null;
+    }
+
+    private static string RowText(Cell[] row)
+    {
+        var sb = new StringBuilder();
+        foreach (var cell in row)
+        {
+            if (cell.IsWideTrailer) continue;
+            sb.Append(cell.Text ?? " ");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    [SkippableTheory]
+    [InlineData("dup9a.raw", 160, 36)]
+    [InlineData("dup9a.raw", 160, 54)]
+    [InlineData("dup9a.raw", 160, 71)]
+    [InlineData("dup9a.raw", 160, 72)]
+    [InlineData("dup9b.raw", 160, 70)]
+    [InlineData("dup9b.raw", 160, 71)]
+    [InlineData("dup9b.raw", 160, 72)]
+    [InlineData("dup9b.raw", 160, 54)]
+    public void Count_banner_occurrences_in_final_state(string fixture, int cols, int rows)
+    {
+        var stream = TryLoad(fixture);
+        Skip.If(stream == null, $"ローカルキャプチャ {fixture} が無いためスキップ");
+
+        var emu = new EmulatedStateBuffer(cols, rows);
+        emu.Append(stream!);
+
+        int InState(string probe)
+        {
+            int count = 0;
+            foreach (var row in emu.Grid.Scrollback)
+            {
+                if (RowText(row).Contains(probe)) count++;
+            }
+            for (int r = 0; r < rows; r++)
+            {
+                if (RowText(emu.Grid.Screen[r]).Contains(probe)) count++;
+            }
+            return count;
+        }
+
+        _output.WriteLine($"{fixture} grid {cols}x{rows}: scrollback={emu.Grid.Scrollback.Count}行");
+        foreach (var probe in new[] { "MCP servers need", "Conversation compacted", "Claude Code" })
+        {
+            _output.WriteLine($"  '{probe}' 最終状態出現数: {InState(probe)}（生ストリーム: {Count(stream!, probe)}）");
+        }
+
+        // スクロールバック内でバナー行がどこにあるか
+        for (int i = 0; i < emu.Grid.Scrollback.Count; i++)
+        {
+            var text = RowText(emu.Grid.Scrollback[i]);
+            if (text.Contains("MCP servers need") || text.Contains("Conversation compacted"))
+            {
+                _output.WriteLine($"  scrollback[{i}]: {text}");
+            }
+        }
+    }
+
+    private static int Count(string haystack, string needle)
+    {
+        int count = 0, idx = 0;
+        while ((idx = haystack.IndexOf(needle, idx, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            idx += needle.Length;
+        }
+        return count;
+    }
+}

--- a/TerminalHub.Terminal.Tests/EmulatedStateBufferTests.cs
+++ b/TerminalHub.Terminal.Tests/EmulatedStateBufferTests.cs
@@ -72,8 +72,12 @@ public class EmulatedStateBufferTests
     // ---- 根治の受け入れ基準: repaint が二重化しない ----
 
     /// <summary>
-    /// 生ストリーム方式では "line3" が2回残った合成 repaint フィクスチャが、
-    /// エミュレータ方式では畳まれて1回だけになる（＝スクロールバック二重化の根治）。
+    /// 合成 repaint フィクスチャ（ESC[H ESC[2J → 同一内容を再描画）の挙動。
+    /// ED2 は Windows Terminal / xterm.js(scrollOnEraseInDisplay) 準拠で
+    /// 「消去前の画面をスクロールバックへ退避」するため、退避1回＋画面1回の計2回が正しい。
+    /// （無限に増えないこと＝2回で止まることが受け入れ基準。
+    ///   ESC[2J を使わない Claude Code 型 repaint の畳み込みは
+    ///   Home_and_erase_repaint_frames_leave_single_copy が担保する）
     /// </summary>
     [Fact]
     public void Repaint_is_collapsed_not_duplicated()
@@ -83,8 +87,8 @@ public class EmulatedStateBufferTests
         buf.Append(stream);
 
         var replay = buf.SerializeForReplay();
-        Assert.Equal(1, CountOccurrences(replay, "line3"));
-        Assert.Equal(1, CountOccurrences(replay, "line1"));
+        Assert.Equal(2, CountOccurrences(replay, "line3"));
+        Assert.Equal(2, CountOccurrences(replay, "line1"));
     }
 
     /// <summary>

--- a/TerminalHub.Terminal.Tests/ReplayCaptureTests.cs
+++ b/TerminalHub.Terminal.Tests/ReplayCaptureTests.cs
@@ -97,6 +97,53 @@ public class ReplayCaptureTests
     }
 
     [Fact]
+    public void Pending_escape_fragment_at_snapshot_is_seeded_into_tail()
+    {
+        // チャンク境界がエスケープシーケンスの途中で切れた状態で BeginReplay した場合、
+        // 未確定の前半をテールへ種付けし、後続チャンクと合わせて完全なシーケンスとして届くこと
+        var buffer = new EmulatedStateBuffer(80, 24);
+        buffer.Append("abc\x1b[3"); // CSI 途中で分断
+        var snapshot = buffer.BeginReplay();
+        buffer.Append("1mred");     // 続き（合わせて ESC[31m red）
+        var tail = buffer.EndReplay(snapshot);
+
+        var restored = new EmulatedStateBuffer(80, 24);
+        restored.Append(snapshot.Content);
+        restored.Append(tail);
+
+        var truth = new EmulatedStateBuffer(80, 24);
+        truth.Append("abc\x1b[31mred");
+
+        Assert.Equal(truth.SerializeForReplay(), restored.SerializeForReplay());
+    }
+
+    [Fact]
+    public void Pending_high_surrogate_at_snapshot_is_seeded_into_tail()
+    {
+        // サロゲートペアの前半でチャンクが切れた状態で BeginReplay した場合も同様
+        var emoji = "😀"; // U+1F600（サロゲートペア）
+        var buffer = new EmulatedStateBuffer(80, 24);
+        buffer.Append("x" + emoji[0]); // 前半のみ
+        var snapshot = buffer.BeginReplay();
+        buffer.Append(emoji[1].ToString() + "y"); // 後半＋続き
+        var tail = buffer.EndReplay(snapshot);
+
+        // スナップショット側は孤立サロゲートを含まない（JS interop の JSON 化で化けるため）
+        Assert.DoesNotContain(emoji[0], snapshot.Content);
+        // テール先頭で前半＋後半が揃う
+        Assert.StartsWith(emoji, tail);
+
+        var restored = new EmulatedStateBuffer(80, 24);
+        restored.Append(snapshot.Content);
+        restored.Append(tail);
+
+        var truth = new EmulatedStateBuffer(80, 24);
+        truth.Append("x" + emoji + "y");
+
+        Assert.Equal(truth.SerializeForReplay(), restored.SerializeForReplay());
+    }
+
+    [Fact]
     public void RawStream_capture_has_same_semantics()
     {
         var buffer = new RawStreamStateBuffer();

--- a/TerminalHub.Terminal.Tests/ReplayCaptureTests.cs
+++ b/TerminalHub.Terminal.Tests/ReplayCaptureTests.cs
@@ -1,0 +1,111 @@
+using Xunit;
+
+namespace TerminalHub.Terminal.Tests;
+
+/// <summary>
+/// BeginReplay/EndReplay（リプレイキャプチャ）の検証。
+/// 「スナップショット取得〜xterm書き込み完了」の間に届いたライブ出力が
+/// 消失・二重化・順序逆転しないことを保証する（セッション切替/リサイズ再同期のレース対策）。
+/// </summary>
+public class ReplayCaptureTests
+{
+    [Fact]
+    public void Append_outside_capture_returns_false()
+    {
+        var buffer = new EmulatedStateBuffer(80, 24);
+        Assert.False(buffer.Append("hello"));
+    }
+
+    [Fact]
+    public void Append_during_capture_returns_true_and_tail_preserves_order()
+    {
+        var buffer = new EmulatedStateBuffer(80, 24);
+        buffer.Append("before\r\n");
+
+        var snapshot = buffer.BeginReplay();
+        Assert.Contains("before", snapshot.Content);
+
+        Assert.True(buffer.Append("chunk1"));
+        Assert.True(buffer.Append("chunk2"));
+
+        var tail = buffer.EndReplay(snapshot);
+        Assert.Equal("chunk1chunk2", tail);
+
+        // キャプチャ終了後は通常動作に戻る
+        Assert.False(buffer.Append("after"));
+    }
+
+    [Fact]
+    public void Snapshot_content_does_not_include_tail_data()
+    {
+        var buffer = new EmulatedStateBuffer(80, 24);
+        buffer.Append("line1\r\n");
+
+        var snapshot = buffer.BeginReplay();
+        buffer.Append("line2\r\n");
+
+        Assert.Contains("line1", snapshot.Content);
+        Assert.DoesNotContain("line2", snapshot.Content);
+
+        var tail = buffer.EndReplay(snapshot);
+        Assert.Contains("line2", tail);
+    }
+
+    [Fact]
+    public void Snapshot_plus_tail_reconstructs_same_state()
+    {
+        // 連続して見ていた端末(A)と、キャプチャ中にライブ出力が届いた復元端末(B)の最終状態が一致すること
+        var a = new EmulatedStateBuffer(80, 24);
+        a.Append("line1\r\nline2\r\n");
+        a.Append("live1\r\nlive2\r\n");
+
+        var source = new EmulatedStateBuffer(80, 24);
+        source.Append("line1\r\nline2\r\n");
+        var snapshot = source.BeginReplay();
+        source.Append("live1\r\nlive2\r\n"); // 書き込み中に届いたライブ出力
+        var tail = source.EndReplay(snapshot);
+
+        var b = new EmulatedStateBuffer(80, 24);
+        b.Append(snapshot.Content);
+        b.Append(tail);
+
+        Assert.Equal(a.SerializeForReplay(), b.SerializeForReplay());
+    }
+
+    [Fact]
+    public void Empty_buffer_snapshot_is_empty()
+    {
+        var buffer = new EmulatedStateBuffer(80, 24);
+        var snapshot = buffer.BeginReplay();
+        Assert.Equal(string.Empty, snapshot.Content);
+        Assert.Equal(string.Empty, buffer.EndReplay(snapshot));
+    }
+
+    [Fact]
+    public void Concurrent_captures_each_get_their_own_tail()
+    {
+        var buffer = new EmulatedStateBuffer(80, 24);
+        buffer.Append("base\r\n");
+
+        var first = buffer.BeginReplay();
+        buffer.Append("x");
+        var second = buffer.BeginReplay();
+        buffer.Append("y");
+
+        Assert.Equal("xy", buffer.EndReplay(first));
+        Assert.Equal("y", buffer.EndReplay(second));
+    }
+
+    [Fact]
+    public void RawStream_capture_has_same_semantics()
+    {
+        var buffer = new RawStreamStateBuffer();
+        buffer.Append("before");
+
+        var snapshot = buffer.BeginReplay();
+        Assert.Equal("before", snapshot.Content);
+        Assert.True(buffer.Append("tail"));
+        Assert.Equal("tail", buffer.EndReplay(snapshot));
+        Assert.False(buffer.Append("after"));
+    }
+}

--- a/TerminalHub.Terminal/EmulatedStateBuffer.cs
+++ b/TerminalHub.Terminal/EmulatedStateBuffer.cs
@@ -60,6 +60,12 @@ public sealed class EmulatedStateBuffer : ITerminalStateBuffer
         lock (_lock)
         {
             var snapshot = new ReplaySnapshot(_hasData ? AnsiSerializer.Serialize(_grid) : string.Empty);
+            // チャンク境界で分断された未確定シーケンス（途中で切れたエスケープ/サロゲート前半）を
+            // テールの先頭に種付けする。この続きは以降のライブ出力として届くため、
+            // これが無いと xterm 側でシーケンスの後半だけが届きゴミ文字として表示される。
+            // （スナップショット側でなくテール側に付けるのは、孤立サロゲートが
+            // 単独の書き込み末尾になると JSON 化で化けるのを避けるため）
+            snapshot.Tail.Append(_parser.Pending);
             _activeReplays.Add(snapshot);
             return snapshot;
         }

--- a/TerminalHub.Terminal/EmulatedStateBuffer.cs
+++ b/TerminalHub.Terminal/EmulatedStateBuffer.cs
@@ -12,6 +12,7 @@ public sealed class EmulatedStateBuffer : ITerminalStateBuffer
     private readonly TerminalGrid _grid;
     private readonly VtParser _parser;
     private readonly object _lock = new();
+    private readonly List<ReplaySnapshot> _activeReplays = new();
     private bool _hasData;
 
     public EmulatedStateBuffer(int cols = 120, int rows = 30)
@@ -23,16 +24,26 @@ public sealed class EmulatedStateBuffer : ITerminalStateBuffer
     /// <summary>内部グリッド（テスト・診断用）。ロック外で触らないこと。</summary>
     public TerminalGrid Grid => _grid;
 
-    public void Append(string data)
+    public bool Append(string data)
     {
         if (string.IsNullOrEmpty(data))
         {
-            return;
+            return false;
         }
         lock (_lock)
         {
             _hasData = true;
             _parser.Feed(data);
+
+            if (_activeReplays.Count == 0)
+            {
+                return false;
+            }
+            foreach (var replay in _activeReplays)
+            {
+                replay.Tail.Append(data);
+            }
+            return true;
         }
     }
 
@@ -41,6 +52,25 @@ public sealed class EmulatedStateBuffer : ITerminalStateBuffer
         lock (_lock)
         {
             return AnsiSerializer.Serialize(_grid);
+        }
+    }
+
+    public ReplaySnapshot BeginReplay()
+    {
+        lock (_lock)
+        {
+            var snapshot = new ReplaySnapshot(_hasData ? AnsiSerializer.Serialize(_grid) : string.Empty);
+            _activeReplays.Add(snapshot);
+            return snapshot;
+        }
+    }
+
+    public string EndReplay(ReplaySnapshot snapshot)
+    {
+        lock (_lock)
+        {
+            _activeReplays.Remove(snapshot);
+            return snapshot.Tail.ToString();
         }
     }
 

--- a/TerminalHub.Terminal/ITerminalStateBuffer.cs
+++ b/TerminalHub.Terminal/ITerminalStateBuffer.cs
@@ -10,14 +10,29 @@ namespace TerminalHub.Terminal;
 /// </remarks>
 public interface ITerminalStateBuffer
 {
-    /// <summary>ConPTY から届いた（UTF-8 デコード済みの）出力チャンクを取り込む。</summary>
-    void Append(string data);
+    /// <summary>
+    /// ConPTY から届いた（UTF-8 デコード済みの）出力チャンクを取り込む。
+    /// 進行中のリプレイキャプチャ（<see cref="BeginReplay"/>〜<see cref="EndReplay"/>）がある場合は
+    /// テールにも記録し <c>true</c> を返す。<c>true</c> のとき呼び出し側はこのチャンクを
+    /// xterm へ直接書き込んではならない（<see cref="EndReplay"/> のテール書き込みで届くため二重になる）。
+    /// </summary>
+    bool Append(string data);
 
     /// <summary>
     /// セッション切替/リサイズ/再接続時に、新しい xterm へ書き戻すための出力を生成する。
     /// 生ストリーム方式では貯めた生データそのまま。エミュレータ方式では確定状態を最小 ANSI にシリアライズしたもの。
     /// </summary>
     string SerializeForReplay();
+
+    /// <summary>
+    /// リプレイをアトミックに開始する。スナップショット生成と同時に以降の <see cref="Append"/> の
+    /// テール記録を開始するため、「スナップショット取得〜書き込み完了」の間に届いたライブ出力が
+    /// 消失・順序逆転しない。書き込み完了後は必ず <see cref="EndReplay"/> を呼ぶこと。
+    /// </summary>
+    ReplaySnapshot BeginReplay();
+
+    /// <summary>テール記録を終了し、スナップショット以降に届いた出力を順序どおり返す。</summary>
+    string EndReplay(ReplaySnapshot snapshot);
 
     /// <summary>保持状態を破棄する。</summary>
     void Clear();

--- a/TerminalHub.Terminal/RawStreamStateBuffer.cs
+++ b/TerminalHub.Terminal/RawStreamStateBuffer.cs
@@ -15,6 +15,7 @@ public sealed class RawStreamStateBuffer : ITerminalStateBuffer
 {
     private readonly StringBuilder _buffer = new();
     private readonly object _lock = new();
+    private readonly List<ReplaySnapshot> _activeReplays = new();
     private readonly int _maxSize;
 
     /// <summary>既定の上限サイズ（文字数）。従来の SessionInfo 実装と同じ 2MB 相当。</summary>
@@ -25,11 +26,11 @@ public sealed class RawStreamStateBuffer : ITerminalStateBuffer
         _maxSize = maxSize;
     }
 
-    public void Append(string data)
+    public bool Append(string data)
     {
         if (string.IsNullOrEmpty(data))
         {
-            return;
+            return false;
         }
 
         lock (_lock)
@@ -48,6 +49,35 @@ public sealed class RawStreamStateBuffer : ITerminalStateBuffer
                 }
             }
             _buffer.Append(data);
+
+            if (_activeReplays.Count == 0)
+            {
+                return false;
+            }
+            foreach (var replay in _activeReplays)
+            {
+                replay.Tail.Append(data);
+            }
+            return true;
+        }
+    }
+
+    public ReplaySnapshot BeginReplay()
+    {
+        lock (_lock)
+        {
+            var snapshot = new ReplaySnapshot(_buffer.ToString());
+            _activeReplays.Add(snapshot);
+            return snapshot;
+        }
+    }
+
+    public string EndReplay(ReplaySnapshot snapshot)
+    {
+        lock (_lock)
+        {
+            _activeReplays.Remove(snapshot);
+            return snapshot.Tail.ToString();
         }
     }
 

--- a/TerminalHub.Terminal/ReplaySnapshot.cs
+++ b/TerminalHub.Terminal/ReplaySnapshot.cs
@@ -1,0 +1,23 @@
+using System.Text;
+
+namespace TerminalHub.Terminal;
+
+/// <summary>
+/// <see cref="ITerminalStateBuffer.BeginReplay"/> が返すリプレイ用スナップショット。
+/// <see cref="Content"/> は開始時点の確定状態。開始以降に <c>Append</c> された出力は
+/// <see cref="ITerminalStateBuffer.EndReplay"/> まで内部のテールに蓄積され、順序どおりに取り出せる。
+/// これにより「スナップショット取得〜xterm 書き込み完了」の間に届いたライブ出力が
+/// 消失・順序逆転することなく復元できる（セッション切替/リサイズ再同期のレース対策）。
+/// </summary>
+public sealed class ReplaySnapshot
+{
+    /// <summary>スナップショット時点の復元用出力（xterm へ最初に書き込む内容）。</summary>
+    public string Content { get; }
+
+    internal StringBuilder Tail { get; } = new();
+
+    internal ReplaySnapshot(string content)
+    {
+        Content = content;
+    }
+}

--- a/TerminalHub.Terminal/TerminalGrid.cs
+++ b/TerminalHub.Terminal/TerminalGrid.cs
@@ -189,7 +189,7 @@ public sealed class TerminalGrid
         _pendingWrap = false;
         if (CursorRow >= Rows - 1)
         {
-            ScrollUp(1);
+            ScrollUpArchiving(1);
         }
         else
         {
@@ -277,6 +277,33 @@ public sealed class TerminalGrid
                 }
                 break;
             case 2:
+                // Windows Terminal 準拠: ED2 は「消去」ではなく「現在の画面内容をスクロールバックへ
+                // 退避して、新しい空のページにする」（adaptDispatch の _EraseAll と同じ設計）。
+                // 退避するのは最終コンテンツ行まで（末尾の空白行は退避しない）。
+                // カーソルの行・列位置は新ページ内で維持される。alt-screen 中は退避せず空白化のみ。
+                if (!IsAltScreen)
+                {
+                    int lastContent = -1;
+                    for (int r = _screen.Count - 1; r >= 0; r--)
+                    {
+                        if (RowHasContent(_screen[r]))
+                        {
+                            lastContent = r;
+                            break;
+                        }
+                    }
+                    for (int r = 0; r <= lastContent; r++)
+                    {
+                        // 行配列の所有権をスクロールバックへ移し、画面側は新しい行に差し替える
+                        // （FillRowBlank で退避済みの行まで消してしまわないように）
+                        _scrollback.Add(_screen[r]);
+                        _screen[r] = CreateBlankRow(Cols);
+                        if (_scrollback.Count > MaxScrollback)
+                        {
+                            _scrollback.RemoveAt(0);
+                        }
+                    }
+                }
                 for (int r = 0; r < Rows; r++)
                 {
                     FillRowBlank(r);
@@ -393,8 +420,17 @@ public sealed class TerminalGrid
 
     // ---- スクロール ----
 
-    /// <summary>画面を n 行上へスクロール（上端行はスクロールバックへ、alt-screen 中は破棄）。</summary>
-    public void ScrollUp(int n)
+    /// <summary>
+    /// SU（CSI S）: 画面を n 行上へスクロールし、スクロールアウトした行は**破棄**する。
+    /// Windows Terminal 準拠（adaptDispatch の _ScrollMovement はスクロールバックへ退避しない）。
+    /// スクロールバックへ入るのは「最下行での改行」（<see cref="LineFeed"/>）と ED2 のみ。
+    /// </summary>
+    public void ScrollUp(int n) => ScrollUpCore(n, archiveToScrollback: false);
+
+    /// <summary>最下行での改行によるスクロール。上端行をスクロールバックへ退避する（alt-screen 中は破棄）。</summary>
+    internal void ScrollUpArchiving(int n) => ScrollUpCore(n, archiveToScrollback: true);
+
+    private void ScrollUpCore(int n, bool archiveToScrollback)
     {
         n = Math.Clamp(n, 1, Rows);
         for (int i = 0; i < n; i++)
@@ -402,7 +438,7 @@ public sealed class TerminalGrid
             var top = _screen[0];
             _screen.RemoveAt(0);
             _screen.Add(CreateBlankRow(Cols));
-            if (!IsAltScreen)
+            if (archiveToScrollback && !IsAltScreen)
             {
                 _scrollback.Add(top);
                 if (_scrollback.Count > MaxScrollback)

--- a/TerminalHub.Terminal/VtParser.cs
+++ b/TerminalHub.Terminal/VtParser.cs
@@ -24,6 +24,7 @@ public sealed class VtParser
     private readonly TerminalGrid _grid;
     private State _state = State.Ground;
     private readonly StringBuilder _csiParams = new();
+    private readonly StringBuilder _pendingRaw = new();
     private char _pendingHighSurrogate;
 
     public VtParser(TerminalGrid grid)
@@ -31,11 +32,30 @@ public sealed class VtParser
         _grid = grid;
     }
 
+    /// <summary>
+    /// チャンク境界で分断されて未確定のまま保持している入力の生文字列
+    /// （途中で切れたエスケープシーケンス、またはサロゲートペアの前半）。
+    /// リプレイのスナップショット生成時、この続きがテールとして届くため、
+    /// これをテールの先頭に付けないと xterm 側で断片がゴミ文字として表示される。
+    /// </summary>
+    public string Pending
+    {
+        get
+        {
+            if (_state != State.Ground)
+            {
+                return _pendingRaw.ToString();
+            }
+            return _pendingHighSurrogate != '\0' ? _pendingHighSurrogate.ToString() : string.Empty;
+        }
+    }
+
     /// <summary>出力チャンクを解釈してグリッドへ適用する。</summary>
     public void Feed(string data)
     {
         foreach (char ch in data)
         {
+            var wasGround = _state == State.Ground;
             switch (_state)
             {
                 case State.Ground:
@@ -74,6 +94,24 @@ public sealed class VtParser
                 case State.DcsEsc:
                     _state = ch == '\\' ? State.Ground : State.Dcs;
                     break;
+            }
+
+            // 未確定シーケンスの生文字列を追跡（Pending 用）。
+            // シーケンス中の文字を蓄積し、Ground に戻ったら破棄する
+            if (_state == State.Ground)
+            {
+                if (!wasGround)
+                {
+                    _pendingRaw.Clear();
+                }
+            }
+            else
+            {
+                if (wasGround)
+                {
+                    _pendingRaw.Clear();
+                }
+                _pendingRaw.Append(ch);
             }
         }
     }

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -989,6 +989,24 @@
                 // 過去バッファの誤検出を防ぐため、接続時刻を記録
                 selectedSession.LastConnectionTime = DateTime.Now;
 
+                // リプレイ前にエミュレータ/ConPTY を xterm の実サイズへ同期する。
+                // 切替中はリサイズ通知を skip しているため、別セッション閲覧中にパネル開閉や
+                // ウィンドウ変更があるとサイズがずれたままになる。エミュレータの行数が xterm より
+                // 大きい状態でリプレイすると、超過分が xterm のスクロールバックへ押し出されて
+                // 「古い画面が上に残る」重複が恒久化する。
+                // ConPTY のリサイズで conhost が新サイズの画面を再描画し、それはリプレイの
+                // テール（またはそれ以降のライブ出力）として正しい順序で届く。
+                var xtermSize = await TerminalService.GetTerminalSizeAsync(activeTerminal);
+                if (xtermSize is { Cols: >= 20, Rows: >= 10 } size && activeSession != null &&
+                    (activeSession.Cols != size.Cols || activeSession.Rows != size.Rows))
+                {
+                    Logger.LogInformation("[SelectSession] リプレイ前サイズ同期: {OldCols}x{OldRows} → {Cols}x{Rows}",
+                        activeSession.Cols, activeSession.Rows, size.Cols, size.Rows);
+                    // 必ずエミュレータ → ConPTY の順（再送データより先に画面を空にするため）
+                    selectedSession.ResizeTerminalBuffer(size.Cols, size.Rows);
+                    activeSession.Resize(size.Cols, size.Rows);
+                }
+
                 // スナップショット生成と同時にライブ出力のテール記録を開始し、
                 // スナップショット→テールの順で書き込むことで取りこぼし・順序逆転を防ぐ
                 await _terminalWriteLock.WaitAsync();

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1078,7 +1078,7 @@
         activeTerminal = await TerminalService.InitializeTerminalAsync(sessionId, terminalDotNetRef, terminalFontSize);
     }
 
-    private async Task ProcessReceivedData(Guid sessionId, string data)
+    private async Task ProcessReceivedData(Guid sessionId, string data, bool capturedByReplay)
     {
         try
         {
@@ -1097,16 +1097,12 @@
 
             var isActive = activeSessionId == sessionId;
 
-            // 生ストリームキャプチャ（デバッグ有効時のみ。VTエミュレータ検証フィクスチャ採取用）
-            if (RawStreamCapture.Enabled)
-            {
-                RawStreamCapture.Capture(sessionId, data);
-            }
-
-            // スクロールバック保持用バッファに追記（常時有効、セッション切替時の画面復元とバッファダンプに使用）
-            // true が返った場合は進行中のリプレイキャプチャに取り込まれており、
+            // 状態バッファへの追記と生ストリームキャプチャは SessionManager のサーバー側タップで
+            // （チャンクごとに1回だけ）実施済み。ここ（Circuit ごとのハンドラ）で行うと、
+            // 複数ブラウザ接続や切断後も残存する Circuit の数だけ多重に Append され、
+            // リプレイ時に行の重複・表示ズレが起きる。
+            // capturedByReplay=true のチャンクは進行中のリプレイキャプチャに取り込まれており、
             // リプレイのテール書き込みで届くため直接書き込みしてはならない（二重表示になる）
-            var capturedByReplay = sessionInfo.AppendToTerminalBuffer(data);
 
             // Claude Codeの場合、"No conversation found to continue"エラーをチェック
             // ただし、処理中（Claude が出力中）の場合は誤検出を防ぐためスキップ
@@ -2573,7 +2569,7 @@
         {
             try
             {
-                await ProcessReceivedData(args.SessionId, args.Data);
+                await ProcessReceivedData(args.SessionId, args.Data, args.CapturedByReplay);
             }
             catch (Exception ex)
             {

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -231,6 +231,14 @@
     // fit()によるリサイズがConPTYに通知されると画面内容が再送信され重複するため
     private bool _skipConPtyResize = false;
 
+    // xterm への書き込み直列化用。ライブ出力とリプレイ（切替復元/リサイズ再同期）が
+    // 交錯すると行の重複・1行ズレが発生するため、書き込みを1本に直列化する
+    private readonly SemaphoreSlim _terminalWriteLock = new(1, 1);
+
+    // 復元処理中のセッションID。復元中に届いたライブ出力は直接書き込みせずスキップする
+    // （スナップショットに含まれているか、リプレイキャプチャのテールとして後で書き込まれるため）
+    private Guid? _restoringSessionId;
+
     // HookNotificationServiceイベントハンドラー
     private EventHandler<HookNotificationEventArgs>? _hookNotificationHandler;
 
@@ -959,6 +967,9 @@
         // showTerminal/InitializeTerminal内のfitAddon.fit()が過渡的なサイズでConPTYに通知するのを防ぐ
         // 最終的なリサイズはResizeTerminalAsyncで正しいサイズを適用する
         _skipConPtyResize = true;
+        // 復元完了までライブ出力の直接書き込みを止める（新しい空のxtermへリプレイより先に
+        // ライブチャンクが書かれると、以降のCUP絶対座標描画が全部ズレて重複表示になるため）
+        _restoringSessionId = sessionId;
         try
         {
             // ターミナルdivが存在するか確認し、表示する
@@ -978,40 +989,37 @@
                 // 過去バッファの誤検出を防ぐため、接続時刻を記録
                 selectedSession.LastConnectionTime = DateTime.Now;
 
-                // バッファ内容をターミナルに書き込み
-                var bufferContent = selectedSession.GetTerminalBuffer();
-                if (!string.IsNullOrEmpty(bufferContent))
+                // スナップショット生成と同時にライブ出力のテール記録を開始し、
+                // スナップショット→テールの順で書き込むことで取りこぼし・順序逆転を防ぐ
+                await _terminalWriteLock.WaitAsync();
+                try
                 {
-                    // デバッグ: バッファ内容を解析
-                    Logger.LogInformation("[SelectSession] バッファ書き込み開始: SessionId={SessionId}, Size={Size}バイト",
-                        sessionId, bufferContent.Length);
-
-                    // 危険なエスケープシーケンスをチェック（巨大な行/列番号）
-                    var cursorMovePattern = new System.Text.RegularExpressions.Regex(@"\x1b\[(\d+);?(\d*)H");
-                    var matches = cursorMovePattern.Matches(bufferContent);
-                    foreach (System.Text.RegularExpressions.Match match in matches)
+                    var replaySnapshot = selectedSession.BeginTerminalBufferReplay();
+                    string replayTail;
+                    try
                     {
-                        if (int.TryParse(match.Groups[1].Value, out int row) && row > 1000)
+                        if (!string.IsNullOrEmpty(replaySnapshot.Content))
                         {
-                            Logger.LogWarning("[SelectSession] 危険なカーソル移動検出: Row={Row}, Match={Match}",
-                                row, match.Value);
+                            Logger.LogInformation("[SelectSession] バッファ書き込み開始: SessionId={SessionId}, Size={Size}文字",
+                                sessionId, replaySnapshot.Content.Length);
+                            await TerminalService.WriteToTerminalAsync(activeTerminal, replaySnapshot.Content);
+                            Logger.LogInformation("[SelectSession] バッファ書き込み完了");
                         }
                     }
-
-                    // バッファの先頭と末尾をログ出力（エスケープシーケンスを可視化）
-                    var preview = bufferContent.Length > 500 ? bufferContent.Substring(0, 500) : bufferContent;
-                    var previewEscaped = preview.Replace("\x1b", "\\e").Replace("\r", "\\r").Replace("\n", "\\n");
-                    Logger.LogDebug("[SelectSession] バッファ先頭500文字: {Preview}", previewEscaped);
-
-                    if (bufferContent.Length > 500)
+                    finally
                     {
-                        var tail = bufferContent.Substring(bufferContent.Length - 500);
-                        var tailEscaped = tail.Replace("\x1b", "\\e").Replace("\r", "\\r").Replace("\n", "\\n");
-                        Logger.LogDebug("[SelectSession] バッファ末尾500文字: {Tail}", tailEscaped);
+                        replayTail = selectedSession.EndTerminalBufferReplay(replaySnapshot);
                     }
 
-                    await TerminalService.WriteToTerminalAsync(activeTerminal, bufferContent);
-                    Logger.LogInformation("[SelectSession] バッファ書き込み完了");
+                    if (!string.IsNullOrEmpty(replayTail))
+                    {
+                        await TerminalService.WriteToTerminalAsync(activeTerminal, replayTail);
+                    }
+                    _restoringSessionId = null;
+                }
+                finally
+                {
+                    _terminalWriteLock.Release();
                 }
 
                 await Task.Delay(50);
@@ -1028,6 +1036,7 @@
         finally
         {
             _skipConPtyResize = false;
+            _restoringSessionId = null;
         }
 
         // ConPtySessionをConPtyConnectionServiceに登録
@@ -1095,7 +1104,9 @@
             }
 
             // スクロールバック保持用バッファに追記（常時有効、セッション切替時の画面復元とバッファダンプに使用）
-            sessionInfo.AppendToTerminalBuffer(data);
+            // true が返った場合は進行中のリプレイキャプチャに取り込まれており、
+            // リプレイのテール書き込みで届くため直接書き込みしてはならない（二重表示になる）
+            var capturedByReplay = sessionInfo.AppendToTerminalBuffer(data);
 
             // Claude Codeの場合、"No conversation found to continue"エラーをチェック
             // ただし、処理中（Claude が出力中）の場合は誤検出を防ぐためスキップ
@@ -1168,7 +1179,23 @@
             // アクティブセッションの場合は直接ターミナルに出力
             if (isActive && activeTerminal != null)
             {
-                await TerminalService.WriteToTerminalAsync(activeTerminal, data);
+                if (!capturedByReplay)
+                {
+                    // リプレイ（切替復元/リサイズ再同期）と交錯しないよう書き込みを直列化する
+                    await _terminalWriteLock.WaitAsync();
+                    try
+                    {
+                        // 復元開始前に届いたチャンクはスナップショットに含まれているため書き込まない
+                        if (_restoringSessionId != sessionId)
+                        {
+                            await TerminalService.WriteToTerminalAsync(activeTerminal, data);
+                        }
+                    }
+                    finally
+                    {
+                        _terminalWriteLock.Release();
+                    }
+                }
 
                 // 接続直後（バッファ復元直後）は出力解析をスキップ
                 if (!sessionInfo.IsRecentConnection)
@@ -1628,11 +1655,33 @@
 
         try
         {
-            var replay = session.GetTerminalBuffer();
-            // ESC c (RIS) は xterm.js でスクロールバックを含む完全リセット
-            await TerminalService.WriteToTerminalAsync(activeTerminal, "\x1bc" + replay);
-            Logger.LogInformation("[Resize] エミュレータ再同期完了: {Size}文字 session={SessionId}",
-                replay.Length, guid.ToString().Substring(0, 8));
+            // ライブ出力と交錯すると1行ズレ・重複が起きるため、書き込みロック下で
+            // スナップショット→テールの順に書き込む（スナップショット以降のライブ出力はテールで届く）
+            await _terminalWriteLock.WaitAsync();
+            try
+            {
+                var snapshot = session.BeginTerminalBufferReplay();
+                string tail;
+                try
+                {
+                    // ESC c (RIS) は xterm.js でスクロールバックを含む完全リセット
+                    await TerminalService.WriteToTerminalAsync(activeTerminal, "\x1bc" + snapshot.Content);
+                }
+                finally
+                {
+                    tail = session.EndTerminalBufferReplay(snapshot);
+                }
+                if (!string.IsNullOrEmpty(tail))
+                {
+                    await TerminalService.WriteToTerminalAsync(activeTerminal, tail);
+                }
+                Logger.LogInformation("[Resize] エミュレータ再同期完了: {Size}文字＋テール{TailSize}文字 session={SessionId}",
+                    snapshot.Content.Length, tail.Length, guid.ToString().Substring(0, 8));
+            }
+            finally
+            {
+                _terminalWriteLock.Release();
+            }
         }
         catch (JSDisconnectedException)
         {

--- a/TerminalHub/Models/SessionInfo.cs
+++ b/TerminalHub/Models/SessionInfo.cs
@@ -155,9 +155,28 @@ namespace TerminalHub.Models
         private readonly TerminalHub.Terminal.ITerminalStateBuffer _terminalBuffer
             = TerminalHub.Terminal.TerminalStateBufferFactory.Create();
 
-        public void AppendToTerminalBuffer(string data)
+        /// <summary>
+        /// 出力チャンクをバッファへ取り込む。進行中のリプレイキャプチャに取り込まれた場合 true を返し、
+        /// そのとき呼び出し側は xterm へ直接書き込んではならない（テール書き込みで届くため二重になる）。
+        /// </summary>
+        public bool AppendToTerminalBuffer(string data)
         {
-            _terminalBuffer.Append(data);
+            return _terminalBuffer.Append(data);
+        }
+
+        /// <summary>
+        /// リプレイをアトミックに開始する（スナップショット生成＋以降のライブ出力のテール記録開始）。
+        /// 書き込み完了後は必ず <see cref="EndTerminalBufferReplay"/> を呼ぶこと。
+        /// </summary>
+        public TerminalHub.Terminal.ReplaySnapshot BeginTerminalBufferReplay()
+        {
+            return _terminalBuffer.BeginReplay();
+        }
+
+        /// <summary>テール記録を終了し、スナップショット以降に届いた出力を順序どおり返す。</summary>
+        public string EndTerminalBufferReplay(TerminalHub.Terminal.ReplaySnapshot snapshot)
+        {
+            return _terminalBuffer.EndReplay(snapshot);
         }
 
         /// <summary>端末サイズ変更をバッファへ通知する。</summary>

--- a/TerminalHub/Services/ConPtyConnectionService.cs
+++ b/TerminalHub/Services/ConPtyConnectionService.cs
@@ -44,7 +44,10 @@ namespace TerminalHub.Services
             {
                 try
                 {
-                    DataReceived?.Invoke(this, new ConPtyDataReceivedEventArgs(sessionId, args.Data));
+                    DataReceived?.Invoke(this, new ConPtyDataReceivedEventArgs(sessionId, args.Data)
+                    {
+                        CapturedByReplay = args.CapturedByReplay
+                    });
                 }
                 catch (Exception ex)
                 {
@@ -157,6 +160,12 @@ namespace TerminalHub.Services
     {
         public Guid SessionId { get; }
         public string Data { get; }
+
+        /// <summary>
+        /// サーバー側タップがバッファへ Append した際、進行中のリプレイキャプチャに
+        /// 取り込まれたかどうか。true のとき xterm へ直接書き込んではならない。
+        /// </summary>
+        public bool CapturedByReplay { get; init; }
 
         public ConPtyDataReceivedEventArgs(Guid sessionId, string data)
         {

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -24,7 +24,14 @@ namespace TerminalHub.Services
     public class DataReceivedEventArgs : EventArgs
     {
         public string Data { get; }
-        
+
+        /// <summary>
+        /// SessionManager のサーバー側タップ（最初の購読者）がバッファへ Append した結果、
+        /// 進行中のリプレイキャプチャに取り込まれたかどうか。true のとき Circuit 側は
+        /// このチャンクを xterm へ直接書き込んではならない（リプレイのテールで届くため二重になる）。
+        /// </summary>
+        public bool CapturedByReplay { get; set; }
+
         public DataReceivedEventArgs(string data)
         {
             Data = data;

--- a/TerminalHub/Services/ITerminalService.cs
+++ b/TerminalHub/Services/ITerminalService.cs
@@ -36,6 +36,11 @@ namespace TerminalHub.Services
         Task ResizeTerminalAsync(IJSObjectReference terminal);
 
         /// <summary>
+        /// xterm の現在のサイズ（cols/rows）を取得する。取得できない場合は null。
+        /// </summary>
+        Task<(int Cols, int Rows)?> GetTerminalSizeAsync(IJSObjectReference terminal);
+
+        /// <summary>
         /// ターミナルを最下部にスクロールする
         /// </summary>
         Task ScrollToBottomAsync(Guid sessionId);

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -116,6 +116,34 @@ namespace TerminalHub.Services
         private readonly IRawStreamCaptureService? _rawStreamCapture;
 
         /// <summary>
+        /// ConPTY 出力へのサーバー側シングルタップを取り付ける。
+        /// 状態バッファへの Append と生ストリームキャプチャは、ここで（チャンクごとに1回だけ）行う。
+        /// Circuit（ブラウザ接続）側で行うと、複数接続や切断後も残存する Circuit の数だけ
+        /// 同じチャンクが多重に Append され、リプレイ時に行の重複・表示ズレが起きる。
+        /// ConPtySession 生成直後（Circuit の購読より先）に登録するため、マルチキャストの
+        /// 呼び出し順により Circuit のハンドラより先に実行され、args.CapturedByReplay を
+        /// Circuit 側が参照できる。
+        /// </summary>
+        private void AttachServerSideBufferTap(SessionInfo sessionInfo, ConPtySession session)
+        {
+            session.DataReceived += (sender, args) =>
+            {
+                try
+                {
+                    if (_rawStreamCapture?.Enabled == true)
+                    {
+                        _rawStreamCapture.Capture(sessionInfo.SessionId, args.Data);
+                    }
+                    args.CapturedByReplay = sessionInfo.AppendToTerminalBuffer(args.Data);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "状態バッファへの取り込みに失敗: SessionId={SessionId}", sessionInfo.SessionId);
+                }
+            };
+        }
+
+        /// <summary>
         /// サーバーのベース URL を取得する（スキーム + ホスト + ポート）
         /// 複数アドレスがある場合は HTTP を優先する（Claude Code hook は自己署名 HTTPS 証明書を扱えないケースがあるため）
         /// 0.0.0.0 等のワイルドカードホストは localhost に置換する（LAN バインド対策）
@@ -429,6 +457,7 @@ namespace TerminalHub.Services
 
                 _logger.LogInformation("新規セッション接続開始: SessionId={SessionId}", sessionId);
                 var newSession = await _conPtyService.CreateSessionAsync(command, args, sessionInfo.FolderPath, cols, rows);
+                AttachServerSideBufferTap(sessionInfo, newSession);
 
                 // ConPtySession登録をロック内で実行
                 lock (_lockObject)
@@ -937,6 +966,7 @@ namespace TerminalHub.Services
 
                 // 新しいセッションを作成（Startは呼ばない）
                 ConPtySession newSession = await _conPtyService.CreateSessionAsync(command, args, sessionInfo.FolderPath, cols, rows);
+                AttachServerSideBufferTap(sessionInfo, newSession);
                 _sessions[sessionId] = newSession;
                 sessionInfo.ConPtySession = newSession;
 
@@ -991,6 +1021,7 @@ namespace TerminalHub.Services
 
                 // 新しいセッションを作成して起動
                 ConPtySession newSession = await _conPtyService.CreateSessionAsync(command, args, sessionInfo.FolderPath, cols, rows);
+                AttachServerSideBufferTap(sessionInfo, newSession);
                 _sessions[sessionId] = newSession;
                 sessionInfo.ConPtySession = newSession;
                 newSession.Start();

--- a/TerminalHub/Services/TerminalService.cs
+++ b/TerminalHub/Services/TerminalService.cs
@@ -135,6 +135,26 @@ namespace TerminalHub.Services
             }
         }
 
+        private sealed class TerminalSizeDto
+        {
+            public int Cols { get; set; }
+            public int Rows { get; set; }
+        }
+
+        public async Task<(int Cols, int Rows)?> GetTerminalSizeAsync(IJSObjectReference terminal)
+        {
+            try
+            {
+                var size = await terminal.InvokeAsync<TerminalSizeDto>("getSize");
+                return (size.Cols, size.Rows);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "[GetTerminalSize] サイズ取得エラー（無視）");
+                return null;
+            }
+        }
+
         public async Task ScrollToBottomAsync(Guid sessionId)
         {
             try

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -486,6 +486,10 @@ window.terminalFunctions = {
             // Claude Code のように毎秒複数回再描画する CLI では、履歴を遡って読むことができなくなる
             // （特にモバイル）。false でも最下部に居るときは新規出力に自動追従する（xterm 標準挙動）。
             scrollOnOutput: false,
+            // ED2（CSI 2J 全画面消去）で画面内容をスクロールバックへ退避する（Windows Terminal と同じ挙動）。
+            // クリアしても履歴を遡れるようになる。サーバー側のVTエミュレータ（TerminalGrid.EraseInDisplay）
+            // も同じ意味論で実装しており、ライブ表示とセッション切替時のリプレイが一致する。
+            scrollOnEraseInDisplay: true,
             theme: {
                 background: '#1e1e1e',
                 foreground: '#d4d4d4',


### PR DESCRIPTION
## 概要

セッション切替復帰時の表示崩れ（行重複・文字混ざり・古いスピナーが上に凍って残る）を実キャプチャ9本で追跡し、**独立した4つのバグ**を特定して修正。さらに microsoft/terminal のソース調査に基づき、スクロールバックの意味論を Windows Terminal / xterm.js 準拠に整合させた。ユーザー実機確認済み（「すごい綺麗に出るようになった」）。

## 修正した4つの切替バグ

### 1. リプレイとライブ出力のレース（3653603）
リプレイ書き込み中のJS interop await の隙間にライブ出力が空のxtermへ直接書かれると、以降のCUP絶対座標描画が全部ズレる。
- `ITerminalStateBuffer.BeginReplay/EndReplay`: スナップショット生成と同時にライブ出力のテール記録をアトミックに開始し、スナップショット→テールの順で書き込む
- Root に `SemaphoreSlim` 書き込み直列化＋復元中スキップ（`_restoringSessionId`）。リサイズ後のRIS再同期にも適用

### 2. チャンク境界で分断されたシーケンスのゴミ文字化（68dedb1）
エスケープ/サロゲートの途中でチャンクが切れた状態でリプレイすると後半だけが届き `●mC` のようなゴミ文字が出る。`VtParser.Pending`（未確定断片の生文字列）をテール先頭に種付け。

### 3. 状態バッファへの多重Append（b562759）
Append/キャプチャが Circuit ごとに実行されており、複数ブラウザ接続や**切断後も数分残存する Circuit（リロード直後）**の数だけ同じチャンクが多重パースされ、エミュレータ状態が汚染されていた。SessionManager のサーバー側シングルタップ化＋`CapturedByReplay` フラグ伝搬。

### 4. リプレイ時のサイズ不一致（a9f7f1f）
切替中はリサイズ通知をskipするため、別セッション閲覧中のパネル開閉等でエミュレータ行数＞xterm行数のままリプレイされ、超過分がxtermスクロールバックへ押し出されて「古い画面が上に残る」。リプレイ直前に `GetTerminalSizeAsync` で実サイズへ同期。

## スクロールバック意味論のWT/xterm準拠化（d25d96d）

microsoft/terminal ソース（adaptDispatch/_EraseAll, _ScrollMovement, _DoLineFeed）と xterm.js InputHandler を逐語調査して整合:

- **ED2 (CSI 2J)**: 「その場で消去」→「画面をスクロールバックへ退避して新ページ」（WTの_EraseAll方式）。xterm.js側も `scrollOnEraseInDisplay: true` で一致させた。クリアしても履歴が遡れる改善つき
- **SU/SD (CSI S/T)**: スクロールアウト行は履歴に入れず**破棄**（WT/xterm.jsとも破棄が正）。履歴に入るのは最下行LFとED2のみ

## 検証

- 全59テスト成功（リプレイキャプチャ関連9本、実キャプチャ診断 Dup3〜Dup9 を新規追加。診断テストはローカルキャプチャ無し環境では自動スキップ）
- 修正前順序のシミュレーション: 全切替位置で画面崩れ（60〜70行不一致）／修正後フロー: 全位置・複数サイズで完全一致
- 実機確認: 出力中切替・パネル開閉後切替・リロード直後切替・ブラウザ再起動後の履歴表示

## 既知の残課題（別イシュー扱い）

- カニ（バナー）重複: Claude Code 自身の描画方式（全画面再描画×スクロール）由来で生ストリームに元々含まれる。WTにもdedup機構は無くどのターミナルでも発生。対処するなら「辻褄合わせ」ヒューリスティック（WT超え機能）
- スクロールで上に戻った状態でのリサイズ: RIS再同期がスクロール位置を最下部へ飛ばす（乱暴だが壊れてはいない）。保留→最下部復帰時に実行 or 位置復元で改善可能
- マルチブラウザ同時視聴時の復元中チャンクのライブ表示スキップ（従来からの制約）

🤖 Generated with [Claude Code](https://claude.com/claude-code)