### PR TITLE
feat(mcp): セッション間メッセージング(send_to_session/list_sessions)と関連改善

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -273,6 +273,23 @@
     }
 
     /// <summary>
+    /// Notification（曖昧な発火源）由来のベルを立てる。
+    /// Notification は AskUserQuestion の裏でも飛ぶことがあり、その message が "permission" を含むと
+    /// Confirm と誤判定されうる。既に精密イベント(PreToolUse=Select / PermissionRequest=Confirm)で
+    /// 要操作ベルが立っている場合は上書きしない（三択待ちが「許可待ち」へ化けるのを防ぐ）。
+    /// </summary>
+    private void SetNotificationBellFromNotification(Guid sessionId, SessionBellKind kind)
+    {
+        if (_notificationPendingSessions.TryGetValue(sessionId, out var existing)
+            && existing != SessionBellKind.Stopped)
+        {
+            // 既に要操作ベル(Select/Confirm)が立っている → 曖昧な Notification では上書きしない
+            return;
+        }
+        SetNotificationBell(sessionId, kind);
+    }
+
+    /// <summary>
     /// Notification イベントの message から通知ベル種別を判別する。
     /// Notification は許可待ち(permission)・アイドル(idle)・認証成功 等で発火するため、
     /// 一律 Confirm（盾＝許可待ち）にすると idle/認証まで「許可待ち」と誤表示してしまう。
@@ -2286,7 +2303,7 @@
                 session.ProcessingStartTime = null;
                 session.ProcessingElapsedSeconds = null;
                 session.LastProcessingUpdateTime = null;
-                session.IsWaitingForUserInput = false;
+                session.ClearWaitingForUserInput();
 
                 // 非アクティブセッションの場合は通知マークを表示
                 if (activeSessionId != sessionId)
@@ -2355,7 +2372,7 @@
                 session.ProcessingStartTime = null;
                 session.ProcessingElapsedSeconds = null;
                 session.LastProcessingUpdateTime = null;
-                session.IsWaitingForUserInput = false;
+                session.ClearWaitingForUserInput();
 
                 // 非アクティブセッションの場合は通知マークを表示（インスタンスごとの通知リストに追加）
                 if (activeSessionId != notification.SessionId)
@@ -2414,16 +2431,26 @@
                 //                         idle/認証成功等は停止（ベル）にして「許可待ち」を誤表示しない。
                 if (activeSessionId != notification.SessionId)
                 {
-                    var bellKind = eventType switch
-                    {
-                        HookEventType.PreToolUse => SessionBellKind.Select,
-                        HookEventType.PermissionRequest => SessionBellKind.Confirm,
-                        _ => ClassifyNotificationBell(notification.Message)
-                    };
                     Logger.LogInformation(
-                        "[通知マーク ON] きっかけ: OnHookNotification({Event}), 種別: {Kind}, Message={Message}, セッション: {SessionName}",
-                        eventType, bellKind, notification.Message, session.GetDisplayName());
-                    SetNotificationBell(notification.SessionId, bellKind);
+                        "[通知マーク ON] きっかけ: OnHookNotification({Event}), Message={Message}, セッション: {SessionName}",
+                        eventType, notification.Message, session.GetDisplayName());
+
+                    // PreToolUse=選択 / PermissionRequest=許可 は「何を待っているか」が確定する精密な発火源。
+                    // 一方 Notification は曖昧（許可待ち/idle/認証成功が混在）。精密イベントを Notification が
+                    // 上書きして三択が「許可待ち」に化けないよう、Notification 由来はガード付きで立てる。
+                    switch (eventType)
+                    {
+                        case HookEventType.PreToolUse:
+                            SetNotificationBell(notification.SessionId, SessionBellKind.Select);
+                            break;
+                        case HookEventType.PermissionRequest:
+                            SetNotificationBell(notification.SessionId, SessionBellKind.Confirm);
+                            break;
+                        default:
+                            SetNotificationBellFromNotification(
+                                notification.SessionId, ClassifyNotificationBell(notification.Message));
+                            break;
+                    }
                     StateHasChanged();
                 }
                 break;

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -905,6 +905,36 @@
 
                                 <hr />
 
+                                @* 試験機能: 各CLIの設定フォルダへ terminalhub MCP を自動登録する（既定OFF） *@
+                                <div class="mb-4">
+                                    <h6 class="mb-2">
+                                        <span class="badge bg-warning text-dark me-1">試験機能</span>
+                                        MCP自動登録
+                                    </h6>
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" @bind="autoRegisterMcpEnabled" id="autoRegisterMcpSwitch">
+                                        <label class="form-check-label" for="autoRegisterMcpSwitch">
+                                            対応CLIのフォルダに TerminalHub のローカル MCP を自動登録する
+                                        </label>
+                                    </div>
+                                    <p class="text-muted small mt-2 mb-0">
+                                        <i class="bi bi-info-circle me-1"></i>
+                                        ONにすると、<strong>Claude Code / Codex</strong> のセッション作成/再起動時に、その作業フォルダへ
+                                        TerminalHub のローカル MCP サーバー（<code>terminalhub</code>）を追記します。
+                                        起動しただけで <code>list_sessions</code> / <code>send_to_session</code> が使えるようになります。
+                                    </p>
+                                    <ul class="text-muted small mt-1 mb-0">
+                                        <li>Claude Code → <code>&lt;folder&gt;/.mcp.json</code> の <code>mcpServers.terminalhub</code></li>
+                                        <li>Codex → <code>&lt;folder&gt;/.codex/config.toml</code> の <code>[mcp_servers.terminalhub]</code></li>
+                                    </ul>
+                                    <p class="text-muted small mt-1 mb-0">
+                                        既存の設定はそのまま残し、<code>terminalhub</code> エントリのみを管理します。
+                                        Claude Code / Codex のみ対応（Gemini 等は非対応）。ポートは起動中の値を使います。
+                                    </p>
+                                </div>
+
+                                <hr />
+
                                 <div class="mb-4">
                                     <h6 class="mb-2">@L["Settings.Special.DevTools.Header"]</h6>
                                     <div class="form-check form-switch">
@@ -1197,6 +1227,7 @@
 
     // 開発ツール関連
     private bool devToolsEnabled = false;
+    private bool autoRegisterMcpEnabled = false;
     private bool captureRawStreamEnabled = false;
     private List<SessionInfo> diagnosticSessions = new();
     private int jsTerminalCount = 0;
@@ -1330,6 +1361,7 @@
 
             // 開発ツール設定
             devToolsEnabled = settings.DevTools.Enabled;
+            autoRegisterMcpEnabled = settings.Experimental.AutoRegisterMcp;
             captureRawStreamEnabled = settings.DevTools.CaptureRawStream;
 
             // 一般設定
