### PR TITLE
feat: 表示設定4項目をデバイス別(LocalStorage)保存に変更

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -486,13 +486,22 @@
                 showTerminalType = appSettings.Sessions.ShowTerminalType;
                 showGitInfo = appSettings.Sessions.ShowGitInfo;
                 hideInputPanel = appSettings.Sessions.HideInputPanel;
-                sessionListScale = appSettings.General.SessionListScale;
-                terminalFontSize = appSettings.General.TerminalFontSize;
-                terminalHeightPercent = appSettings.General.TerminalHeightPercent;
-                sidebarWidthPercent = appSettings.General.SidebarWidthPercent;
+                // 表示系4項目はデバイス別 (LocalStorage 優先、無ければ app-settings をシード)。
+                // PC とモバイルで別々のフォントサイズ等を持てるようにするため。
+                var localDisplay = await LocalStorageService.LoadDisplaySettingsAsync();
+                sessionListScale = localDisplay?.SessionListScale ?? appSettings.General.SessionListScale;
+                terminalFontSize = localDisplay?.TerminalFontSize ?? appSettings.General.TerminalFontSize;
+                terminalHeightPercent = localDisplay?.TerminalHeightPercent ?? appSettings.General.TerminalHeightPercent;
+                sidebarWidthPercent = localDisplay?.SidebarWidthPercent ?? appSettings.General.SidebarWidthPercent;
+                if (localDisplay == null)
+                {
+                    // 初回アクセス: 現在のサーバー側設定をこのデバイスの初期値として保存
+                    await SaveDisplaySettingsToLocalStorageAsync();
+                }
 
                 // テーマは App.razor でサーバーレンダー時に <html data-bs-theme> に
                 // 埋め込み済みのため、ここでは JS での再適用は行わない（フラッシュ防止）。
+                // テーマのみ全デバイス共通 (app-settings) のまま。
             }
             catch
             {
@@ -762,45 +771,63 @@
     }
 
     [JSInvokable]
-    public Task OnSplitterDragEnd(int percent)
+    public async Task OnSplitterDragEnd(int percent)
     {
         terminalHeightPercent = percent;
         StateHasChanged();
 
-        // 設定に保存
-        try
-        {
-            var appSettings = AppSettingsService.GetSettings();
-            appSettings.General.TerminalHeightPercent = percent;
-            AppSettingsService.SaveSettings(appSettings);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "スプリッター位置の保存に失敗");
-        }
-
-        return Task.CompletedTask;
+        // ドラッグはデバイス固有の操作なので LocalStorage のみに保存
+        // (app-settings 側は新デバイスのシード値としてダイアログ保存時のみ更新)
+        await UpdateLocalDisplaySettingAsync(s => s.TerminalHeightPercent = percent);
     }
 
     [JSInvokable]
-    public Task OnSidebarSplitterDragEnd(int percent)
+    public async Task OnSidebarSplitterDragEnd(int percent)
     {
         sidebarWidthPercent = percent;
         StateHasChanged();
 
-        // 設定に保存
+        await UpdateLocalDisplaySettingAsync(s => s.SidebarWidthPercent = percent);
+    }
+
+    /// <summary>
+    /// 現在の表示系4項目をデバイス別設定として LocalStorage に保存する（初回シード用）。
+    /// </summary>
+    private async Task SaveDisplaySettingsToLocalStorageAsync()
+    {
         try
         {
-            var appSettings = AppSettingsService.GetSettings();
-            appSettings.General.SidebarWidthPercent = percent;
-            AppSettingsService.SaveSettings(appSettings);
+            await LocalStorageService.SaveDisplaySettingsAsync(new LocalDisplaySettings
+            {
+                SessionListScale = sessionListScale,
+                TerminalFontSize = terminalFontSize,
+                TerminalHeightPercent = terminalHeightPercent,
+                SidebarWidthPercent = sidebarWidthPercent,
+            });
         }
         catch (Exception ex)
         {
-            Logger.LogWarning(ex, "サイドバー幅の保存に失敗");
+            Logger.LogWarning(ex, "表示設定のLocalStorage保存に失敗");
         }
+    }
 
