### PR TITLE
fix: エクスプローラーで開いたフォルダウィンドウが前面に出ない問題を修正

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -9,6 +9,7 @@
 @inject ILogger<SessionSettingsDialog> Logger
 @inject ISessionMemoRepository MemoRepository
 @inject IStringLocalizer<SharedResource> L
+@inject IExplorerLauncherService ExplorerLauncher
 
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
     <div class="modal-dialog modal-dialog-centered modal-lg">
@@ -530,21 +531,8 @@
 
     private void OpenFolder(string path)
     {
-        try
-        {
-            if (Directory.Exists(path))
-            {
-                Process.Start(new ProcessStartInfo
-                {
-                    FileName = path.Replace('/', '\\'),
-                    UseShellExecute = true,
-                });
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "フォルダを開けませんでした: {Path}", path);
-        }
+        // ブラウザの裏に隠れないよう、開いたウィンドウを前面化するサービス経由で開く
+        ExplorerLauncher.OpenFolder(path);
     }
 
     private async Task HandleCreateSubSession()

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -11,6 +11,7 @@
 @inject ILocalStorageService LocalStorageService
 @inject IAppSettingsService AppSettingsService
 @inject IFolderPickerService FolderPicker
+@inject IExplorerLauncherService ExplorerLauncher
 @inject ISessionManager SessionManager
 @inject IStorageServiceFactory StorageServiceFactory
 @inject IVersionCheckService VersionCheckService
@@ -1542,11 +1543,8 @@
             {
                 Directory.CreateDirectory(logPath);
             }
-            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = logPath,
-                UseShellExecute = true,
-            });
+            // ブラウザの裏に隠れないよう、開いたウィンドウを前面化するサービス経由で開く
+            ExplorerLauncher.OpenFolder(logPath);
         }
         catch (Exception ex)
         {

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -127,6 +127,9 @@ builder.Services.AddSingleton<IAppSettingsService, AppSettingsService>();
 // FolderPickerServiceを登録
 builder.Services.AddSingleton<IFolderPickerService, FolderPickerService>();
 
+// エクスプローラー起動（前面化付き）を登録
+builder.Services.AddSingleton<IExplorerLauncherService, ExplorerLauncherService>();
+
 // リモート起動サービスを登録
 builder.Services.AddSingleton<IRemoteLaunchService, RemoteLaunchService>();
 builder.Services.AddSingleton<MqttService>();

--- a/TerminalHub/Services/ExplorerLauncherService.cs
+++ b/TerminalHub/Services/ExplorerLauncherService.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics;
+
+namespace TerminalHub.Services;
+
+/// <summary>
+/// エクスプローラーでフォルダを開くサービス。
+/// Blazor Server はバックグラウンドプロセスのため、素の Process.Start では
+/// 開いた Explorer ウィンドウがブラウザの裏に隠れてしまう。
+/// 起動後に新規ウィンドウを探して強制前面化する。
+/// </summary>
+public interface IExplorerLauncherService
+{
+    /// <summary>エクスプローラーで指定フォルダを開き、ウィンドウを前面に出す。フォルダが無ければ何もしない。</summary>
+    void OpenFolder(string path);
+}
+
+public class ExplorerLauncherService : IExplorerLauncherService
+{
+    // エクスプローラーのフォルダウィンドウのウィンドウクラス名
+    private const string ExplorerWindowClass = "CabinetWClass";
+
+    private readonly ILogger<ExplorerLauncherService> _logger;
+
+    public ExplorerLauncherService(ILogger<ExplorerLauncherService> logger)
+    {
+        _logger = logger;
+    }
+
+    public void OpenFolder(string path)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+                return;
+
+            // 起動前のウィンドウ一覧を控えておき、後で「新しく増えたウィンドウ」を特定する
+            var before = ForegroundWindowHelper.FindVisibleWindowsByClass(ExplorerWindowClass).ToHashSet();
+
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "explorer.exe",
+                Arguments = $"\"{path.Replace('/', '\\')}\"",
+                UseShellExecute = true,
+            });
+
+            // Explorer ウィンドウは既存の explorer.exe プロセス側で開くため、
+            // Process.Start の戻り値からはウィンドウを辿れない。
+            // 新規の CabinetWClass ウィンドウが現れるのをポーリングして前面化する（最大3秒）。
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    for (var i = 0; i < 30; i++)
+                    {
+                        await Task.Delay(100);
+                        var fresh = ForegroundWindowHelper.FindVisibleWindowsByClass(ExplorerWindowClass)
+                            .FirstOrDefault(h => !before.Contains(h));
+                        if (fresh != IntPtr.Zero)
+                        {
+                            ForegroundWindowHelper.ForceForeground(fresh);
+                            return;
+                        }
+                    }
+                    // 見つからなければ既存ウィンドウが再利用された等。従来どおり何もしない。
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "[ExplorerLauncher] ウィンドウ前面化に失敗: {Path}", path);
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[ExplorerLauncher] フォルダを開けませんでした: {Path}", path);
+        }
+    }
+}

