### PR TITLE
feat: 試験機能タブの新設と入力待ちでのカーソルパッド自動切替

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -49,6 +49,7 @@
                 OnTerminalHeightPercentChanged="HandleTerminalHeightPercentChanged"
                 OnSidebarWidthPercentChanged="HandleSidebarWidthPercentChanged"
                 OnVoiceInputEnabledChanged="HandleVoiceInputEnabledChanged"
+                OnAutoSwitchCursorPadChanged="HandleAutoSwitchCursorPadChanged"
                 OnThemeChanged="HandleThemeChanged" />
 <SubSessionDialog IsVisible="showSubSessionDialog"
                          ParentSessionName="@subSessionParentSessionName"
@@ -498,7 +499,10 @@
                     "altM" or "shiftTab" or "none" => appSettings.Special.ClaudeModeSwitchKey,
                     _ => "none"
                 };
-                voiceInputEnabled = appSettings.Special.VoiceInputEnabled;
+                // 音声入力・カーソルパッド自動切替はデバイス別 (LocalStorage 優先、無ければ app-settings をシード)。
+                var localExperimental = await LocalStorageService.LoadExperimentalSettingsAsync();
+                voiceInputEnabled = localExperimental?.VoiceInputEnabled ?? appSettings.Special.VoiceInputEnabled;
+                autoSwitchCursorPadEnabled = localExperimental?.AutoSwitchToCursorPadOnWait ?? false;
                 sessionSortMode = appSettings.Sessions.SortMode;
                 showTerminalType = appSettings.Sessions.ShowTerminalType;
                 showGitInfo = appSettings.Sessions.ShowGitInfo;
@@ -742,6 +746,11 @@
     {
         voiceInputEnabled = enabled;
         StateHasChanged();
+    }
+
+    private void HandleAutoSwitchCursorPadChanged(bool enabled)
+    {
+        autoSwitchCursorPadEnabled = enabled;
     }
 
     private async Task HandleThemeChanged(string newTheme)
@@ -1976,6 +1985,7 @@
 
     private string claudeModeSwitchKey = "altM";
     private bool voiceInputEnabled = false;
+    private bool autoSwitchCursorPadEnabled = false; // 試験機能: 入力待ちでカーソルパッドへ自動切替(デバイス別)
 
     private async Task SendCustomKey(string keyName)
     {
@@ -2453,9 +2463,26 @@
                     }
                     StateHasChanged();
                 }
+                else if (autoSwitchCursorPadEnabled && bottomPanel != null
+                         && IsUserInputWaitEvent(eventType, notification.Message))
+                {
+                    // 試験機能: アクティブ(表示中)セッションが入力待ちになったら、既存のカーソルパッドタブが
+                    // あればそこへ自動切替する（無ければ何もしない）。↑↓←→/Enter でそのまま応答できる。
+                    await bottomPanel.ActivateCursorPadIfExistsAsync();
+                }
                 break;
         }
     }
+
+    /// <summary>
+    /// この hook イベントが「ユーザーの入力受付中(許可/選択待ち)」を意味するか。
+    /// PreToolUse=選択待ち / PermissionRequest=許可待ち / Notification は message に "permission" を含むときのみ。
+    /// </summary>
+    private static bool IsUserInputWaitEvent(HookEventType? eventType, string? message)
+        => eventType == HookEventType.PreToolUse
+        || eventType == HookEventType.PermissionRequest
+        || (eventType == HookEventType.Notification
+            && ClassifyNotificationBell(message) == SessionBellKind.Confirm);
 
     private void ShowSessionSettingsDialog(Guid sessionId)
     {

--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -370,6 +370,21 @@
         }
     }
 