-        return Task.CompletedTask;
+    /// <summary>
+    /// LocalStorage のデバイス別表示設定のうち指定項目のみを更新する。
+    /// 全項目書き込みだと設定ダイアログでプレビュー中（未保存）の値まで
+    /// 永続化してしまうため、スプリッター操作は自分の項目だけを書く。
+    /// </summary>
+    private async Task UpdateLocalDisplaySettingAsync(Action<LocalDisplaySettings> mutate)
+    {
+        try
+        {
+            var settings = await LocalStorageService.LoadDisplaySettingsAsync() ?? new LocalDisplaySettings();
+            mutate(settings);
+            await LocalStorageService.SaveDisplaySettingsAsync(settings);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "表示設定のLocalStorage保存に失敗");
+        }
     }
 
     private async Task HandleTextInputSend(string text)

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -1335,11 +1335,14 @@
             // 一般設定
             defaultFolderPath = settings.General.DefaultFolderPath;
             favoriteFolders = new List<string>(settings.General.FavoriteFolders);
-            sessionListScale = settings.General.SessionListScale;
-            terminalFontSize = settings.General.TerminalFontSize;
-            terminalHeightPercent = settings.General.TerminalHeightPercent;
-            sidebarWidthPercent = settings.General.SidebarWidthPercent;
             theme = settings.General.Theme;
+
+            // 表示系4項目はデバイス別 (LocalStorage 優先、無ければ app-settings の値)
+            var localDisplay = await LocalStorageService.LoadDisplaySettingsAsync();
+            sessionListScale = localDisplay?.SessionListScale ?? settings.General.SessionListScale;
+            terminalFontSize = localDisplay?.TerminalFontSize ?? settings.General.TerminalFontSize;
+            terminalHeightPercent = localDisplay?.TerminalHeightPercent ?? settings.General.TerminalHeightPercent;
+            sidebarWidthPercent = localDisplay?.SidebarWidthPercent ?? settings.General.SidebarWidthPercent;
 
             // カスタムコマンド
             editingCommands = settings.Commands.CommandsByTerminalType
@@ -1606,6 +1609,16 @@
                 }
             };
             AppSettingsService.SaveSettings(settings);
+
+            // 表示系4項目はデバイス別設定として LocalStorage にも保存する
+            // (app-settings 側の値は新デバイス初回アクセス時のシードとして機能する)
+            await LocalStorageService.SaveDisplaySettingsAsync(new LocalDisplaySettings
+            {
+                SessionListScale = sessionListScale,
+                TerminalFontSize = terminalFontSize,
+                TerminalHeightPercent = terminalHeightPercent,
+                SidebarWidthPercent = sidebarWidthPercent,
+            });
 
             // 生ストリームキャプチャの ON/OFF を即時反映（無効化時はライターを閉じる）
             RawStreamCapture.SetEnabled(captureRawStreamEnabled);

--- a/TerminalHub/Models/LocalDisplaySettings.cs
+++ b/TerminalHub/Models/LocalDisplaySettings.cs
@@ -1,0 +1,19 @@
+namespace TerminalHub.Models
+{
+    /// <summary>
+    /// ブラウザ(デバイス)ごとの表示設定。LocalStorage に保存する。
+    /// PC とモバイルで別々の表示設定を持てるようにするため、
+    /// app-settings.json (サーバー側・全デバイス共通) から分離した。
+    ///
+    /// 各プロパティは nullable で「未設定」を表し、未設定の項目は
+    /// app-settings.json の値 (サーバーデフォルト) にフォールバックする。
+    /// なおテーマはデバイス別にする需要がないため対象外 (app-settings 共通のまま)。
+    /// </summary>
+    public class LocalDisplaySettings
+    {
+        public double? SessionListScale { get; set; }
+        public int? TerminalFontSize { get; set; }
+        public int? SidebarWidthPercent { get; set; }
+        public int? TerminalHeightPercent { get; set; }
+    }
+}