@@ -1562,6 +1594,10 @@
                 {
                     Enabled = devToolsEnabled,
                     CaptureRawStream = captureRawStreamEnabled
+                },
+                Experimental = new ExperimentalSettings
+                {
+                    AutoRegisterMcp = autoRegisterMcpEnabled
                 },
                 General = new GeneralSettings
                 {

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -146,15 +146,9 @@
                         @if (session.ProcessingElapsedSeconds.HasValue || !string.IsNullOrEmpty(session.ProcessingStatus))
                         {
                             <div>
-                                <small class="@(session.IsWaitingForUserInput ? "text-warning" : "text-primary")">
-                                    @if (session.IsWaitingForUserInput)
-                                    {
-                                        <i class="bi bi-person-fill-exclamation me-1"></i>
-                                    }
-                                    else
-                                    {
-                                        <i class="bi bi-clock-fill me-1"></i>
-                                    }
+                                @* ステータス行は常に時計＋通常色。入力待ちの種別は通知ベル側で区別する。 *@
+                                <small class="text-primary">
+                                    <i class="bi bi-clock-fill me-1"></i>
                                     @if (!string.IsNullOrEmpty(session.ProcessingStatus))
                                     {
                                         <span>@session.ProcessingStatus</span>
@@ -485,8 +479,8 @@
     /// </summary>
     private string BellIcon(SessionBellKind kind) => kind switch
     {
-        SessionBellKind.Confirm => "bi-shield-exclamation",   // 許可待ち
-        SessionBellKind.Select => "bi-ui-radios",             // 質問（選択）
+        SessionBellKind.Confirm => "bi-question-octagon",     // 許可待ち（停止標識風の八角形＋？）
+        SessionBellKind.Select => "bi-list-ol",               // 質問（選択）
         _ => "bi-bell-fill"                                    // 停止
     };
 

--- a/TerminalHub/Mcp/SessionMessagingTools.cs
+++ b/TerminalHub/Mcp/SessionMessagingTools.cs
@@ -37,7 +37,8 @@ namespace TerminalHub.Mcp
         [McpServerTool(Name = "list_sessions")]
         [Description(
             "TerminalHub が管理中の(アーカイブでない)セッション一覧を返す。send_to_session の宛先を選ぶために使う。" +
-            "任意のフィルタ引数で絞り込める。各項目の status は idle(受信可) か processing(処理中=送ると入力が化ける)。")]
+            "任意のフィルタ引数で絞り込める。各項目の status は ready(受付中=送信可。作業中でも相手CLIのキューに積まれる) / " +
+            "waiting_user_input(ユーザーの許可/選択待ち=送信不可) / not_ready(ConPTY未接続=起動が必要・送信不可)。")]
         public static IEnumerable<SessionSummary> ListSessions(
             ISessionManager sessionManager,
             [Description("種別で絞り込み(ClaudeCode / CodexCLI / GeminiCLI / Terminal / Antigravity / Grok)。未指定なら全種別。")]
@@ -64,12 +65,20 @@ namespace TerminalHub.Mcp
                     folder.IndexOf(folderContains, StringComparison.OrdinalIgnoreCase) < 0)
                     continue;
 
+                // 送信可否で状態を導出（呼び出し側が「送れるか」を一目で判断できるように）。
+                //   not_ready          = ConPTY 未接続。まず起動が必要（送信不可）。
+                //   waiting_user_input = ユーザーの許可/選択待ち（送信不可・待ち解消後に再試行）。
+                //   ready              = 受付中。idle でも busy でも送れる（busy は相手CLIのキューに積まれる）。
+                var status = s.ConPtySession == null ? "not_ready"
+                    : s.IsWaitingForUserInput ? "waiting_user_input"
+                    : "ready";
+
                 result.Add(new SessionSummary(
                     s.SessionId.ToString(),
                     name,
                     s.TerminalType.ToString(),
                     folder,
-                    s.ProcessingStartTime.HasValue ? "processing" : "idle"));
+                    status));
             }
             return result;
         }
@@ -78,7 +87,9 @@ namespace TerminalHub.Mcp
         [Description(
             "指定した既存セッションのターミナルにメッセージを1件送る(投げっぱなし・応答は待たない)。" +
             "target はセッションGUIDか表示名(完全一致)。submit=true なら末尾でEnterを送り即実行させる。" +
-            "相手が処理中(processing)のときは送らず success=false を返すので、呼び出し側で待って再試行すること。" +
+            "相手がユーザーの許可/選択待ち(waiting)のときは送らず success=false を返す(承認プロンプトを誤確定させないため。待ち解消後に再試行)。" +
+            "単なる作業中(busy)は送信可(AI CLI がプロンプトをキューに積む)。" +
+            "宛先が未起動のときも success=false(自動起動しない・ユーザーに起動を依頼し、自動リトライはしない)。" +
             "長文はそのまま流さず、ファイルに書いて絶対パスだけ送る運用を推奨。")]
         public static async Task<SendResult> SendToSession(
             ISessionManager sessionManager,
@@ -101,20 +112,31 @@ namespace TerminalHub.Mcp
             if (info == null)
                 return new SendResult(false, $"宛先セッションが見つかりません: {target}");
 
-            // 処理中なら送らない(送ると入力が化ける)。呼び出し側でリトライ判断させる。
-            if (info.ProcessingStartTime.HasValue)
+            // 入力待ち(許可/選択待ち)なら送らない。ここで送ると submit の Enter が
+            // 許可プロンプトの確定に化けて意図しない承認をしてしまうため。呼び出し側でリトライ判断させる。
+            // 単なる作業中(busy)は送信を許可する(AI CLI がプロンプトをキューに積むため)。
+            if (info.IsWaitingForUserInput)
                 return new SendResult(false,
-                    $"宛先が処理中(processing)のため送信しませんでした。idle になってから再試行してください: {info.GetDisplayName()}");
+                    $"宛先がユーザーの許可/選択待ち(status=waiting_user_input)のため送信しませんでした。" +
+                    $"ここで送ると承認プロンプトを誤って確定させる恐れがあります。" +
+                    $"待ちが解消(status=ready)してから再試行してください: {info.GetDisplayName()}");
 
             var conpty = info.ConPtySession;
             if (conpty == null)
-                return new SendResult(false, $"宛先セッションが未起動です(ConPTY 未接続): {info.GetDisplayName()}");
+                return new SendResult(false,
+                    $"宛先セッションが未起動です(status=not_ready / ConPTY 未接続)。これは自動起動できません。" +
+                    $"ユーザーに「TerminalHub で『{info.GetDisplayName()}』を開いて起動してください」と依頼し、" +
+                    $"status=ready になったのを確認してから再送してください。自動でリトライしないこと。");
 
             // 送信本体。submit=true なら Enter(\r) を続けて送り実行を確定する。
             // WriteAsync 側で256文字チャンク＋Flush 済みなので長文でも切り捨てられない。
             await conpty.WriteAsync(message);
             if (submit)
             {
+                // テキスト送信後、Enter 送信前に待機する。
+                // Codex 等の TUI CLI は本文取り込み前に \r が来ると送信確定されず入力欄で止まるため、
+                // UI の SendInput と同じく 0.2 秒挟んでから Enter を送る。
+                await Task.Delay(200);
                 await conpty.WriteAsync("\r");
             }
 