+    /// <summary>
+    /// 既存のカーソルパッドタブがあればそこへ切り替える（試験機能: 入力待ちで自動切替から呼ばれる）。
+    /// 既に選択済み、またはカーソルパッドタブが無い場合は何もしない（新規タブは作らない）。戻り値は切り替えたか。
+    /// </summary>
+    public async Task<bool> ActivateCursorPadIfExistsAsync()
+    {
+        var cursorPad = Tabs.FirstOrDefault(t => t.Type == BottomPanelTabType.CursorPad);
+        if (cursorPad == null || ActiveTabId == cursorPad.Id)
+        {
+            return false;
+        }
+        await SelectTab(cursorPad.Id);
+        return true;
+    }
+
     private string GetTabIcon(BottomPanelTabType type)
     {
         return type switch

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -95,6 +95,13 @@
                                 <i class="bi bi-wrench me-1"></i>@L["Settings.Tab.Special"]
                             </button>
                         </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link @(activeTab == "experimental" ? "active" : "")"
+                                    type="button"
+                                    @onclick="@(() => activeTab = "experimental")">
+                                <i class="bi bi-flask me-1"></i>試験機能
+                            </button>
+                        </li>
                         @if (devToolsEnabled)
                         {
                             <li class="nav-item" role="presentation">
@@ -890,52 +897,6 @@
                                 <hr />
 
                                 <div class="mb-4">
-                                    <h6 class="mb-2">@L["Settings.Special.VoiceInput.Header"]</h6>
-                                    <div class="form-check form-switch">
-                                        <input class="form-check-input" type="checkbox" @bind="voiceInputEnabled" id="voiceInputSwitch">
-                                        <label class="form-check-label" for="voiceInputSwitch">
-                                            @L["Settings.Special.VoiceInput.Enable"]
-                                        </label>
-                                    </div>
-                                    <p class="text-muted small mt-2 mb-0">
-                                        <i class="bi bi-info-circle me-1"></i>
-                                        @L["Settings.Special.VoiceInput.Help"]
-                                    </p>
-                                </div>
-
-                                <hr />
-
-                                @* 試験機能: 各CLIの設定フォルダへ terminalhub MCP を自動登録する（既定OFF） *@
-                                <div class="mb-4">
-                                    <h6 class="mb-2">
-                                        <span class="badge bg-warning text-dark me-1">試験機能</span>
-                                        MCP自動登録
-                                    </h6>
-                                    <div class="form-check form-switch">
-                                        <input class="form-check-input" type="checkbox" @bind="autoRegisterMcpEnabled" id="autoRegisterMcpSwitch">
-                                        <label class="form-check-label" for="autoRegisterMcpSwitch">
-                                            対応CLIのフォルダに TerminalHub のローカル MCP を自動登録する
-                                        </label>
-                                    </div>
-                                    <p class="text-muted small mt-2 mb-0">
-                                        <i class="bi bi-info-circle me-1"></i>
-                                        ONにすると、<strong>Claude Code / Codex</strong> のセッション作成/再起動時に、その作業フォルダへ
-                                        TerminalHub のローカル MCP サーバー（<code>terminalhub</code>）を追記します。
-                                        起動しただけで <code>list_sessions</code> / <code>send_to_session</code> が使えるようになります。
-                                    </p>
-                                    <ul class="text-muted small mt-1 mb-0">
-                                        <li>Claude Code → <code>&lt;folder&gt;/.mcp.json</code> の <code>mcpServers.terminalhub</code></li>
-                                        <li>Codex → <code>&lt;folder&gt;/.codex/config.toml</code> の <code>[mcp_servers.terminalhub]</code></li>
-                                    </ul>
-                                    <p class="text-muted small mt-1 mb-0">
-                                        既存の設定はそのまま残し、<code>terminalhub</code> エントリのみを管理します。
-                                        Claude Code / Codex のみ対応（Gemini 等は非対応）。ポートは起動中の値を使います。
-                                    </p>
-                                </div>
-
-                                <hr />
-
-                                <div class="mb-4">
                                     <h6 class="mb-2">@L["Settings.Special.DevTools.Header"]</h6>
                                     <div class="form-check form-switch">
                                         <input class="form-check-input" type="checkbox" @bind="devToolsEnabled" id="devToolsSwitch">
@@ -959,6 +920,73 @@
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
                                         @L["Settings.Special.Logs.Help"]
+                                    </p>
+                                </div>
+                            </div>
+                        }
+                        else if (activeTab == "experimental")
+                        {
+                            <div class="tab-pane fade show active">
+                                <p class="text-muted small mb-3">
+                                    <i class="bi bi-flask me-1"></i>
+                                    実験的な機能です。音声入力とカーソルパッド自動切替は<strong>このデバイスのみ</strong>（LocalStorage 保存）で、PC とモバイルで別々に設定できます。
+                                </p>
+
+                                <div class="mb-4">
+                                    <h6 class="mb-2">@L["Settings.Special.VoiceInput.Header"]</h6>
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" @bind="voiceInputEnabled" id="voiceInputSwitch">
+                                        <label class="form-check-label" for="voiceInputSwitch">
+                                            @L["Settings.Special.VoiceInput.Enable"]
+                                        </label>
+                                    </div>
+                                    <p class="text-muted small mt-2 mb-0">
+                                        <i class="bi bi-info-circle me-1"></i>
+                                        @L["Settings.Special.VoiceInput.Help"]（このデバイスのみ。例: PC は ON、モバイルは OS の音声入力を使うので OFF）
+                                    </p>
+                                </div>
+
+                                <hr />
+
+                                <div class="mb-4">
+                                    <h6 class="mb-2">入力待ちでカーソルパッドへ自動切替</h6>
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" @bind="autoSwitchCursorPadEnabled" id="autoSwitchCursorPadSwitch">
+                                        <label class="form-check-label" for="autoSwitchCursorPadSwitch">
+                                            セッションが入力待ちになったら下部パネルをカーソルパッドに切り替える
+                                        </label>
+                                    </div>
+                                    <p class="text-muted small mt-2 mb-0">
+                                        <i class="bi bi-info-circle me-1"></i>
+                                        許可待ち/選択待ちのプロンプトが出た瞬間に、そのセッションに<strong>カーソルパッドタブが既にある場合だけ</strong>そこへ自動で切り替えます（無ければ何もしません）。
+                                        ↑↓←→/Enter でそのまま応答でき、タッチ操作のモバイルで便利です。このデバイスのみ。
+                                    </p>
+                                </div>
+
+                                <hr />
+
+                                @* 各CLIの設定フォルダへ terminalhub MCP を自動登録する（既定OFF・全デバイス共通） *@
+                                <div class="mb-4">
+                                    <h6 class="mb-2">MCP自動登録</h6>
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" @bind="autoRegisterMcpEnabled" id="autoRegisterMcpSwitch">
+                                        <label class="form-check-label" for="autoRegisterMcpSwitch">
+                                            対応CLIのフォルダに TerminalHub のローカル MCP を自動登録する
+                                        </label>
+                                    </div>
+                                    <p class="text-muted small mt-2 mb-0">
+                                        <i class="bi bi-info-circle me-1"></i>
+                                        ONにすると、<strong>Claude Code / Codex</strong> のセッション作成/再起動時に、その作業フォルダへ
+                                        TerminalHub のローカル MCP サーバー（<code>terminalhub</code>）を追記します。
+                                        起動しただけで <code>list_sessions</code> / <code>send_to_session</code> が使えるようになります。
+                                    </p>
+                                    <ul class="text-muted small mt-1 mb-0">
+                                        <li>Claude Code → <code>&lt;folder&gt;/.mcp.json</code> の <code>mcpServers.terminalhub</code></li>
+                                        <li>Codex → <code>&lt;folder&gt;/.codex/config.toml</code> の <code>[mcp_servers.terminalhub]</code></li>
+                                    </ul>
+                                    <p class="text-muted small mt-1 mb-0">
+                                        既存の設定はそのまま残し、<code>terminalhub</code> エントリのみを管理します。
+                                        Claude Code / Codex のみ対応（Gemini 等は非対応）。ポートは起動中の値を使います。全デバイス共通の設定です。
                                     </p>
                                 </div>
                             </div>
@@ -1228,6 +1256,7 @@
     // 開発ツール関連
     private bool devToolsEnabled = false;
     private bool autoRegisterMcpEnabled = false;
+    private bool autoSwitchCursorPadEnabled = false;
     private bool captureRawStreamEnabled = false;
     private List<SessionInfo> diagnosticSessions = new();
     private int jsTerminalCount = 0;
@@ -1248,6 +1277,7 @@
     [Parameter] public EventCallback<int> OnTerminalHeightPercentChanged { get; set; }
     [Parameter] public EventCallback<int> OnSidebarWidthPercentChanged { get; set; }
     [Parameter] public EventCallback<bool> OnVoiceInputEnabledChanged { get; set; }
+    [Parameter] public EventCallback<bool> OnAutoSwitchCursorPadChanged { get; set; }
     [Parameter] public EventCallback<string> OnThemeChanged { get; set; }
 
     // ダイアログが開いている間は設定を再読み込みしないためのフラグ
@@ -1346,7 +1376,10 @@
                 "altM" or "shiftTab" or "none" => settings.Special.ClaudeModeSwitchKey,
                 _ => "none"
             };
-            voiceInputEnabled = settings.Special.VoiceInputEnabled;
+            // 音声入力・カーソルパッド自動切替はデバイス別 (LocalStorage 優先、無ければ app-settings をシード)。
+            var localExperimental = await LocalStorageService.LoadExperimentalSettingsAsync();
+            voiceInputEnabled = localExperimental?.VoiceInputEnabled ?? settings.Special.VoiceInputEnabled;
+            autoSwitchCursorPadEnabled = localExperimental?.AutoSwitchToCursorPadOnWait ?? false;
 
             // セッション表示設定
             // 未知の SortMode 値は lastAccessed にフォールバック（UI ラジオの未選択状態を防ぐ）
@@ -1656,6 +1689,14 @@
                 SidebarWidthPercent = sidebarWidthPercent,
             });
 