--- a/TerminalHub/Services/LocalStorageService.cs
+++ b/TerminalHub/Services/LocalStorageService.cs
@@ -16,6 +16,8 @@ namespace TerminalHub.Services
         Task SetAsync<T>(string key, T value);
         Task SaveSessionExpandedStatesAsync(Dictionary<Guid, bool> expandedStates);
         Task<Dictionary<Guid, bool>> LoadSessionExpandedStatesAsync();
+        Task<LocalDisplaySettings?> LoadDisplaySettingsAsync();
+        Task SaveDisplaySettingsAsync(LocalDisplaySettings settings);
     }
 
     public class LocalStorageService : ILocalStorageService
@@ -26,6 +28,7 @@ namespace TerminalHub.Services
         private const string SessionsKey = "terminalHub_sessions";
         private const string ActiveSessionKey = "terminalHub_activeSession";
         private const string ExpandedStatesKey = "terminalHub_expandedStates";
+        private const string DisplaySettingsKey = "terminalHub_displaySettings";
 
         public LocalStorageService(IJSRuntime jsRuntime, ILogger<LocalStorageService> logger)
         {
@@ -194,6 +197,16 @@ namespace TerminalHub.Services
                 _logger.LogError(ex, "Error saving {Key} to localStorage", key);
             }
         }
+
+        /// <summary>
+        /// デバイス別表示設定を読み込む。未保存 (キー無し) の場合は null を返し、
+        /// 呼び出し側で app-settings.json の値をシードする。
+        /// </summary>
+        public Task<LocalDisplaySettings?> LoadDisplaySettingsAsync()
+            => GetAsync<LocalDisplaySettings>(DisplaySettingsKey);
+
+        public Task SaveDisplaySettingsAsync(LocalDisplaySettings settings)
+            => SetAsync(DisplaySettingsKey, settings);
 
         public async Task SaveSessionExpandedStatesAsync(Dictionary<Guid, bool> expandedStates)
         {


### PR DESCRIPTION
## 概要
表示タブの4項目（ターミナルフォントサイズ・サイドバー幅・ターミナル高さ比率・セッションリスト倍率）を `app-settings.json`（全デバイス共通）からブラウザの LocalStorage（デバイス別）保存へ移行する。

## 動機
モバイル対応により PC とスマホの両方から利用するようになったが、表示系の設定はデバイスの画面特性に依存するため、共通設定だと片方に最適化するともう片方が崩れる。デバイスごとに独立して持てるようにする。

## 変更内容
- **`LocalDisplaySettings`（新規モデル）**: 4項目を nullable で保持。LocalStorage キー `terminalHub_displaySettings` に保存
- **読み込み（Root / SettingsDialog）**: LocalStorage 優先、未保存なら app-settings の値にフォールバック。初回アクセス時は app-settings の値をシードとして書き込むため、既存ユーザーの設定はそのまま引き継がれる
- **設定ダイアログ保存**: LocalStorage と app-settings の両方へ書き込み。app-settings 側は「新デバイス初回アクセス時のシード値」として機能
- **スプリッタードラッグ**: LocalStorage のみ、かつ操作した項目だけを read-modify-write（設定ダイアログでプレビュー中の未保存値を巻き込んで永続化しないため）
- **テーマは対象外**: デバイス別にする需要がないため app-settings 共通のまま。サーバーレンダー時の `<html data-bs-theme>` 埋め込み（フラッシュ防止）も従来どおり

## 動作確認（実機）
- PC: 既存設定がシードされ表示が変わらないこと、変更→リロードで保持されることを確認
- モバイル: 初回は PC と同じ値で開始し、モバイル側で変更しても PC に影響しない（デバイス別）ことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)