--- a/TerminalHub/Services/FolderPickerService.cs
+++ b/TerminalHub/Services/FolderPickerService.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-
 namespace TerminalHub.Services;
 
 /// <summary>
@@ -16,77 +14,6 @@ public interface IFolderPickerService
 
 public class FolderPickerService : IFolderPickerService
 {
-    [DllImport("user32.dll")]
-    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
-
-    [DllImport("user32.dll")]
-    private static extern bool SetForegroundWindow(IntPtr hWnd);
-
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetForegroundWindow();
-
-    [DllImport("user32.dll")]
-    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
-
-    [DllImport("user32.dll")]
-    private static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
-
-    [DllImport("user32.dll")]
-    private static extern bool BringWindowToTop(IntPtr hWnd);
-
-    [DllImport("user32.dll")]
-    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
-
-    [DllImport("kernel32.dll")]
-    private static extern uint GetCurrentThreadId();
-
-    private static readonly IntPtr HWND_TOPMOST = new(-1);
-    private static readonly IntPtr HWND_NOTOPMOST = new(-2);
-    private const uint SWP_NOMOVE = 0x0002;
-    private const uint SWP_NOSIZE = 0x0001;
-    private const uint SWP_NOACTIVATE = 0x0010;
-    private const uint TopMostFlags = SWP_NOMOVE | SWP_NOSIZE;
-    private const int SW_SHOW = 5;
-
-    /// <summary>
-    /// 指定ウィンドウを強制的にフォアグラウンド化する。
-    /// Blazor Server はバックグラウンドプロセスのため、単純な SetForegroundWindow は
-    /// Windows のフォアグラウンドロックで拒否される。現在フォアグラウンドのウィンドウの
-    /// 入力スレッドへ一時的に AttachThreadInput することで前面化を成功させる。
-    /// ShowDialog(owner) で開くモーダルの IFileDialog はオーナーに追従して前面に出る。
-    /// </summary>
-    private static void ForceForeground(IntPtr hWnd)
-    {
-        if (hWnd == IntPtr.Zero) return;
-
-        var foreground = GetForegroundWindow();
-        uint foreThread = foreground == IntPtr.Zero ? 0 : GetWindowThreadProcessId(foreground, out _);
-        uint thisThread = GetCurrentThreadId();
-
-        bool attached = false;
-        try
-        {
-            if (foreThread != 0 && foreThread != thisThread)
-            {
-                attached = AttachThreadInput(foreThread, thisThread, true);
-            }
-
-            SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0, TopMostFlags);
-            ShowWindow(hWnd, SW_SHOW);
-            BringWindowToTop(hWnd);
-            SetForegroundWindow(hWnd);
-            // TOPMOST は前面化のための一時措置。アクティブ化後は解除して通常の Z オーダーに戻す。
-            SetWindowPos(hWnd, HWND_NOTOPMOST, 0, 0, 0, 0, TopMostFlags | SWP_NOACTIVATE);
-        }
-        finally
-        {
-            if (attached)
-            {
-                AttachThreadInput(foreThread, thisThread, false);
-            }
-        }
-    }
-
     public Task<string?> PickFolderAsync(string? initialDirectory = null)
     {
         var tcs = new TaskCompletionSource<string?>();
@@ -111,7 +38,7 @@ public class FolderPickerService : IFolderPickerService
                 using var owner = new TopmostOwnerWindow();
                 // オーナーを強制的にフォアグラウンド化してから ShowDialog する。
                 // こうしないと App Mode(Chrome) などが前面のとき、ダイアログが裏に回ってしまう。
-                ForceForeground(owner.Handle);
+                ForegroundWindowHelper.ForceForeground(owner.Handle);
                 var result = dialog.ShowDialog(owner);
                 tcs.SetResult(result == System.Windows.Forms.DialogResult.OK ? dialog.SelectedPath : null);
             }
@@ -140,14 +67,14 @@ public class FolderPickerService : IFolderPickerService
                 X = 0, Y = 0, Width = 0, Height = 0,
                 Style = 0x00000000, // WS_OVERLAPPED (不可視)
             });
-            SetWindowPos(Handle, HWND_TOPMOST, 0, 0, 0, 0, TopMostFlags);
+            ForegroundWindowHelper.MakeTopmost(Handle);
         }
 
         public void Dispose()
         {
             if (Handle != IntPtr.Zero)
             {
-                SetWindowPos(Handle, HWND_NOTOPMOST, 0, 0, 0, 0, TopMostFlags | SWP_NOACTIVATE);
+                ForegroundWindowHelper.ClearTopmost(Handle);
                 DestroyHandle();
             }
         }