--- a/TerminalHub/Mcp/SessionMessagingTools.cs
+++ b/TerminalHub/Mcp/SessionMessagingTools.cs
@@ -1,0 +1,124 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using TerminalHub.Models;
+using TerminalHub.Services;
+
+namespace TerminalHub.Mcp
+{
+    /// <summary>
+    /// セッション間メッセージング用の MCP ツール群。
+    /// TerminalHub が管理する「既存」セッションに対して、一覧取得(list_sessions)と
+    /// メッセージ送信(send_to_session)だけを提供する最小構成。
+    ///
+    /// 設計方針（壁打ちで確定）:
+    /// - spawn なし: 子セッションは作らない。宛先は既存セッションのみ（暴走ガード不要）。
+    /// - 集約なし: 結果待ち(wait)/読み取り(read)はしない。完了は TerminalHub 本体の LED/通知で人間が気づく。
+    /// - エンベロープ/自己識別なし: 本文だけ送る。送信元明示や応答要否は将来「呼び出し元フラグ」で足す。
+    /// - サーバーは状態を持たず、渡されたフラグ(submit 等)に素直に従うだけ。
+    /// メインユースケース: Claude で仕様を書きファイル化 → その絶対パスを Codex セッションへ送って実装させる。
+    /// </summary>
+    [McpServerToolType]
+    public class SessionMessagingTools
+    {
+        /// <summary>list_sessions の返却項目。</summary>
+        public record SessionSummary(
+            string sessionId,
+            string name,
+            string terminalType,
+            string folderPath,
+            string status);
+
+        /// <summary>
+        /// send_to_session の結果。宛先なし/未起動/処理中は例外にせず success=false で返し、
+        /// 呼び出し側（エージェント）にリトライ判断を委ねる。
+        /// </summary>
+        public record SendResult(bool success, string message);
+
+        [McpServerTool(Name = "list_sessions")]
+        [Description(
+            "TerminalHub が管理中の(アーカイブでない)セッション一覧を返す。send_to_session の宛先を選ぶために使う。" +
+            "任意のフィルタ引数で絞り込める。各項目の status は idle(受信可) か processing(処理中=送ると入力が化ける)。")]
+        public static IEnumerable<SessionSummary> ListSessions(
+            ISessionManager sessionManager,
+            [Description("種別で絞り込み(ClaudeCode / CodexCLI / GeminiCLI / Terminal / Antigravity / Grok)。未指定なら全種別。")]
+            string? terminalType = null,
+            [Description("表示名に含む文字列で絞り込み(部分一致・大文字小文字無視)。")]
+            string? nameContains = null,
+            [Description("作業フォルダパスに含む文字列で絞り込み(部分一致・大文字小文字無視)。")]
+            string? folderContains = null)
+        {
+            var result = new List<SessionSummary>();
+            foreach (var s in sessionManager.GetActiveSessions())
+            {
+                if (!string.IsNullOrEmpty(terminalType) &&
+                    !string.Equals(s.TerminalType.ToString(), terminalType, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var name = s.GetDisplayName();
+                if (!string.IsNullOrEmpty(nameContains) &&
+                    name.IndexOf(nameContains, StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                var folder = s.FolderPath ?? "";
+                if (!string.IsNullOrEmpty(folderContains) &&
+                    folder.IndexOf(folderContains, StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                result.Add(new SessionSummary(
+                    s.SessionId.ToString(),
+                    name,
+                    s.TerminalType.ToString(),
+                    folder,
+                    s.ProcessingStartTime.HasValue ? "processing" : "idle"));
+            }
+            return result;
+        }
+
+        [McpServerTool(Name = "send_to_session")]
+        [Description(
+            "指定した既存セッションのターミナルにメッセージを1件送る(投げっぱなし・応答は待たない)。" +
+            "target はセッションGUIDか表示名(完全一致)。submit=true なら末尾でEnterを送り即実行させる。" +
+            "相手が処理中(processing)のときは送らず success=false を返すので、呼び出し側で待って再試行すること。" +
+            "長文はそのまま流さず、ファイルに書いて絶対パスだけ送る運用を推奨。")]
+        public static async Task<SendResult> SendToSession(
+            ISessionManager sessionManager,
+            [Description("宛先。セッションGUID、または表示名(完全一致・大文字小文字無視)。")]
+            string target,
+            [Description("送る本文。改行を含む長文は避け、短い指示＋ファイルの絶対パスを推奨。")]
+            string message,
+            [Description("末尾にEnterを送って実行を確定するか(既定 true)。false なら入力欄に流し込むだけ。")]
+            bool submit = true)
+        {
+            // 宛先解決: GUID を優先し、ダメなら表示名の完全一致で探す。
+            SessionInfo? info = null;
+            if (Guid.TryParse(target, out var guid))
+            {
+                info = sessionManager.GetSessionInfo(guid);
+            }
+            info ??= sessionManager.GetActiveSessions()
+                .FirstOrDefault(s => string.Equals(s.GetDisplayName(), target, StringComparison.OrdinalIgnoreCase));
+
+            if (info == null)
+                return new SendResult(false, $"宛先セッションが見つかりません: {target}");
+
+            // 処理中なら送らない(送ると入力が化ける)。呼び出し側でリトライ判断させる。
+            if (info.ProcessingStartTime.HasValue)
+                return new SendResult(false,
+                    $"宛先が処理中(processing)のため送信しませんでした。idle になってから再試行してください: {info.GetDisplayName()}");
+
+            var conpty = info.ConPtySession;
+            if (conpty == null)
+                return new SendResult(false, $"宛先セッションが未起動です(ConPTY 未接続): {info.GetDisplayName()}");
+
+            // 送信本体。submit=true なら Enter(\r) を続けて送り実行を確定する。
+            // WriteAsync 側で256文字チャンク＋Flush 済みなので長文でも切り捨てられない。
+            await conpty.WriteAsync(message);
+            if (submit)
+            {
+                await conpty.WriteAsync("\r");
+            }
+
+            return new SendResult(true, $"送信しました: {info.GetDisplayName()} (submit={submit})");
+        }
+    }
+}

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -15,6 +15,20 @@ public class AppSettings
     public CustomCommandSettings Commands { get; set; } = new();
     public CustomCliOptionsSettings CliOptions { get; set; } = new();
     public RemoteLaunchSettings RemoteLaunch { get; set; } = new();
+    public ExperimentalSettings Experimental { get; set; } = new();
+}
+
+/// <summary>
+/// 試験機能設定。TerminalHub が各CLIの設定ファイルへ書き込む等の実験的挙動を、既定OFFで束ねる。
+/// </summary>
+public class ExperimentalSettings
+{
+    /// <summary>
+    /// セッション生成時に、対応CLI(Claude Code / Codex)のフォルダへ TerminalHub のローカル MCP サーバー
+    /// (terminalhub) を自動登録する。ONにすると Claude=.mcp.json / Codex=.codex/config.toml に
+    /// terminalhub エントリを追記し、起動しただけで list_sessions / send_to_session が使える。既定OFF。
+    /// </summary>
+    public bool AutoRegisterMcp { get; set; } = false;
 }
 
 /// <summary>

--- a/TerminalHub/Models/SessionInfo.cs
+++ b/TerminalHub/Models/SessionInfo.cs
@@ -82,8 +82,27 @@ namespace TerminalHub.Models
         [System.Text.Json.Serialization.JsonIgnore]
         public DateTime? LastProcessingUpdateTime { get; set; }
 
+        /// <summary>ユーザーの許可/承認待ち（Claude Notification permission / Codex PermissionRequest）。</summary>
         [System.Text.Json.Serialization.JsonIgnore]
-        public bool IsWaitingForUserInput { get; set; }
+        public bool IsWaitingForPermission { get; set; }
+
+        /// <summary>ユーザーへの質問/選択待ち（AskUserQuestion / request_user_input）。</summary>
+        [System.Text.Json.Serialization.JsonIgnore]
+        public bool IsWaitingForSelection { get; set; }
+
+        /// <summary>
+        /// 許可待ち・選択待ちのいずれか＝ユーザー入力待ちの合成フラグ。
+        /// send_to_session の送信ガード等、種別を問わない粗い判定に使う。
+        /// </summary>
+        [System.Text.Json.Serialization.JsonIgnore]
+        public bool IsWaitingForUserInput => IsWaitingForPermission || IsWaitingForSelection;
+
+        /// <summary>入力待ち状態（許可・選択の両方）を解除する。</summary>
+        public void ClearWaitingForUserInput()
+        {
+            IsWaitingForPermission = false;
+            IsWaitingForSelection = false;
+        }
 
         /// <summary>
         /// コンテキスト compact 実行中（PreCompact ～ PostCompact の間）。
@@ -144,6 +163,9 @@ namespace TerminalHub.Models
 
         [System.Text.Json.Serialization.JsonIgnore]
         public bool HookConfigured { get; set; } // Claude Code hook 設定済みかどうか
+
+        [System.Text.Json.Serialization.JsonIgnore]
+        public bool McpConfigured { get; set; } // MCP 自動登録 設定済みかどうか（プロセス内のみ・再起動でリセット→ポート追従）
         
         [System.Text.Json.Serialization.JsonIgnore]
         public bool IsExpanded { get; set; } = true; // サブセッションの展開状態

--- a/TerminalHub/Models/SessionInfo.cs
+++ b/TerminalHub/Models/SessionInfo.cs
@@ -97,11 +97,20 @@ namespace TerminalHub.Models
         [System.Text.Json.Serialization.JsonIgnore]
         public bool IsWaitingForUserInput => IsWaitingForPermission || IsWaitingForSelection;
 
+        /// <summary>
+        /// hook(PermissionRequest/PreToolUse/Notification)が最後に入力待ちを立てた時刻。
+        /// OutputAnalyzer が「処理中検出」で待ちを解除する際、直前に hook が立てた待ちを
+        /// 古いスピナー出力チャンクの遅延解析で誤クリアするレースを避けるためのクールダウン判定に使う。
+        /// </summary>
+        [System.Text.Json.Serialization.JsonIgnore]
+        public DateTime? LastWaitingHookSetTime { get; set; }
+
         /// <summary>入力待ち状態（許可・選択の両方）を解除する。</summary>
         public void ClearWaitingForUserInput()
         {
             IsWaitingForPermission = false;
             IsWaitingForSelection = false;
+            LastWaitingHookSetTime = null;
         }
 
         /// <summary>

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -147,6 +147,14 @@ builder.Services.AddSingleton<IVersionCheckService, VersionCheckService>();
 // 生ストリームキャプチャ（VTエミュレータ検証フィクスチャ採取用のデバッグサービス）
 builder.Services.AddSingleton<IRawStreamCaptureService, RawStreamCaptureService>();
 
+// MCP サーバー（セッション間メッセージング）。
+// TerminalHub 本体プロセスに HTTP MCP を同居させ、list_sessions / send_to_session を公開する。
+// SessionManager(Singleton) に直結するため HTTP トランスポート一択（stdio だと別プロセスで共有状態に届かない）。
+builder.Services
+    .AddMcpServer()
+    .WithHttpTransport()
+    .WithTools<TerminalHub.Mcp.SessionMessagingTools>();
+
 
 var app = builder.Build();
 
@@ -265,6 +273,9 @@ app.MapPost("/api/hook/codex/{sessionId:guid}",
     await hookService.HandleHookNotificationAsync(notification);
     return Results.NoContent();
 });
+
+// MCP エンドポイント（/mcp）。Claude Code 等の MCP クライアントがここへ接続する。
+app.MapMcp("/mcp");
 
 app.Run();
 return 0;

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -141,6 +141,9 @@ builder.Services.AddSingleton<IClaudeHookService, ClaudeHookService>();
 // CodexHookServiceを登録（Codex CLI の lifecycle hook 設定）
 builder.Services.AddSingleton<ICodexHookService, CodexHookService>();
 
+// McpConfigServiceを登録（試験機能: 各CLIへ terminalhub MCP を自動登録）
+builder.Services.AddSingleton<IMcpConfigService, McpConfigService>();
+
 // VersionCheckServiceを登録
 builder.Services.AddSingleton<IVersionCheckService, VersionCheckService>();
 

--- a/TerminalHub/Services/HookNotificationService.cs
+++ b/TerminalHub/Services/HookNotificationService.cs
@@ -443,12 +443,18 @@ public class HookNotificationService : IHookNotificationService
             "Notification イベント処理: Session={SessionName}, Message={Message}",
             session.GetDisplayName(), notification.Message);
 
-        // message に "permission" を含めば許可待ち（それ以外は idle 通知）。
-        // 許可待ちのときだけ「許可待ち」フラグを立てる（send_to_session の送信ガード / UI アイコン用）。
+        // message に "permission" を含めば許可待ち、それ以外は idle/認証成功 等の非permission通知。
+        // 許可待ちフラグは立て下げを対称にする（idle 通知で解除しないと stuck するため）。
         if (!string.IsNullOrEmpty(notification.Message) &&
             notification.Message.Contains("permission", StringComparison.OrdinalIgnoreCase))
         {
             session.IsWaitingForPermission = true;
+            session.LastWaitingHookSetTime = DateTime.Now;
+        }
+        else
+        {
+            // 非permission通知＝許可待ちではない。許可待ちフラグを解除する（選択待ちは PreToolUse 管理なので触らない）。
+            session.IsWaitingForPermission = false;
         }
 
         await SendSessionHookWebhookAsync(session, notification);
@@ -467,6 +473,7 @@ public class HookNotificationService : IHookNotificationService
 
         // 発火 = ユーザーへの質問（選択待ち）。選択待ちフラグを立てる（send_to_session の送信ガード / UI アイコン用）。
         session.IsWaitingForSelection = true;
+        session.LastWaitingHookSetTime = DateTime.Now;
 
         await SendSessionHookWebhookAsync(session, notification);
     }
@@ -484,6 +491,7 @@ public class HookNotificationService : IHookNotificationService
 
         // ツール実行の承認待ち。許可待ちフラグを立てる（send_to_session の送信ガード / UI アイコン用）。
         session.IsWaitingForPermission = true;
+        session.LastWaitingHookSetTime = DateTime.Now;
 
         await SendSessionHookWebhookAsync(session, notification);
     }

--- a/TerminalHub/Services/HookNotificationService.cs
+++ b/TerminalHub/Services/HookNotificationService.cs
@@ -193,7 +193,7 @@ public class HookNotificationService : IHookNotificationService
         session.ProcessingStatus = null;
         session.ProcessingElapsedSeconds = null;
         session.LastProcessingUpdateTime = null;
-        session.IsWaitingForUserInput = false;
+        session.ClearWaitingForUserInput();
 
         // compact 中フラグを倒す保険。auto-compact がブロック/中断され PostCompact が
         // 飛ばないケースがあり（公式仕様上、PreCompact がブロックされると PostCompact は来ない）、
@@ -409,6 +409,9 @@ public class HookNotificationService : IHookNotificationService
         session.ProcessingStartTime = DateTime.Now;
         // ProcessingStatus は OutputAnalyzer が実際のステータステキストを設定するため、ここでは設定しない
 
+        // 新しいプロンプトが送られた＝直前の許可/選択待ちは解消。入力待ちフラグを下ろす。
+        session.ClearWaitingForUserInput();
+
         // Webhook通知を送信（本来の hook イベント名 "UserPromptSubmit" をそのまま eventType として送る。
         // 「UserPromptSubmit = LED 点灯」等の解釈は受け側に委ねる）
         try
@@ -439,6 +442,15 @@ public class HookNotificationService : IHookNotificationService
         _logger.LogInformation(
             "Notification イベント処理: Session={SessionName}, Message={Message}",
             session.GetDisplayName(), notification.Message);
+
+        // message に "permission" を含めば許可待ち（それ以外は idle 通知）。
+        // 許可待ちのときだけ「許可待ち」フラグを立てる（send_to_session の送信ガード / UI アイコン用）。
+        if (!string.IsNullOrEmpty(notification.Message) &&
+            notification.Message.Contains("permission", StringComparison.OrdinalIgnoreCase))
+        {
+            session.IsWaitingForPermission = true;
+        }
+
         await SendSessionHookWebhookAsync(session, notification);
     }
 
