### PR TITLE
feat: Gitバッジクリックで変更ファイル一覧ダイアログを表示

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
@@ -109,12 +109,19 @@
     {
         if (string.IsNullOrEmpty(FolderPath)) return;
 
+        // 応答待ちの間にダイアログが閉じられて別セッションで開き直された場合、
+        // 遅れて返ってきた古い応答が新しい表示や赤丸通知を汚染しないよう、
+        // リクエスト時のパスを控えておき、応答時に対象が変わっていたら破棄する。
+        var requestPath = FolderPath;
         isLoading = true;
         loadFailed = false;
         StateHasChanged();
         try
         {
-            var files = await GitService.GetChangedFilesAsync(FolderPath);
+            var files = await GitService.GetChangedFilesAsync(requestPath);
+            if (!IsVisible || requestPath != FolderPath)
+                return; // 古い応答: 破棄（isLoading は現行リクエスト側が管理する）
+
             if (files == null)
             {
                 loadFailed = true;
@@ -128,12 +135,18 @@
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "[GitChangesDialog] 変更ファイル取得失敗: {Path}", FolderPath);
-            loadFailed = true;
+            Logger.LogError(ex, "[GitChangesDialog] 変更ファイル取得失敗: {Path}", requestPath);
+            if (IsVisible && requestPath == FolderPath)
+            {
+                loadFailed = true;
+            }
         }
         finally
         {
-            isLoading = false;
+            if (requestPath == FolderPath)
+            {
+                isLoading = false;
+            }
         }
     }
 