--- a/TerminalHub/Services/ForegroundWindowHelper.cs
+++ b/TerminalHub/Services/ForegroundWindowHelper.cs
@@ -1,0 +1,123 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace TerminalHub.Services;
+
+/// <summary>
+/// バックグラウンドプロセス(Blazor Server)から開いたウィンドウを前面化するための Win32 ヘルパー。
+/// FolderPickerService(フォルダ選択ダイアログ) と ExplorerLauncherService(エクスプローラー) で共用する。
+/// </summary>
+internal static class ForegroundWindowHelper
+{
+    [DllImport("user32.dll")]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    [DllImport("user32.dll")]
+    private static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
+
+    [DllImport("user32.dll")]
+    private static extern bool BringWindowToTop(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("kernel32.dll")]
+    private static extern uint GetCurrentThreadId();
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr hWnd);
+
+    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+    private static readonly IntPtr HWND_NOTOPMOST = new(-2);
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOSIZE = 0x0001;
+    private const uint SWP_NOACTIVATE = 0x0010;
+    private const uint TopMostFlags = SWP_NOMOVE | SWP_NOSIZE;
+    private const int SW_SHOW = 5;
+
+    /// <summary>ウィンドウを一時的に TOPMOST にする（位置・サイズは変えない）</summary>
+    internal static void MakeTopmost(IntPtr hWnd)
+        => SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0, TopMostFlags);
+
+    /// <summary>TOPMOST を解除して通常の Z オーダーに戻す（アクティブ化はしない）</summary>
+    internal static void ClearTopmost(IntPtr hWnd)
+        => SetWindowPos(hWnd, HWND_NOTOPMOST, 0, 0, 0, 0, TopMostFlags | SWP_NOACTIVATE);
+
+    /// <summary>
+    /// 指定ウィンドウを強制的にフォアグラウンド化する。
+    /// Blazor Server はバックグラウンドプロセスのため、単純な SetForegroundWindow は
+    /// Windows のフォアグラウンドロックで拒否される。現在フォアグラウンドのウィンドウの
+    /// 入力スレッドへ一時的に AttachThreadInput することで前面化を成功させる。
+    /// </summary>
+    internal static void ForceForeground(IntPtr hWnd)
+    {
+        if (hWnd == IntPtr.Zero) return;
+
+        var foreground = GetForegroundWindow();
+        uint foreThread = foreground == IntPtr.Zero ? 0 : GetWindowThreadProcessId(foreground, out _);
+        uint thisThread = GetCurrentThreadId();
+
+        bool attached = false;
+        try
+        {
+            if (foreThread != 0 && foreThread != thisThread)
+            {
+                attached = AttachThreadInput(foreThread, thisThread, true);
+            }
+
+            MakeTopmost(hWnd);
+            ShowWindow(hWnd, SW_SHOW);
+            BringWindowToTop(hWnd);
+            SetForegroundWindow(hWnd);
+            // TOPMOST は前面化のための一時措置。アクティブ化後は解除して通常の Z オーダーに戻す。
+            ClearTopmost(hWnd);
+        }
+        finally
+        {
+            if (attached)
+            {
+                AttachThreadInput(foreThread, thisThread, false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 指定ウィンドウクラスの可視トップレベルウィンドウを列挙する。
+    /// エクスプローラーのフォルダウィンドウは "CabinetWClass"。
+    /// </summary>
+    internal static List<IntPtr> FindVisibleWindowsByClass(string className)
+    {
+        var result = new List<IntPtr>();
+        EnumWindows((hWnd, _) =>
+        {
+            if (IsWindowVisible(hWnd))
+            {
+                var sb = new StringBuilder(64);
+                GetClassName(hWnd, sb, sb.Capacity);
+                if (sb.ToString() == className)
+                {
+                    result.Add(hWnd);
+                }
+            }
+            return true; // 列挙続行
+        }, IntPtr.Zero);
+        return result;
+    }
+}


### PR DESCRIPTION
## 問題
セッション設定の「フォルダを開く」ボタンでエクスプローラーを開いても、ウィンドウがブラウザの裏に隠れてしまう。

v1.0.58 の対処（#既存の FolderPickerService の強制前面化）は**フォルダ選択ダイアログ専用**で、エクスプローラー起動の経路は素の `Process.Start` のままだった。Blazor Server はバックグラウンドプロセスのため、Windows のフォアグラウンドロックで新しいウィンドウが前面に出ない。

## 修正内容
- **`ForegroundWindowHelper`（新規）**: FolderPickerService にあった強制前面化ロジック（AttachThreadInput 方式）と Win32 P/Invoke を抽出して共用化。ウィンドウクラス名による可視トップレベルウィンドウ列挙も追加
- **`ExplorerLauncherService`（新規）**: explorer.exe 起動後、新規の CabinetWClass ウィンドウを最大3秒ポーリングで特定して強制前面化。Explorer は既存プロセス側でウィンドウを開くため `Process.Start` の戻り値からは辿れず、この方式にした。見つからない場合は従来動作（何もしない）
- **呼び出し側の差し替え（2箇所）**: セッション設定「フォルダを開く」と、設定画面「ログフォルダを開く」（同じ問題があった）
- FolderPickerService はヘルパー使用にリファクタリング（挙動変更なし）

## 動作確認
- ビルド 0警告0エラー
- 実機確認はローカルで実施予定（App Mode / 通常ブラウザの両方でフォルダを開いてウィンドウが前面に出ること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)