@@ -452,6 +464,10 @@ public class HookNotificationService : IHookNotificationService
         _logger.LogInformation(
             "PreToolUse イベント処理（ツール={ToolName}、回答待ち）: Session={SessionName}",
             notification.ToolName, session.GetDisplayName());
+
+        // 発火 = ユーザーへの質問（選択待ち）。選択待ちフラグを立てる（send_to_session の送信ガード / UI アイコン用）。
+        session.IsWaitingForSelection = true;
+
         await SendSessionHookWebhookAsync(session, notification);
     }
 
@@ -465,6 +481,10 @@ public class HookNotificationService : IHookNotificationService
         _logger.LogInformation(
             "PermissionRequest イベント処理（ツール={ToolName}、承認待ち）: Session={SessionName}",
             notification.ToolName, session.GetDisplayName());
+
+        // ツール実行の承認待ち。許可待ちフラグを立てる（send_to_session の送信ガード / UI アイコン用）。
+        session.IsWaitingForPermission = true;
+
         await SendSessionHookWebhookAsync(session, notification);
     }
 }

--- a/TerminalHub/Services/McpConfigService.cs
+++ b/TerminalHub/Services/McpConfigService.cs
@@ -1,0 +1,203 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using TerminalHub.Models;
+
+namespace TerminalHub.Services;
+
+/// <summary>
+/// 試験機能: 対応CLI(Claude Code / Codex)のフォルダへ TerminalHub のローカル MCP サーバー
+/// (terminalhub) を自動登録/撤去するサービス。CodexHookService と同じく per-folder に書き、
+/// 既存設定はマージ・TerminalHub は「terminalhub」エントリのみ所有する。
+///
+/// - Claude Code → <c>&lt;folder&gt;/.mcp.json</c> の <c>mcpServers.terminalhub</c>（type:"http"）
+/// - Codex       → <c>&lt;folder&gt;/.codex/config.toml</c> の <c>[mcp_servers.terminalhub]</c>
+///                 （per-folder の config.toml を Codex が MCP 用に読むかは要検証。読まなければ無害な no-op）
+/// </summary>
+public interface IMcpConfigService
+{
+    /// <summary>terminalhub MCP サーバーを CLI 設定へ追記（既存があれば最新値へ更新）。</summary>
+    Task SetupAsync(string folderPath, TerminalType terminalType, string baseUrl);
+
+    /// <summary>TerminalHub 由来（terminalhub）エントリだけを CLI 設定から除去。</summary>
+    Task RemoveAsync(string folderPath, TerminalType terminalType);
+}
+
+public class McpConfigService : IMcpConfigService
+{
+    private readonly ILogger<McpConfigService> _logger;
+
+    /// <summary>登録する MCP サーバー名（＝所有マーク）。撤去時はこのキー/テーブルだけ触る。</summary>
+    private const string ServerName = "terminalhub";
+
+    private const string ClaudeMcpFileName = ".mcp.json";
+    private const string CodexConfigFileName = ".codex/config.toml";
+
+    public McpConfigService(ILogger<McpConfigService> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>baseUrl(例 http://localhost:5081) から MCP エンドポイント URL を作る。</summary>
+    private static string BuildMcpUrl(string baseUrl) => baseUrl.TrimEnd('/') + "/mcp";
+
+    public async Task SetupAsync(string folderPath, TerminalType terminalType, string baseUrl)
+    {
+        var url = BuildMcpUrl(baseUrl);
+        switch (terminalType)
+        {
+            case TerminalType.ClaudeCode:
+                await SetupClaudeAsync(folderPath, url);
+                break;
+            case TerminalType.CodexCLI:
+                await SetupCodexAsync(folderPath, url);
+                break;
+            default:
+                // Claude Code / Codex のみサポート。それ以外は何もしない。
+                break;
+        }
+    }
+
+    public async Task RemoveAsync(string folderPath, TerminalType terminalType)
+    {
+        switch (terminalType)
+        {
+            case TerminalType.ClaudeCode:
+                await RemoveClaudeAsync(folderPath);
+                break;
+            case TerminalType.CodexCLI:
+                await RemoveCodexAsync(folderPath);
+                break;
+        }
+    }
+
+    // ---- Claude Code (.mcp.json / JSON) ----
+
+    private async Task SetupClaudeAsync(string folderPath, string url)
+    {
+        var path = Path.Combine(folderPath, ClaudeMcpFileName);
+
+        JsonObject root;
+        if (File.Exists(path))
+        {
+            var existing = await File.ReadAllTextAsync(path);
+            root = JsonNode.Parse(existing)?.AsObject() ?? new JsonObject();
+        }
+        else
+        {
+            root = new JsonObject();
+        }
+
+        if (root["mcpServers"] is not JsonObject servers)
+        {
+            servers = new JsonObject();
+            root["mcpServers"] = servers;
+        }
+
+        // terminalhub エントリだけを最新値で上書き。他サーバーは温存。
+        servers[ServerName] = new JsonObject
+        {
+            ["type"] = "http",
+            ["url"] = url
+        };
+
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        await File.WriteAllTextAsync(path, root.ToJsonString(options));
+        _logger.LogInformation("MCP設定を追記(Claude): {Path} url={Url}", path, url);
+    }
+
+    private async Task RemoveClaudeAsync(string folderPath)
+    {
+        var path = Path.Combine(folderPath, ClaudeMcpFileName);
+        if (!File.Exists(path)) return;
+
+        var root = JsonNode.Parse(await File.ReadAllTextAsync(path))?.AsObject();
+        if (root?["mcpServers"] is not JsonObject servers) return;
+        if (!servers.ContainsKey(ServerName)) return;
+
+        servers.Remove(ServerName);
+        if (servers.Count == 0) root.Remove("mcpServers");
+
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        await File.WriteAllTextAsync(path, root.ToJsonString(options));
+        _logger.LogInformation("MCP設定を除去(Claude): {Path}", path);
+    }
+
+    // ---- Codex (.codex/config.toml / TOML) ----
+    // TOML ライブラリを持たないため、TerminalHub が所有する [mcp_servers.terminalhub] テーブルの
+    // ブロックだけを行スキャンで置換/除去する。他のTOMLには手を触れない。
+
+    private async Task SetupCodexAsync(string folderPath, string url)
+    {
+        var path = Path.Combine(folderPath, CodexConfigFileName);
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        var lines = File.Exists(path)
+            ? (await File.ReadAllTextAsync(path)).Replace("\r\n", "\n").Split('\n').ToList()
+            : new List<string>();
+
+        // 既存の terminalhub ブロックを除去してから、新しい値で追記（＝更新に対応）。
+        RemoveTerminalHubTomlBlock(lines);
+        TrimTrailingBlankLines(lines);
+
+        if (lines.Count > 0) lines.Add("");
+        lines.Add($"[mcp_servers.{ServerName}]");
+        lines.Add($"url = \"{url}\"");
+        lines.Add("");
+
+        await File.WriteAllTextAsync(path, string.Join("\n", lines));
+        _logger.LogInformation("MCP設定を追記(Codex): {Path} url={Url}", path, url);
+    }
+
+    private async Task RemoveCodexAsync(string folderPath)
+    {
+        var path = Path.Combine(folderPath, CodexConfigFileName);
+        if (!File.Exists(path)) return;
+
+        var lines = (await File.ReadAllTextAsync(path)).Replace("\r\n", "\n").Split('\n').ToList();
+        if (!RemoveTerminalHubTomlBlock(lines)) return;
+
+        TrimTrailingBlankLines(lines);
+        if (lines.Count > 0) lines.Add("");
+        await File.WriteAllTextAsync(path, string.Join("\n", lines));
+        _logger.LogInformation("MCP設定を除去(Codex): {Path}", path);
+    }
+
+    /// <summary>
+    /// [mcp_servers.terminalhub] のテーブルヘッダ行から、次のテーブルヘッダ([で始まる行)または
+    /// EOF までを lines から取り除く。除去したら true。
+    /// </summary>
+    private static bool RemoveTerminalHubTomlBlock(List<string> lines)
+    {
+        int start = lines.FindIndex(l => IsTerminalHubTableHeader(l));
+        if (start < 0) return false;
+
+        int end = start + 1;
+        while (end < lines.Count && !lines[end].TrimStart().StartsWith("["))
+        {
+            end++;
+        }
+        lines.RemoveRange(start, end - start);
+        return true;
+    }
+
+    private static bool IsTerminalHubTableHeader(string line)
+    {
+        var t = line.Trim();
+        // [mcp_servers.terminalhub] / [mcp_servers."terminalhub"] の両表記を許容。
+        return t == $"[mcp_servers.{ServerName}]" || t == $"[mcp_servers.\"{ServerName}\"]";
+    }
+
+    private static void TrimTrailingBlankLines(List<string> lines)
+    {
+        while (lines.Count > 0 && string.IsNullOrWhiteSpace(lines[^1]))
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+    }
+}

--- a/TerminalHub/Services/OutputAnalyzerService.cs
+++ b/TerminalHub/Services/OutputAnalyzerService.cs
@@ -65,8 +65,19 @@ namespace TerminalHub.Services
                     }
                     else if (result.IsProcessing)
                     {
-                        // ユーザー入力待ち状態をセッションに設定
-                        sessionInfo.IsWaitingForUserInput = result.IsWaitingForUser;
+                        // 出力解析で「処理中(esc to interrupt 等)」を検出＝ユーザープロンプト待ちではない状態。
+                        if (result.IsWaitingForUser)
+                        {
+                            // 出力解析ベースで入力待ちを検出（Gemini 等）。種別まではわからないので選択待ち扱い。
+                            sessionInfo.IsWaitingForSelection = true;
+                        }
+                        else
+                        {
+                            // 処理中＝プロンプト待ちではないので、hook(PermissionRequest/PreToolUse)が立てた
+                            // 許可/選択待ちも含めて解除する。Codex は承認後の作業中に waiting が残り続けて
+                            // send_to_session が誤ブロックされるのを防ぐ（Codexは Stop まで waiting が下がらないため）。
+                            sessionInfo.ClearWaitingForUserInput();
+                        }
 
                         // ステータステキストを決定
                         var statusText = result.ProcessingText ?? result.StatusText;
@@ -231,7 +242,7 @@ namespace TerminalHub.Services
                     session.ProcessingStartTime = null;
                     session.ProcessingElapsedSeconds = null;
                     session.LastProcessingUpdateTime = null;
-                    session.IsWaitingForUserInput = false;
+                    session.ClearWaitingForUserInput();
 
                     // セッションのタイマーを停止（ISessionTimerServiceに委譲）
                     StopSessionTimer(session.SessionId);

--- a/TerminalHub/Services/OutputAnalyzerService.cs
+++ b/TerminalHub/Services/OutputAnalyzerService.cs
@@ -76,7 +76,19 @@ namespace TerminalHub.Services
                             // 処理中＝プロンプト待ちではないので、hook(PermissionRequest/PreToolUse)が立てた
                             // 許可/選択待ちも含めて解除する。Codex は承認後の作業中に waiting が残り続けて
                             // send_to_session が誤ブロックされるのを防ぐ（Codexは Stop まで waiting が下がらないため）。
-                            sessionInfo.ClearWaitingForUserInput();
+                            //
+                            // ただし hook が直前(クールダウン内)に待ちを立てた場合は解除しない。
+                            // プロンプト表示直前の古いスピナー出力チャンクが遅れて解析され、開いている
+                            // プロンプトの待ちを誤クリアする（→ send_to_session が誤送信）レースを避けるため。
+                            var withinHookCooldown =
+                                IsHookDriven(sessionInfo.TerminalType) &&
+                                sessionInfo.LastWaitingHookSetTime.HasValue &&
+                                (DateTime.Now - sessionInfo.LastWaitingHookSetTime.Value).TotalSeconds < WaitingHookCooldownSeconds;
+
+                            if (!withinHookCooldown)
+                            {
+                                sessionInfo.ClearWaitingForUserInput();
+                            }
                         }
 
                         // ステータステキストを決定
@@ -109,6 +121,11 @@ namespace TerminalHub.Services
 
         // Stop イベント後、この秒数間は OutputAnalyzer からのステータス更新をスキップ
         private const double StopEventCooldownSeconds = 3.0;
+
+        // hook が入力待ちを立てた後、この秒数間は OutputAnalyzer の「処理中検出」による待ち解除をスキップ。
+        // プロンプト表示直前の古いスピナー出力チャンクが遅れて解析されて誤クリアするレースを避ける。
+        // 承認後の作業中に waiting が残る over-stay の解除は、ユーザー操作を挟む＝この窓より後になるので影響しない。
+        private const double WaitingHookCooldownSeconds = 1.5;
 
         private void UpdateSessionProcessingStatus(SessionInfo session, string? statusText, Guid activeSessionId, Action<Guid, string?>? updateStatus, string? matchedText = null, bool skipNotification = false)
         {

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -90,6 +90,7 @@ namespace TerminalHub.Services
         private readonly IGitService _gitService;
         private readonly IClaudeHookService? _claudeHookService;
         private readonly ICodexHookService? _codexHookService;
+        private readonly IMcpConfigService? _mcpConfigService;
         private readonly IAppSettingsService? _appSettingsService;
         private readonly IServer? _server;
         private Guid? _activeSessionId;
@@ -100,7 +101,7 @@ namespace TerminalHub.Services
         /// </summary>
         public event EventHandler? OnSessionsChanged;
 
-        public SessionManager(IConPtyService conPtyService, ILogger<SessionManager> logger, IConfiguration configuration, IGitService gitService, IClaudeHookService? claudeHookService = null, IAppSettingsService? appSettingsService = null, IServer? server = null, ICodexHookService? codexHookService = null, IRawStreamCaptureService? rawStreamCapture = null)
+        public SessionManager(IConPtyService conPtyService, ILogger<SessionManager> logger, IConfiguration configuration, IGitService gitService, IClaudeHookService? claudeHookService = null, IAppSettingsService? appSettingsService = null, IServer? server = null, ICodexHookService? codexHookService = null, IRawStreamCaptureService? rawStreamCapture = null, IMcpConfigService? mcpConfigService = null)
         {
             _conPtyService = conPtyService;
             _logger = logger;
@@ -111,6 +112,7 @@ namespace TerminalHub.Services
             _server = server;
             _codexHookService = codexHookService;
             _rawStreamCapture = rawStreamCapture;
+            _mcpConfigService = mcpConfigService;
         }
 
         private readonly IRawStreamCaptureService? _rawStreamCapture;
@@ -448,6 +450,7 @@ namespace TerminalHub.Services
                 // ClaudeCode セッションの場合、ConPty 起動前に hook 設定をセットアップ
                 await SetupClaudeHookIfNeededAsync(sessionInfo, isResetup: false);
                 await SetupCodexHookIfNeededAsync(sessionInfo, isResetup: false);
+                await SetupMcpConfigIfNeededAsync(sessionInfo, isResetup: false);
 
                 // ConPtyセッションを初期化
                 var cols = _configuration.GetValue<int>("SessionSettings:DefaultCols", TerminalConstants.DefaultCols);
@@ -917,6 +920,44 @@ namespace TerminalHub.Services
         }
 
         /// <summary>
+        /// 試験機能: セッション生成/再起動時に、対応CLI(Claude Code / Codex)のフォルダへ TerminalHub の
+        /// ローカル MCP サーバー(terminalhub)を自動登録する。設定 Experimental.AutoRegisterMcp が ON の
+        /// ときのみ実行（既定OFF）。Hook セットアップと対称。失敗してもセッション処理は続行する。
+        /// </summary>
+        private async Task SetupMcpConfigIfNeededAsync(SessionInfo sessionInfo, bool isResetup = false)
+        {
+            if (_mcpConfigService == null || _appSettingsService == null)
+                return;
+
+            // Claude Code / Codex のみサポート。
+            if (sessionInfo.TerminalType != TerminalType.ClaudeCode &&
+                sessionInfo.TerminalType != TerminalType.CodexCLI)
+                return;
+
+            if (!_appSettingsService.GetSettings().Experimental.AutoRegisterMcp)
+                return;
+
+            // Hook と同じく、プロセス内では初回のみ書く。McpConfigured は [JsonIgnore] で
+            // TerminalHub 再起動時に false へ戻るため、ポートが変わっても再起動後の初回で追従する。
+            if (!isResetup && sessionInfo.McpConfigured)
+                return;
+
+            try
+            {
+                var baseUrl = GetServerBaseUrl();
+                await _mcpConfigService.SetupAsync(sessionInfo.FolderPath, sessionInfo.TerminalType, baseUrl);
+                sessionInfo.McpConfigured = true;
+                var action = isResetup ? "再登録" : "登録";
+                _logger.LogInformation("MCP自動{Action}: SessionId={SessionId}, Type={Type}, BaseUrl={BaseUrl}",
+                    action, sessionInfo.SessionId, sessionInfo.TerminalType, baseUrl);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "MCP自動登録に失敗しましたが、セッション処理は続行します: SessionId={SessionId}", sessionInfo.SessionId);
+            }
+        }
+
+        /// <summary>
         /// セッションオプションを準備（--continueオプションの除外判定含む）
         /// </summary>
         private Dictionary<string, string> PrepareSessionOptions(SessionInfo sessionInfo, bool removeContinueOption = false)