--- a/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
@@ -1,0 +1,171 @@
+@using TerminalHub.Models
+@using TerminalHub.Services
+@using Microsoft.Extensions.Localization
+@inject IGitService GitService
+@inject IStringLocalizer<SharedResource> L
+@inject ILogger<GitChangesDialog> Logger
+
+@* Git バッジクリックで開く、未コミット変更ファイル一覧ダイアログ。
+   開くたびに git status を取り直すので常に最新の状態を表示する。 *@
+<div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
+    <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title text-truncate">
+                    <i class="bi bi-git me-2"></i>@L["GitChanges.Title"]
+                    @if (!string.IsNullOrEmpty(BranchName))
+                    {
+                        <span class="badge bg-success ms-2">@BranchName</span>
+                    }
+                </h5>
+                <button type="button" class="btn-close" @onclick="HandleClose"></button>
+            </div>
+            <div class="modal-body">
+                <div class="small text-muted mb-2 text-truncate" title="@FolderPath">
+                    <i class="bi bi-folder me-1"></i>@FolderPath
+                </div>
+                @if (isLoading)
+                {
+                    <div class="text-center py-4">
+                        <span class="spinner-border spinner-border-sm me-1" role="status"></span>@L["GitChanges.Loading"]
+                    </div>
+                }
+                else if (loadFailed)
+                {
+                    <div class="alert alert-warning py-2 mb-0">
+                        <i class="bi bi-exclamation-triangle me-1"></i>@L["GitChanges.LoadError"]
+                    </div>
+                }
+                else if (changedFiles.Count == 0)
+                {
+                    <div class="alert alert-success py-2 mb-0">
+                        <i class="bi bi-check-circle me-1"></i>@L["GitChanges.NoChanges"]
+                    </div>
+                }
+                else
+                {
+                    <div class="small text-muted mb-2">
+                        @string.Format(L["GitChanges.CountFormat"], changedFiles.Count)
+                    </div>
+                    <div class="list-group list-group-flush border rounded" style="max-height: 55vh; overflow-y: auto;">
+                        @foreach (var file in changedFiles)
+                        {
+                            <div class="list-group-item py-1 px-2 d-flex align-items-center gap-2">
+                                <span class="badge @GetStatusBadgeClass(file)" style="min-width: 4.5rem;">@GetStatusLabel(file)</span>
+                                <span class="font-monospace small text-break">
+                                    @if (file.OldFilePath != null)
+                                    {
+                                        <span class="text-muted">@file.OldFilePath →</span>
+                                    }
+                                    @file.FilePath
+                                    @if (file.IsStaged && !file.IsUntracked)
+                                    {
+                                        <i class="bi bi-check2 text-success ms-1" title="@L["GitChanges.Staged"]"></i>
+                                    }
+                                </span>
+                            </div>
+                        }
+                    </div>
+                }
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" @onclick="ReloadAsync" disabled="@isLoading">
+                    <i class="bi bi-arrow-clockwise me-1"></i>@L["GitChanges.Refresh"]
+                </button>
+                <button type="button" class="btn btn-secondary" @onclick="HandleClose">@L["Common.Close"]</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public string? FolderPath { get; set; }
+    [Parameter] public string? BranchName { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+    /// <summary>取得結果の「変更あり/なし」を親に通知（バッジの赤丸を最新化するため）</summary>
+    [Parameter] public EventCallback<bool> OnChangesLoaded { get; set; }
+
+    private List<GitChangedFile> changedFiles = new();
+    private bool isLoading = false;
+    private bool loadFailed = false;
+    private string? _loadedPath;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (IsVisible && !string.IsNullOrEmpty(FolderPath) && _loadedPath != FolderPath)
+        {
+            // ダイアログが開かれた時（または対象が変わった時）のみ取得する
+            _loadedPath = FolderPath;
+            await ReloadAsync();
+        }
+        else if (!IsVisible)
+        {
+            _loadedPath = null;
+        }
+    }
+
+    private async Task ReloadAsync()
+    {
+        if (string.IsNullOrEmpty(FolderPath)) return;
+
+        isLoading = true;
+        loadFailed = false;
+        StateHasChanged();
+        try
+        {
+            var files = await GitService.GetChangedFilesAsync(FolderPath);
+            if (files == null)
+            {
+                loadFailed = true;
+                changedFiles = new();
+            }
+            else
+            {
+                changedFiles = files;
+                await OnChangesLoaded.InvokeAsync(files.Count > 0);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[GitChangesDialog] 変更ファイル取得失敗: {Path}", FolderPath);
+            loadFailed = true;
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private async Task HandleClose()
+    {
+        await OnClose.InvokeAsync();
+    }
+
+    // 表示は「作業ツリー側の状態」を優先し、ステージ済みのみの場合はステージ側を使う
+    private static char EffectiveStatus(GitChangedFile file)
+        => file.IsUntracked ? '?' : (file.WorkTreeStatus != ' ' ? file.WorkTreeStatus : file.IndexStatus);
+
+    private string GetStatusLabel(GitChangedFile file) => EffectiveStatus(file) switch
+    {
+        '?' => L["GitChanges.Status.Untracked"],
+        'M' => L["GitChanges.Status.Modified"],
+        'A' => L["GitChanges.Status.Added"],
+        'D' => L["GitChanges.Status.Deleted"],
+        'R' => L["GitChanges.Status.Renamed"],
+        'C' => L["GitChanges.Status.Copied"],
+        'U' => L["GitChanges.Status.Conflicted"],
+        var c => c.ToString()
+    };
+
+    private static string GetStatusBadgeClass(GitChangedFile file) => EffectiveStatus(file) switch
+    {
+        '?' => "bg-secondary",
+        'M' => "bg-warning text-dark",
+        'A' => "bg-success",
+        'D' => "bg-danger",
+        'R' or 'C' => "bg-info text-dark",
+        'U' => "bg-danger",
+        _ => "bg-secondary"
+    };
+}

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -1,6 +1,7 @@
 @using System.IO
 @using TerminalHub.Models
 @using TerminalHub.Constants
+@using TerminalHub.Components.Shared.Dialogs
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SharedResource> L
 
@@ -117,7 +118,11 @@
                             }
                             @if (ShowGitInfo && session.IsGitRepository && !string.IsNullOrEmpty(session.GitBranch))
                             {
-                                <span class="badge @(session.IsWorktree ? "bg-warning" : "bg-success") ms-1" title="@(session.IsWorktree ? "Worktree" : L["SessionList.Badge.GitBranch"].Value)">
+                                @* クリックで変更ファイル一覧ダイアログを表示（stopPropagation でセッション選択を抑止） *@
+                                <span class="badge @(session.IsWorktree ? "bg-warning" : "bg-success") ms-1" style="cursor: pointer;"
+                                      title="@($"{(session.IsWorktree ? "Worktree" : L["SessionList.Badge.GitBranch"].Value)} - {L["SessionList.Badge.GitBranchClickHint"].Value}")"
+                                      @onclick:stopPropagation="true"
+                                      @onclick="() => OpenGitChanges(session)">
                                     <i class="bi @(session.IsWorktree ? "bi-git" : "bi-git") me-1"></i>@session.GitBranch
                                     @if (session.HasUncommittedChanges)
                                     {
@@ -218,6 +223,13 @@
     </div>
 </div>
 
+@* Git バッジクリックで開く変更ファイル一覧ダイアログ *@
+<GitChangesDialog IsVisible="@(gitChangesSession != null)"
+                  FolderPath="@gitChangesSession?.FolderPath"
+                  BranchName="@gitChangesSession?.GitBranch"
+                  OnClose="() => gitChangesSession = null"
+                  OnChangesLoaded="HandleGitChangesLoaded" />
+
 @code {
     [Parameter] public List<SessionInfo> Sessions { get; set; } = new();
     [Parameter] public Guid? ActiveSessionId { get; set; }
@@ -231,6 +243,24 @@
     [Parameter] public int WidthPercent { get; set; } = 25;
 
     private string filterText = string.Empty;
+
+    // Git バッジクリックで変更ファイル一覧を表示する対象セッション (null=非表示)
+    private SessionInfo? gitChangesSession;
+
+    private void OpenGitChanges(SessionInfo session)
+    {
+        gitChangesSession = session;
+    }
+
+    private void HandleGitChangesLoaded(bool hasChanges)
+    {
+        // 取得結果でバッジの赤丸を最新化する
+        if (gitChangesSession != null && gitChangesSession.HasUncommittedChanges != hasChanges)
+        {
+            gitChangesSession.HasUncommittedChanges = hasChanges;
+            StateHasChanged();
+        }
+    }
 
     [Parameter] public EventCallback OnAddSession { get; set; }
     [Parameter] public EventCallback<Guid> OnSessionSelect { get; set; }

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -507,6 +507,21 @@
   <data name="SessionList.Badge.Select" xml:space="preserve"><value>Waiting for selection (please answer the question)</value></data>
   <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git branch</value></data>
   <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>Uncommitted changes</value></data>
+  <data name="SessionList.Badge.GitBranchClickHint" xml:space="preserve"><value>Click to show changed files</value></data>
+  <data name="GitChanges.Title" xml:space="preserve"><value>Git Changes</value></data>
+  <data name="GitChanges.Loading" xml:space="preserve"><value>Loading…</value></data>
+  <data name="GitChanges.NoChanges" xml:space="preserve"><value>No uncommitted changes</value></data>
+  <data name="GitChanges.LoadError" xml:space="preserve"><value>Failed to get changed files</value></data>
+  <data name="GitChanges.CountFormat" xml:space="preserve"><value>{0} changed file(s)</value></data>
+  <data name="GitChanges.Refresh" xml:space="preserve"><value>Refresh</value></data>
+  <data name="GitChanges.Staged" xml:space="preserve"><value>Staged</value></data>
+  <data name="GitChanges.Status.Untracked" xml:space="preserve"><value>Untracked</value></data>
+  <data name="GitChanges.Status.Modified" xml:space="preserve"><value>Modified</value></data>
+  <data name="GitChanges.Status.Added" xml:space="preserve"><value>Added</value></data>
+  <data name="GitChanges.Status.Deleted" xml:space="preserve"><value>Deleted</value></data>
+  <data name="GitChanges.Status.Renamed" xml:space="preserve"><value>Renamed</value></data>
+  <data name="GitChanges.Status.Copied" xml:space="preserve"><value>Copied</value></data>
+  <data name="GitChanges.Status.Conflicted" xml:space="preserve"><value>Conflicted</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>Remote control connected</value></data>
   <data name="SessionList.Badge.ChildrenCountFormat" xml:space="preserve"><value>{0} children</value></data>
   <data name="SessionList.Tooltip.Settings" xml:space="preserve"><value>Session settings</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -507,6 +507,21 @@
   <data name="SessionList.Badge.Select" xml:space="preserve"><value>選択待ち（質問に回答してください）</value></data>
   <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git ブランチ</value></data>
   <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>未コミットの変更があります</value></data>
+  <data name="SessionList.Badge.GitBranchClickHint" xml:space="preserve"><value>クリックで変更ファイル一覧を表示</value></data>
+  <data name="GitChanges.Title" xml:space="preserve"><value>Git 変更ファイル</value></data>
+  <data name="GitChanges.Loading" xml:space="preserve"><value>読み込み中…</value></data>
+  <data name="GitChanges.NoChanges" xml:space="preserve"><value>未コミットの変更はありません</value></data>
+  <data name="GitChanges.LoadError" xml:space="preserve"><value>変更ファイル一覧の取得に失敗しました</value></data>
+  <data name="GitChanges.CountFormat" xml:space="preserve"><value>{0} 件の変更</value></data>
+  <data name="GitChanges.Refresh" xml:space="preserve"><value>更新</value></data>
+  <data name="GitChanges.Staged" xml:space="preserve"><value>ステージ済み</value></data>
+  <data name="GitChanges.Status.Untracked" xml:space="preserve"><value>未追跡</value></data>
+  <data name="GitChanges.Status.Modified" xml:space="preserve"><value>変更</value></data>
+  <data name="GitChanges.Status.Added" xml:space="preserve"><value>追加</value></data>
+  <data name="GitChanges.Status.Deleted" xml:space="preserve"><value>削除</value></data>
+  <data name="GitChanges.Status.Renamed" xml:space="preserve"><value>リネーム</value></data>
+  <data name="GitChanges.Status.Copied" xml:space="preserve"><value>コピー</value></data>
+  <data name="GitChanges.Status.Conflicted" xml:space="preserve"><value>競合</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>リモートコントロール接続中</value></data>
   <data name="SessionList.Badge.ChildrenCountFormat" xml:space="preserve"><value>{0} 件</value></data>
   <data name="SessionList.Tooltip.Settings" xml:space="preserve"><value>セッション設定</value></data>

--- a/TerminalHub/Services/GitService.cs
+++ b/TerminalHub/Services/GitService.cs
@@ -348,6 +348,63 @@ namespace TerminalHub.Services
             }
         }
 
+        public async Task<List<GitChangedFile>?> GetChangedFilesAsync(string path)
+        {
+            try
+            {
+                if (!await IsGitRepositoryAsync(path))
+                    return null;
+
+                // core.quotepath=false: 日本語等の非ASCIIパスが \346... 形式にエスケープされるのを防ぐ
+                var result = await ExecuteGitCommandAsync(path, "-c core.quotepath=false status --porcelain");
+                if (!result.Success)
+                    return null;
+
+                var files = new List<GitChangedFile>();
+                foreach (var line in (result.Output ?? "").Split('\n'))
+                {
+                    // porcelain v1 形式: "XY パス" (X=ステージ側, Y=作業ツリー側)
+                    var trimmed = line.TrimEnd('\r');
+                    if (trimmed.Length < 4)
+                        continue;
+
+                    var entry = new GitChangedFile
+                    {
+                        IndexStatus = trimmed[0],
+                        WorkTreeStatus = trimmed[1],
+                    };
+
+                    var pathPart = trimmed.Substring(3);
+                    // リネーム/コピーは "元パス -> 新パス" 形式
+                    var arrowIndex = pathPart.IndexOf(" -> ", StringComparison.Ordinal);
+                    if (arrowIndex >= 0 && (entry.IndexStatus is 'R' or 'C'))
+                    {
+                        entry.OldFilePath = Unquote(pathPart.Substring(0, arrowIndex));
+                        entry.FilePath = Unquote(pathPart.Substring(arrowIndex + 4));
+                    }
+                    else
+                    {
+                        entry.FilePath = Unquote(pathPart);
+                    }
+
+                    files.Add(entry);
+                }
+
+                return files;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "変更ファイル一覧の取得でエラーが発生しました: {Path}", path);
+                return null;
+            }
+
+            // スペース等を含むパスは "..." で囲まれるため外す
+            static string Unquote(string s)
+                => s.Length >= 2 && s.StartsWith('"') && s.EndsWith('"')
+                    ? s.Substring(1, s.Length - 2).Replace("\\\"", "\"").Replace("\\\\", "\\")
+                    : s;
+        }
+
         private async Task<(bool Success, string? Output, string? Error)> ExecuteGitCommandAsync(string workingDirectory, string arguments)
         {
             try

--- a/TerminalHub/Services/IGitService.cs
+++ b/TerminalHub/Services/IGitService.cs
@@ -62,6 +62,31 @@ namespace TerminalHub.Services
         /// <param name="worktreePath">検証するWorktreeのパス</param>
         /// <returns>Worktree情報、無効な場合はnull</returns>
         Task<WorktreeInfo?> ValidateWorktreeAsync(string worktreePath);
+
+        /// <summary>
+        /// 未コミットの変更ファイル一覧を取得（git status --porcelain）
+        /// </summary>
+        /// <param name="path">リポジトリのパス</param>
+        /// <returns>変更ファイルのリスト。取得失敗時は null（変更なしの空リストと区別する）</returns>
+        Task<List<GitChangedFile>?> GetChangedFilesAsync(string path);
+    }
+
+    /// <summary>
+    /// git status --porcelain の1行に対応する変更ファイル情報
+    /// </summary>
+    public class GitChangedFile
+    {
+        /// <summary>ステージ側の状態 (porcelain の X 列。' '=変更なし, M/A/D/R/C/U, ?=未追跡)</summary>
+        public char IndexStatus { get; set; }
+        /// <summary>作業ツリー側の状態 (porcelain の Y 列)</summary>
+        public char WorkTreeStatus { get; set; }
+        public string FilePath { get; set; } = string.Empty;
+        /// <summary>リネーム/コピー時の元パス</summary>
+        public string? OldFilePath { get; set; }
+
+        public bool IsUntracked => IndexStatus == '?' && WorkTreeStatus == '?';
+        /// <summary>ステージ済みの変更を含むか</summary>
+        public bool IsStaged => !IsUntracked && IndexStatus != ' ';
     }
 
     public class GitInfo


### PR DESCRIPTION
## 概要
セッションリストの Git バッジ（赤丸＝未コミット変更あり）をクリックすると、変更ファイルの一覧をダイアログで確認できるようにする。

## 動機
「赤丸が付いているが何が変わっているのか」を確認するためだけに、LLM に聞いたり別の Git UI を開いたりする手間があった。バッジクリックひとつでその場で確認できるようにする。

## 変更内容
- **`GitService.GetChangedFilesAsync`（新規）**: `git status --porcelain` をパースし、状態（変更/追加/削除/リネーム/コピー/未追跡/競合）＋ファイルパスのリストを返す。`-c core.quotepath=false` で日本語パスの八進エスケープを抑止。リネームは「旧パス → 新パス」、引用符付きパスも復元
- **`GitChangesDialog`（新規コンポーネント）**: 状態別の色付きバッジでファイル一覧を表示（M=黄 / A=緑 / D=赤 / R・C=水色 / ??=グレー / U=赤、ステージ済みは ✓）。開くたびに取得し直すので常に最新。更新ボタン付き
- **`SessionList`**: Git バッジをクリック可能に（`@onclick:stopPropagation` でセッション選択の発火を抑止）。ダイアログの取得結果で赤丸（`HasUncommittedChanges`）の表示も最新化
- ja/en ローカライズリソース追加

## 備考
- 赤丸の判定自体は従来から `git status --porcelain` の空判定であり、同じコマンドの出力を一覧表示に転用したもの
- 表示のみで Git 操作（stage/commit 等）は行わない

🤖 Generated with [Claude Code](https://claude.com/claude-code)