### PR TITLE
feat: Gitバッジクリックをオプション化し変更なしはトースト・パスコピー追加

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -86,6 +86,9 @@
                      SortMode=@sessionSortMode
                      ShowTerminalType=@showTerminalType
                      ShowGitInfo=@showGitInfo
+                     GitChangesOnBadgeClick=@gitChangesOnBadgeClick
+                     OnShowInfoToast="(string msg) => toast?.ShowInfo(msg)"
+                     OnShowErrorToast="(string msg) => toast?.ShowError(msg)"
                      IsMobileOpen=@isMobileSidebarOpen
                      Scale=@sessionListScale
                      WidthPercent=@sidebarWidthPercent
@@ -197,6 +200,7 @@
     private string sessionSortMode = "lastAccessed"; // セッション一覧のソートモード
     private bool showTerminalType = false; // ターミナル種別を表示
     private bool showGitInfo = false; // Git情報を表示
+    private bool gitChangesOnBadgeClick = false; // Gitバッジクリックで変更ファイル一覧を表示
     private bool hideInputPanel = false; // 入力パネルを非表示
     private bool isMobileSidebarOpen = false; // モバイルサイドバーの開閉状態
     private double sessionListScale = 1.0; // セッションリスト表示倍率
@@ -506,6 +510,7 @@
                 sessionSortMode = appSettings.Sessions.SortMode;
                 showTerminalType = appSettings.Sessions.ShowTerminalType;
                 showGitInfo = appSettings.Sessions.ShowGitInfo;
+                gitChangesOnBadgeClick = appSettings.Sessions.GitChangesOnBadgeClick;
                 hideInputPanel = appSettings.Sessions.HideInputPanel;
                 // 表示系4項目はデバイス別 (LocalStorage 優先、無ければ app-settings をシード)。
                 // PC とモバイルで別々のフォントサイズ等を持てるようにするため。
@@ -728,10 +733,11 @@
         StateHasChanged();
     }
 
-    private void HandleSessionDisplaySettingsChanged((bool showTerminalType, bool showGitInfo, bool hideInputPanel) settings)
+    private void HandleSessionDisplaySettingsChanged((bool showTerminalType, bool showGitInfo, bool gitChangesOnBadgeClick, bool hideInputPanel) settings)
     {
         showTerminalType = settings.showTerminalType;
         showGitInfo = settings.showGitInfo;
+        gitChangesOnBadgeClick = settings.gitChangesOnBadgeClick;
         hideInputPanel = settings.hideInputPanel;
         StateHasChanged();
     }

--- a/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
@@ -85,6 +85,8 @@
     [Parameter] public EventCallback OnClose { get; set; }
     /// <summary>取得結果の「変更あり/なし」を親に通知（バッジの赤丸を最新化するため）</summary>
     [Parameter] public EventCallback<bool> OnChangesLoaded { get; set; }
+    /// <summary>親がクリック時に取得済みの変更一覧。指定があれば開いた直後の再取得を省略する（更新ボタンでは取り直す）</summary>
+    [Parameter] public List<GitChangedFile>? InitialFiles { get; set; }
 
     private List<GitChangedFile> changedFiles = new();
     private bool isLoading = false;