@@ -951,13 +992,14 @@ namespace TerminalHub.Services
                 sessionInfo.ProcessingStartTime = null;
                 sessionInfo.ProcessingElapsedSeconds = null;
                 sessionInfo.LastProcessingUpdateTime = null;
-                sessionInfo.IsWaitingForUserInput = false;
+                sessionInfo.ClearWaitingForUserInput();
                 // 再起動で全サブエージェントは消えるため、稼働追跡もリセット（取りこぼし時の復旧経路）
                 sessionInfo.ClearRunningSubagents();
 
                 // ClaudeCode セッションの場合、Hook 設定を再セットアップ
                 await SetupClaudeHookIfNeededAsync(sessionInfo, isResetup: true);
                 await SetupCodexHookIfNeededAsync(sessionInfo, isResetup: true);
+                await SetupMcpConfigIfNeededAsync(sessionInfo, isResetup: true);
 
                 var cols = _configuration.GetValue<int>("SessionSettings:DefaultCols", TerminalConstants.DefaultCols);
                 var rows = _configuration.GetValue<int>("SessionSettings:DefaultRows", TerminalConstants.DefaultRows);
@@ -999,7 +1041,7 @@ namespace TerminalHub.Services
                 sessionInfo.ProcessingStartTime = null;
                 sessionInfo.ProcessingElapsedSeconds = null;
                 sessionInfo.LastProcessingUpdateTime = null;