+            // 音声入力・カーソルパッド自動切替もデバイス別設定として LocalStorage に保存する
+            // (app-settings 側の VoiceInputEnabled は新デバイス初回アクセス時のシードとして機能する)
+            await LocalStorageService.SaveExperimentalSettingsAsync(new LocalExperimentalSettings
+            {
+                VoiceInputEnabled = voiceInputEnabled,
+                AutoSwitchToCursorPadOnWait = autoSwitchCursorPadEnabled,
+            });
+
             // 生ストリームキャプチャの ON/OFF を即時反映（無効化時はライターを閉じる）
             RawStreamCapture.SetEnabled(captureRawStreamEnabled);
 
@@ -1682,6 +1723,9 @@
 
             // 音声入力設定の変更を通知
             await OnVoiceInputEnabledChanged.InvokeAsync(voiceInputEnabled);
+
+            // カーソルパッド自動切替設定の変更を通知
+            await OnAutoSwitchCursorPadChanged.InvokeAsync(autoSwitchCursorPadEnabled);
 
             // テーマの変更を通知
             await OnThemeChanged.InvokeAsync(theme);

--- a/TerminalHub/Models/LocalExperimentalSettings.cs
+++ b/TerminalHub/Models/LocalExperimentalSettings.cs
@@ -1,0 +1,19 @@
+namespace TerminalHub.Models
+{
+    /// <summary>
+    /// ブラウザ(デバイス)ごとの試験機能・デバイス依存設定。LocalStorage に保存する。
+    /// PC とモバイルで別々に持てるようにするため app-settings.json (全デバイス共通) から分離した。
+    /// デバイス別に保存されるので、各デバイスでユーザーが任意に ON/OFF すればよい
+    /// (例: 音声入力は PC では ON、モバイルでは OS 側の音声入力を使うため OFF)。
+    ///
+    /// nullable の項目は「未設定」を表し、未設定なら app-settings.json の値へフォールバックする。
+    /// </summary>
+    public class LocalExperimentalSettings
+    {
+        /// <summary>音声入力の有効/無効(デバイス別)。未設定なら app-settings の Special.VoiceInputEnabled にフォールバック。</summary>
+        public bool? VoiceInputEnabled { get; set; }
+
+        /// <summary>セッションが入力待ち(許可/選択)になった時、既存のカーソルパッドタブへ自動で切り替える(デバイス別)。</summary>
+        public bool AutoSwitchToCursorPadOnWait { get; set; } = false;
+    }
+}