@@ -97,7 +99,16 @@
         {
             // ダイアログが開かれた時（または対象が変わった時）のみ取得する
             _loadedPath = FolderPath;
-            await ReloadAsync();
+            if (InitialFiles != null)
+            {
+                // 親がクリック時に取得済みなら再取得しない
+                changedFiles = InitialFiles;
+                loadFailed = false;
+            }
+            else
+            {
+                await ReloadAsync();
+            }
         }
         else if (!IsVisible)
         {

--- a/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
@@ -8,7 +8,8 @@
 @inject IJSRuntime JSRuntime
 
 @* Git バッジクリックで開く、未コミット変更ファイル一覧ダイアログ。
-   開くたびに git status を取り直すので常に最新の状態を表示する。 *@
+   開いたとき InitialFiles（親がクリック時に取得済みの結果）があればそれを初期表示し、
+   無ければ git status を取得する。更新ボタンでは常に取り直す。 *@
 <div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
     <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
         <div class="modal-content">
@@ -108,6 +109,7 @@
         {
             // ダイアログが開かれた時（または対象が変わった時）のみ取得する
             _loadedPath = FolderPath;
+            pathsCopied = false; // 前回対象の「コピーしました」表示を持ち越さない
             if (InitialFiles != null)
             {
                 // 親がクリック時に取得済みなら再取得しない

--- a/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
@@ -1,9 +1,11 @@
 @using TerminalHub.Models
 @using TerminalHub.Services
 @using Microsoft.Extensions.Localization
+@using Microsoft.JSInterop
 @inject IGitService GitService
 @inject IStringLocalizer<SharedResource> L
 @inject ILogger<GitChangesDialog> Logger
+@inject IJSRuntime JSRuntime
 
 @* Git バッジクリックで開く、未コミット変更ファイル一覧ダイアログ。
    開くたびに git status を取り直すので常に最新の状態を表示する。 *@
@@ -69,6 +71,13 @@
                 }
             </div>
             <div class="modal-footer">
+                @if (changedFiles.Count > 0 && !isLoading && !loadFailed)
+                {
+                    @* 変更ファイルの相対パス一覧（改行区切り）をクリップボードへ。AIへの貼り付け等を想定 *@
+                    <button type="button" class="btn btn-outline-secondary me-auto" @onclick="CopyPathsAsync">
+                        <i class="bi @(pathsCopied ? "bi-check2" : "bi-clipboard") me-1"></i>@(pathsCopied ? L["GitChanges.Copied"] : L["GitChanges.CopyPaths"])
+                    </button>
+                }
                 <button type="button" class="btn btn-outline-secondary" @onclick="ReloadAsync" disabled="@isLoading">
                     <i class="bi bi-arrow-clockwise me-1"></i>@L["GitChanges.Refresh"]
                 </button>
@@ -164,6 +173,29 @@
     private async Task HandleClose()
     {
         await OnClose.InvokeAsync();
+    }
+
+    // 「コピーしました」表示用（数秒で元に戻す）
+    private bool pathsCopied = false;
+
+    private async Task CopyPathsAsync()
+    {
+        if (changedFiles.Count == 0) return;
+        try
+        {
+            // リネーム/コピーは新パス側を使う（git status の相対パスをそのまま改行区切りで）
+            var text = string.Join("\n", changedFiles.Select(f => f.FilePath));
+            await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
+            pathsCopied = true;
+            StateHasChanged();
+            await Task.Delay(2000);
+            pathsCopied = false;
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[GitChangesDialog] パスのコピーに失敗");
+        }
     }
 
     // 表示は「作業ツリー側の状態」を優先し、ステージ済みのみの場合はステージ側を使う

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -480,6 +480,14 @@
                                             <span class="text-muted small">（@L["Settings.Sessions.Display.ShowGitInfoSub"]）</span>
                                         </label>
                                     </div>
+                                    @* Git情報表示のサブオプション（本体がOFFなら無効化） *@
+                                    <div class="form-check ms-4">
+                                        <input class="form-check-input" type="checkbox" @bind="gitChangesOnBadgeClick" id="gitChangesOnBadgeClick" disabled="@(!showGitInfo)">
+                                        <label class="form-check-label" for="gitChangesOnBadgeClick">
+                                            @L["Settings.Sessions.Display.GitChangesOnBadgeClick"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.Display.GitChangesOnBadgeClickSub"]）</span>
+                                        </label>
+                                    </div>
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
                                         @L["Settings.Sessions.Display.Help"]
@@ -1234,6 +1242,7 @@
     private string sessionSortMode = "lastAccessed";
     private bool showTerminalType = false;
     private bool showGitInfo = false;
+    private bool gitChangesOnBadgeClick = false;
     private bool hideInputPanel = false;
     private string defaultFolderPath = "";
     private string? defaultFolderPathWarning = null;
@@ -1271,7 +1280,7 @@
     [Parameter] public EventCallback<string> OnSessionSortModeChanged { get; set; }
     [Parameter] public string SessionSortMode { get; set; } = "lastAccessed";
     [Parameter] public EventCallback<string> OnClaudeModeSwitchKeyChanged { get; set; }
-    [Parameter] public EventCallback<(bool showTerminalType, bool showGitInfo, bool hideInputPanel)> OnSessionDisplaySettingsChanged { get; set; }
+    [Parameter] public EventCallback<(bool showTerminalType, bool showGitInfo, bool gitChangesOnBadgeClick, bool hideInputPanel)> OnSessionDisplaySettingsChanged { get; set; }
     [Parameter] public EventCallback<double> OnSessionListScaleChanged { get; set; }
     [Parameter] public EventCallback<int> OnTerminalFontSizeChanged { get; set; }
     [Parameter] public EventCallback<int> OnTerminalHeightPercentChanged { get; set; }
@@ -1390,6 +1399,7 @@
             };
             showTerminalType = settings.Sessions.ShowTerminalType;
             showGitInfo = settings.Sessions.ShowGitInfo;
+            gitChangesOnBadgeClick = settings.Sessions.GitChangesOnBadgeClick;
             hideInputPanel = settings.Sessions.HideInputPanel;
 
             // 開発ツール設定
@@ -1621,6 +1631,7 @@
                     SortMode = sessionSortMode,
                     ShowTerminalType = showTerminalType,
                     ShowGitInfo = showGitInfo,
+                    GitChangesOnBadgeClick = gitChangesOnBadgeClick,
                     HideInputPanel = hideInputPanel
                 },
                 DevTools = new DevToolsSettings
@@ -1704,7 +1715,7 @@
             await OnSessionSortModeChanged.InvokeAsync(sessionSortMode);
 
             // セッション表示設定の変更を通知
-            await OnSessionDisplaySettingsChanged.InvokeAsync((showTerminalType, showGitInfo, hideInputPanel));
+            await OnSessionDisplaySettingsChanged.InvokeAsync((showTerminalType, showGitInfo, gitChangesOnBadgeClick, hideInputPanel));
 
             // モード切替キーの変更を通知
             await OnClaudeModeSwitchKeyChanged.InvokeAsync(claudeModeSwitchKey);

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -2,8 +2,10 @@
 @using TerminalHub.Models
 @using TerminalHub.Constants
 @using TerminalHub.Components.Shared.Dialogs
+@using TerminalHub.Services
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SharedResource> L
+@inject IGitService GitService
 
 <style>
     @@keyframes bell-ring {
@@ -118,11 +120,13 @@
                             }
                             @if (ShowGitInfo && session.IsGitRepository && !string.IsNullOrEmpty(session.GitBranch))
                             {
-                                @* クリックで変更ファイル一覧ダイアログを表示（stopPropagation でセッション選択を抑止） *@
-                                <span class="badge @(session.IsWorktree ? "bg-warning" : "bg-success") ms-1" style="cursor: pointer;"
-                                      title="@($"{(session.IsWorktree ? "Worktree" : L["SessionList.Badge.GitBranch"].Value)} - {L["SessionList.Badge.GitBranchClickHint"].Value}")"
-                                      @onclick:stopPropagation="true"
-                                      @onclick="() => OpenGitChanges(session)">
+                                @* オプション有効時のみクリックで変更ファイル一覧を表示（stopPropagation でセッション選択を抑止）。
+                                   変更 0 件のときはダイアログを開かずトーストで知らせる。 *@
+                                <span class="badge @(session.IsWorktree ? "bg-warning" : "bg-success") ms-1"
+                                      style="@(GitChangesOnBadgeClick ? "cursor: pointer;" : "")"
+                                      title="@GetGitBadgeTitle(session)"
+                                      @onclick:stopPropagation="GitChangesOnBadgeClick"
+                                      @onclick="async () => await OpenGitChangesAsync(session)">
                                     <i class="bi @(session.IsWorktree ? "bi-git" : "bi-git") me-1"></i>@session.GitBranch
                                     @if (session.HasUncommittedChanges)
                                     {
@@ -217,10 +221,11 @@
     </div>
 </div>
 
-@* Git バッジクリックで開く変更ファイル一覧ダイアログ *@
+@* Git バッジクリックで開く変更ファイル一覧ダイアログ（クリック時に取得済みの結果を初期表示に使う） *@
 <GitChangesDialog IsVisible="@(gitChangesSession != null)"
                   FolderPath="@gitChangesSession?.FolderPath"
                   BranchName="@gitChangesSession?.GitBranch"
+                  InitialFiles="@gitChangesFiles"
                   OnClose="() => gitChangesSession = null"
                   OnChangesLoaded="HandleGitChangesLoaded" />
 
@@ -235,15 +240,61 @@
     [Parameter] public bool IsMobileOpen { get; set; } = false;
     [Parameter] public double Scale { get; set; } = 1.0;
     [Parameter] public int WidthPercent { get; set; } = 25;
+    /// <summary>Git バッジのクリックで変更ファイル一覧を表示する（設定のサブオプション）</summary>
+    [Parameter] public bool GitChangesOnBadgeClick { get; set; }
+    [Parameter] public EventCallback<string> OnShowInfoToast { get; set; }
+    [Parameter] public EventCallback<string> OnShowErrorToast { get; set; }
 
     private string filterText = string.Empty;
 
     // Git バッジクリックで変更ファイル一覧を表示する対象セッション (null=非表示)
     private SessionInfo? gitChangesSession;
+    // クリック時に取得した変更一覧（ダイアログの初期表示用。二重の git status を避ける）
+    private List<GitChangedFile>? gitChangesFiles;
+    // 多重クリックによる並行取得を防ぐ
+    private bool isGitChangesLoading;
 
-    private void OpenGitChanges(SessionInfo session)
+    private string GetGitBadgeTitle(SessionInfo session)
     {
-        gitChangesSession = session;
+        var kind = session.IsWorktree ? "Worktree" : L["SessionList.Badge.GitBranch"].Value;
+        return GitChangesOnBadgeClick
+            ? $"{kind} - {L["SessionList.Badge.GitBranchClickHint"].Value}"
+            : kind;
+    }
+
+    private async Task OpenGitChangesAsync(SessionInfo session)
+    {
+        if (!GitChangesOnBadgeClick || string.IsNullOrEmpty(session.FolderPath) || isGitChangesLoading)
+            return;
+
+        isGitChangesLoading = true;
+        try
+        {
+            var files = await GitService.GetChangedFilesAsync(session.FolderPath);
+            if (files == null)
+            {
+                await OnShowErrorToast.InvokeAsync(L["SessionList.Toast.GitStatusError"]);
+                return;
+            }
+
+            // 取得結果でバッジの赤丸を最新化する
+            session.HasUncommittedChanges = files.Count > 0;
+
+            if (files.Count == 0)
+            {
+                // 変更なしはダイアログを開かずトーストで知らせる
+                await OnShowInfoToast.InvokeAsync(string.Format(L["SessionList.Toast.NoGitChangesFormat"], session.GitBranch));
+            }
+            else
+            {
+                gitChangesFiles = files;
+                gitChangesSession = session;
+            }
+        }
+        finally
+        {
+            isGitChangesLoading = false;
+        }
     }
 
     private void HandleGitChangesLoaded(bool hasChanges)

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -270,7 +270,12 @@
         isGitChangesLoading = true;
         try
         {
-            var files = await GitService.GetChangedFilesAsync(session.FolderPath);
+            // 応答が返るまでにセッションが削除されたり対象パスが変わった場合、
+            // 古い応答で赤丸やダイアログを汚染しないよう破棄する（GitChangesDialog.ReloadAsync と同じ方針）
+            var requestPath = session.FolderPath;
+            var files = await GitService.GetChangedFilesAsync(requestPath);
+            if (requestPath != session.FolderPath || !Sessions.Contains(session))
+                return;
             if (files == null)
             {
                 await OnShowErrorToast.InvokeAsync(L["SessionList.Toast.GitStatusError"]);

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -76,6 +76,8 @@ public class SessionDisplaySettings
     public string SortMode { get; set; } = "lastAccessed";
     public bool ShowTerminalType { get; set; }
     public bool ShowGitInfo { get; set; }
+    /// <summary>Git バッジのクリックで変更ファイル一覧を表示する（ShowGitInfo が有効な場合のみ意味を持つ）。既定 false。</summary>
+    public bool GitChangesOnBadgeClick { get; set; }
     public bool HideInputPanel { get; set; }
 }
 

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -151,6 +151,8 @@
   <data name="Settings.Sessions.Display.ShowTerminalTypeSub" xml:space="preserve"><value>Claude / Gemini / Codex badges</value></data>
   <data name="Settings.Sessions.Display.ShowGitInfo" xml:space="preserve"><value>Show Git info</value></data>
   <data name="Settings.Sessions.Display.ShowGitInfoSub" xml:space="preserve"><value>Branch name badge</value></data>
+  <data name="Settings.Sessions.Display.GitChangesOnBadgeClick" xml:space="preserve"><value>Show Git changes on badge click</value></data>
+  <data name="Settings.Sessions.Display.GitChangesOnBadgeClickSub" xml:space="preserve"><value>Shows changed files; toast when clean</value></data>
   <data name="Settings.Sessions.Display.Help" xml:space="preserve"><value>Choose which additional info to display in the session list.</value></data>
   <data name="Settings.Sessions.InputPanel.Label" xml:space="preserve"><value>Input panel settings</value></data>
   <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>Hide input panel</value></data>
@@ -508,6 +510,8 @@
   <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git branch</value></data>
   <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>Uncommitted changes</value></data>
   <data name="SessionList.Badge.GitBranchClickHint" xml:space="preserve"><value>Click to show changed files</value></data>
+  <data name="SessionList.Toast.NoGitChangesFormat" xml:space="preserve"><value>{0}: no uncommitted changes</value></data>
+  <data name="SessionList.Toast.GitStatusError" xml:space="preserve"><value>Failed to get Git status</value></data>
   <data name="GitChanges.Title" xml:space="preserve"><value>Git Changes</value></data>
   <data name="GitChanges.Loading" xml:space="preserve"><value>Loading…</value></data>
   <data name="GitChanges.NoChanges" xml:space="preserve"><value>No uncommitted changes</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -518,6 +518,8 @@
   <data name="GitChanges.LoadError" xml:space="preserve"><value>Failed to get changed files</value></data>
   <data name="GitChanges.CountFormat" xml:space="preserve"><value>{0} changed file(s)</value></data>
   <data name="GitChanges.Refresh" xml:space="preserve"><value>Refresh</value></data>
+  <data name="GitChanges.CopyPaths" xml:space="preserve"><value>Copy paths</value></data>
+  <data name="GitChanges.Copied" xml:space="preserve"><value>Copied</value></data>
   <data name="GitChanges.Staged" xml:space="preserve"><value>Staged</value></data>
   <data name="GitChanges.Status.Untracked" xml:space="preserve"><value>Untracked</value></data>
   <data name="GitChanges.Status.Modified" xml:space="preserve"><value>Modified</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -151,6 +151,8 @@
   <data name="Settings.Sessions.Display.ShowTerminalTypeSub" xml:space="preserve"><value>Claude/Gemini/Codexバッジ</value></data>
   <data name="Settings.Sessions.Display.ShowGitInfo" xml:space="preserve"><value>Git情報を表示</value></data>
   <data name="Settings.Sessions.Display.ShowGitInfoSub" xml:space="preserve"><value>ブランチ名バッジ</value></data>
+  <data name="Settings.Sessions.Display.GitChangesOnBadgeClick" xml:space="preserve"><value>Gitの変更状態をバッジクリックで表示</value></data>
+  <data name="Settings.Sessions.Display.GitChangesOnBadgeClickSub" xml:space="preserve"><value>変更ファイル一覧を表示。変更なしはトースト通知</value></data>
   <data name="Settings.Sessions.Display.Help" xml:space="preserve"><value>セッション一覧に表示する追加情報を選択できます。</value></data>
   <data name="Settings.Sessions.InputPanel.Label" xml:space="preserve"><value>入力パネル設定</value></data>
   <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>入力パネルを非表示</value></data>
@@ -508,6 +510,8 @@
   <data name="SessionList.Badge.GitBranch" xml:space="preserve"><value>Git ブランチ</value></data>
   <data name="SessionList.Badge.UncommittedChanges" xml:space="preserve"><value>未コミットの変更があります</value></data>
   <data name="SessionList.Badge.GitBranchClickHint" xml:space="preserve"><value>クリックで変更ファイル一覧を表示</value></data>
+  <data name="SessionList.Toast.NoGitChangesFormat" xml:space="preserve"><value>{0}: 未コミットの変更はありません</value></data>
+  <data name="SessionList.Toast.GitStatusError" xml:space="preserve"><value>Gitの変更状態を取得できませんでした</value></data>
   <data name="GitChanges.Title" xml:space="preserve"><value>Git 変更ファイル</value></data>
   <data name="GitChanges.Loading" xml:space="preserve"><value>読み込み中…</value></data>
   <data name="GitChanges.NoChanges" xml:space="preserve"><value>未コミットの変更はありません</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -518,6 +518,8 @@
   <data name="GitChanges.LoadError" xml:space="preserve"><value>変更ファイル一覧の取得に失敗しました</value></data>
   <data name="GitChanges.CountFormat" xml:space="preserve"><value>{0} 件の変更</value></data>
   <data name="GitChanges.Refresh" xml:space="preserve"><value>更新</value></data>
+  <data name="GitChanges.CopyPaths" xml:space="preserve"><value>パスをコピー</value></data>
+  <data name="GitChanges.Copied" xml:space="preserve"><value>コピーしました</value></data>
   <data name="GitChanges.Staged" xml:space="preserve"><value>ステージ済み</value></data>
   <data name="GitChanges.Status.Untracked" xml:space="preserve"><value>未追跡</value></data>
   <data name="GitChanges.Status.Modified" xml:space="preserve"><value>変更</value></data>


### PR DESCRIPTION
## 概要
Git バッジクリックの変更ファイル一覧（PR #97）の使い勝手改善。

## 変更内容

### 1. バッジクリックのオプション化
- 設定 > セッション > 表示 の「Git情報を表示」にサブオプション「**Gitの変更状態をバッジクリックで表示**」を追加（既定 OFF、親が OFF のときはグレーアウト）
- オプション OFF ではバッジは PR #97 以前の挙動に戻る（クリックはセッション選択として作用）

### 2. 変更なしはトースト通知
- クリック時に先に git status を実行し、**変更 0 件ならダイアログを開かずトースト**「{ブランチ}: 未コミットの変更はありません」＋赤丸を消灯
- 変更ありは従来どおりダイアログ表示。クリック時の取得結果を初期表示に渡し、git status の二重実行を回避（更新ボタンは取り直し）
- 取得失敗時はエラートースト

### 3. パスコピー
- 変更一覧ダイアログに「パスをコピー」ボタンを追加。相対パスを改行区切りでクリップボードへ（AIへの貼り付け等を想定）。リネームは新パス側

## 動作確認
- ビルド 0警告0エラー
- 実機確認済み（オプション ON/OFF・変更なしトースト・赤丸消灯・パスコピー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)