-                sessionInfo.IsWaitingForUserInput = false;
+                sessionInfo.ClearWaitingForUserInput();
                 // 再起動で全サブエージェントは消えるため、稼働追跡もリセット（取りこぼし時の復旧経路）
                 sessionInfo.ClearRunningSubagents();
 
@@ -1013,6 +1055,7 @@ namespace TerminalHub.Services
                 // ClaudeCode セッションの場合、Hook 設定を再セットアップ
                 await SetupClaudeHookIfNeededAsync(sessionInfo, isResetup: true);
                 await SetupCodexHookIfNeededAsync(sessionInfo, isResetup: true);
+                await SetupMcpConfigIfNeededAsync(sessionInfo, isResetup: true);
 
                 var cols = _configuration.GetValue<int>("SessionSettings:DefaultCols", TerminalConstants.DefaultCols);
                 var rows = _configuration.GetValue<int>("SessionSettings:DefaultRows", TerminalConstants.DefaultRows);

--- a/TerminalHub/TerminalHub.csproj
+++ b/TerminalHub/TerminalHub.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.0.0-preview.1" />
     <!-- CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) を回避するため、SQLitePCLRaw を 3.x にオーバーライド -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="MQTTnet" Version="5.1.0.1559" />

--- a/docs/mcp-session-messaging.md
+++ b/docs/mcp-session-messaging.md
@@ -1,0 +1,154 @@
+# MCP セッション間メッセージング
+
+TerminalHub 本体プロセスに HTTP MCP サーバーを同居させ、**別のエージェント（Claude Code / Codex 等）から、TerminalHub が管理中の既存セッションへメッセージを送れる**ようにする機能です。
+
+主なユースケース: **Claude で仕様を書いてファイル化し、その絶対パスを Codex のセッションへ送って実装させる** といったエージェント間の受け渡し（オーケストレーション）。
+
+---
+
+## 設計方針（最小構成）
+
+| 方針 | 内容 |
+|---|---|
+| spawn なし | 子セッションは作らない。宛先は **既存セッションのみ**（暴走ガード不要） |
+| 集約なし | 結果待ち(wait)・読み取り(read)はしない。投げっぱなし。完了は TerminalHub 本体の LED/通知で人間が気づく |
+| エンベロープ/自己識別なし | 本文だけ送る。送信元明示や応答要否は将来「呼び出し元フラグ」で足す |
+| サーバーは状態を持たない | 渡されたフラグ（`submit` 等）に素直に従うだけ |
+
+長文は本文に直接流さず、**ファイルに書いて絶対パスだけ送る**運用を推奨（ターミナル入力の化け・切り捨てを避けるため）。
+
+---
+
+## サーバー構成
+
+- ASP.NET Core（Blazor Server）本体に `AddMcpServer().WithHttpTransport()` で同居。
+- エンドポイント: **`/mcp`**（`app.MapMcp("/mcp")`）
+- トランスポートは **HTTP 一択**。SessionManager（Singleton）の共有状態へ直結する必要があるため、stdio（別プロセス）では届かない。
+- 実装: `TerminalHub/Mcp/SessionMessagingTools.cs`、登録は `TerminalHub/Program.cs`。
+
+### ポート運用
+
+| ポート | 用途 |
+|---|---|
+| 5080 | 常用環境（インストール版） |
+| 5081 | Visual Studio 実行（launchSettings 既定） |
+| 5082 | **開発版（MCP 検証用）** ※ 本ドキュメントの想定 |
+
+開発版の起動（PowerShell、5082・launchSettings を無視して起動）:
+
+```powershell
+cd C:\Users\info\source\repos\TerminalHub-worktree-1
+$env:ASPNETCORE_ENVIRONMENT = "Development"
+dotnet run --project TerminalHub/TerminalHub.csproj --no-launch-profile --urls http://localhost:5082
+```
+
+---
+
+## クライアント登録
+
+### `.mcp.json`（プロジェクトスコープ）
+
+MCP クライアント（別の Claude Code）を起動するフォルダに配置:
+
+```json
+{
+  "mcpServers": {
+    "terminalhub": {
+      "type": "http",
+      "url": "http://localhost:5082/mcp"
+    }
+  }
+}
+```
+
+### CLI で登録する場合
+
+```powershell
+claude mcp add --transport http terminalhub http://localhost:5082/mcp
+```
+
+---
+
+## 提供ツール
+
+### `list_sessions`
+
+TerminalHub が管理中の（アーカイブでない）セッション一覧を返す。`send_to_session` の宛先を選ぶために使う。
+
+**引数**（いずれも任意・部分一致・大文字小文字無視）
+
+| 引数 | 型 | 説明 |
+|---|---|---|
+| `terminalType` | string? | 種別で絞り込み（`ClaudeCode` / `CodexCLI` / `GeminiCLI` / `Terminal` / `Antigravity` / `Grok`）。未指定なら全種別 |
+| `nameContains` | string? | 表示名に含む文字列で絞り込み |
+| `folderContains` | string? | 作業フォルダパスに含む文字列で絞り込み |
+
+**返り値**: `SessionSummary` の配列
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `sessionId` | string | セッション GUID |
+| `name` | string | 表示名 |
+| `terminalType` | string | 種別 |
+| `folderPath` | string | 作業フォルダ |
+| `status` | string | 送信可否を表す。`ready`（受付中=送信可。作業中でも相手CLIのキューに積まれる） / `waiting_user_input`（ユーザーの許可/選択待ち=送信不可） / `not_ready`（ConPTY未接続=起動が必要・送信不可） |
+
+### `send_to_session`
+
+指定した既存セッションのターミナルへメッセージを1件送る（投げっぱなし・応答は待たない）。
+
+**引数**
+
+| 引数 | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `target` | string | （必須） | 宛先。セッション GUID、または表示名（完全一致・大文字小文字無視） |
+| `message` | string | （必須） | 送る本文。改行を含む長文は避け、短い指示＋ファイルの絶対パスを推奨 |
+| `submit` | bool | `true` | 末尾に Enter(`\r`) を送って実行を確定するか。`false` なら入力欄に流し込むだけ |
+
+**返り値**: `SendResult`
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `success` | bool | 送信できたか |
+| `message` | string | 結果メッセージ |
+
+**`success=false` になるケース**（いずれも例外にせず結果で返し、呼び出し側にリトライ判断を委ねる）
+
+- 宛先セッションが見つからない
+- 宛先が **ユーザーの許可/選択待ち（`waiting_user_input`）** → submit の Enter が承認プロンプトを誤確定させる恐れがあるため送信しない。`ready` になってから再試行（単なる作業中は `ready` 扱いで送信可＝相手CLIのキューに積まれる）
+- 宛先が **未起動（`not_ready` / ConPTY 未接続）** → 自動起動はしない。ユーザーに起動を依頼し、`ready` を確認してから再送
+
+---
+
+## 典型フロー（Claude → Codex）
+
+1. Claude 側で仕様を書き、ファイル（例: `C:\work\spec.md`）に保存する。
+2. `list_sessions` で Codex セッションを探す（例: `terminalType="CodexCLI"`）。
+3. 対象が `ready` なら `send_to_session` で
+   `target=<GUID or 表示名>`, `message="C:\work\spec.md の内容で実装して"`, `submit=true` を送る。
+4. Codex 側で処理が走る。完了は TerminalHub 本体の LED / 通知で人間が確認する。
+
+---
+
+## 注意点
+
+- **ConPTY 制約**: 実際の送信テスト（ターミナルへの書き込み）は実機で行うこと。
+- **antiforgery**: 既存の `/api/hook`（JSON POST）は `UseAntiforgery` 下でも通っている実績があり、MCP の POST も通る見込み。もし `/mcp` への POST が 400 になる場合は `app.MapMcp("/mcp").DisableAntiforgery()` にする。
+- **セキュリティ**: ローカル利用前提。無認証で `/mcp` を公開するため、localhost 以外へバインドを広げる際は再評価すること。
+
+---
+
+## 接続設定の自動配置（試験機能・既定OFF）
+
+セッション起動時に、対応CLIのフォルダへ `terminalhub` MCP サーバーを自動登録する試験機能（設定「特殊」タブ）。ONにすると Hook セットアップと同じタイミングで書き込む。
+
+- Claude Code → `<folder>/.mcp.json` の `mcpServers.terminalhub`（`type:"http"`）
+- Codex → `<folder>/.codex/config.toml` の `[mcp_servers.terminalhub]`（`url`）
+- 既存設定はマージで温存し、`terminalhub` エントリのみ所有。ポートは実行中の値を反映。
+- 実装: `TerminalHub/Services/McpConfigService.cs`、設定は `AppSettings.Experimental.AutoRegisterMcp`。
+
+## 今後の拡張候補（未実装）
+
+- 送信元を包むエンベロープ／自己識別、応答要否フラグ
+- 結果の集約（wait / read）
+- 宛先セッションの状態変化（`ready` 化）を待つオプション