--- a/TerminalHub/Services/LocalStorageService.cs
+++ b/TerminalHub/Services/LocalStorageService.cs
@@ -18,6 +18,8 @@ namespace TerminalHub.Services
         Task<Dictionary<Guid, bool>> LoadSessionExpandedStatesAsync();
         Task<LocalDisplaySettings?> LoadDisplaySettingsAsync();
         Task SaveDisplaySettingsAsync(LocalDisplaySettings settings);
+        Task<LocalExperimentalSettings?> LoadExperimentalSettingsAsync();
+        Task SaveExperimentalSettingsAsync(LocalExperimentalSettings settings);
     }
 
     public class LocalStorageService : ILocalStorageService
@@ -29,6 +31,7 @@ namespace TerminalHub.Services
         private const string ActiveSessionKey = "terminalHub_activeSession";
         private const string ExpandedStatesKey = "terminalHub_expandedStates";
         private const string DisplaySettingsKey = "terminalHub_displaySettings";
+        private const string ExperimentalSettingsKey = "terminalHub_experimentalSettings";
 
         public LocalStorageService(IJSRuntime jsRuntime, ILogger<LocalStorageService> logger)
         {
@@ -207,6 +210,12 @@ namespace TerminalHub.Services
 
         public Task SaveDisplaySettingsAsync(LocalDisplaySettings settings)
             => SetAsync(DisplaySettingsKey, settings);
+
+        public Task<LocalExperimentalSettings?> LoadExperimentalSettingsAsync()
+            => GetAsync<LocalExperimentalSettings>(ExperimentalSettingsKey);
+
+        public Task SaveExperimentalSettingsAsync(LocalExperimentalSettings settings)
+            => SetAsync(ExperimentalSettingsKey, settings);
 
         public async Task SaveSessionExpandedStatesAsync(Dictionary<Guid, bool> expandedStates)
         {


### PR DESCRIPTION
## 概要

設定に「試験機能」専用タブを新設し、デバイス依存の試験機能を集約。あわせて「入力待ちになったらカーソルパッドへ自動切替」する試験機能を追加。

## 変更点

### 試験機能タブの新設・移設
- 「特殊」タブが盛り沢山だったため、**試験機能タブ**を新設。**MCP自動登録**と**音声入力**をそこへ移設。

### 音声入力のデバイス別(LocalStorage)化
- 音声入力を `AppSettings.Special` 依存から **LocalStorage 優先**に変更（無ければ app-settings をシード）。
- 動機: PC は音声入力ON、モバイルは OS 側の音声入力を使うため OFF、をデバイスごとに設定したい。
- 新規 `LocalExperimentalSettings`（key `terminalHub_experimentalSettings`）＋ `LocalStorageService` の load/save。

### カーソルパッド自動切替（試験機能・デバイス別・既定OFF）
- セッションが入力待ち（`PreToolUse`=選択 / `PermissionRequest`=許可 / `Notification` permission）になった瞬間、そのセッションに**既存のカーソルパッドタブがある場合だけ**下部パネルを自動でカーソルパッドへ切替（無ければ何もしない・新規生成なし）。
- ↑↓←→/Enter でそのまま応答でき、タッチ操作のモバイルで便利。
- `BottomPanel.ActivateCursorPadIfExistsAsync()` を追加。トリガーは `Root.OnHookNotification`（アクティブセッションのみ）。

## テスト状況
- ビルド 0 warning / 0 error。
- ConPTY / UI 実挙動はユーザー実機で確認予定（再ビルド＋再起動）。

## 補足
- MCP自動登録は全デバイス共通のまま（server-side）。移設のみ。
- モバイル自動判定は入れず、LocalStorageのデバイス別保存で「各デバイスで任意にON/OFF」する方針。

🤖 Generated with [Claude Code](https://claude.com/claude-code)