### PR DESCRIPTION
## 概要

TerminalHub 本体に HTTP MCP サーバーを同居させ、別エージェント(Claude Code / Codex 等)から**管理中の既存セッションへメッセージを送れる**ようにする機能一式。メインは **Claude で仕様を書き → Codex セッションへ投げて実装させる**エージェント間受け渡し。

## 含まれる変更

### 1. MCPサーバー本体（既存コミット 03ad028）
- `/mcp` エンドポイント、`list_sessions` / `send_to_session` の2ツール。

### 2. 入力待ち状態の種別分離・通知アイコン整理
- `IsWaitingForPermission` / `IsWaitingForSelection` に分離し、`IsWaitingForUserInput` を合成に。
- Hook から待ち種別を配線(PermissionRequest/Notification=許可、PreToolUse=選択、Stop/UserPromptSubmit=解除)。
- 通知ベルのアイコンを種別で出し分け(許可=question-octagon / 選択=list-ol)。曖昧な Notification が精密イベントを上書きしないガード。
- OutputAnalyzer: 処理中検出で over-stay した待ちを解除(Codex の承認後 waiting 残りによる send 誤ブロックを修正)。

### 3. send_to_session の送信ガード改善と status 整理
- submit=true 時に本文送信後 0.2 秒待って Enter(TUI の取り込み対策)。
- `list_sessions` の status を送信可否ベース3値に: `ready` / `waiting_user_input` / `not_ready`。
- 送信ガードは「入力待ち」or「ConPTY未接続」のときのみ(作業中=busyは送信可でキューに積む)。

### 4. 試験機能: 各CLIへ terminalhub MCP を自動登録（既定OFF）
- `McpConfigService`: Claude=`.mcp.json` / Codex=`.codex/config.toml` に `terminalhub` をマージ書き込み。既存設定は温存。
- 設定「特殊」タブにトグルと詳細説明。Claude Code / Codex のみ対応。Hook セットアップと同じ仕組み・ポート追従。

## テスト状況
- ビルド: 0 warning / 0 error。
- 実機: `list_sessions` / `send_to_session`(Claude/Codex)、waiting ガード、MCP自動登録(Claude=.mcp.json / Codex=.codex/config.toml)、通知アイコン出し分けをユーザー実機で確認済み。
- ConPTY 制約により実送信テストはユーザー実機で実施。

## 補足
- MCP自動登録は既定OFFの試験機能。Codex の per-folder `.codex/config.toml` は既存の discord/QueryHub MCP で読まれる実績を確認済み。
- ローカル利用前提・無認証で `/mcp` を公開(localhost 以外へ広げる際は再評価)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)