### PR TITLE
feat: ターミナル内URLのタップでコピーするモード＋モバイル向け表示改善

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -519,6 +519,8 @@
                 terminalFontSize = localDisplay?.TerminalFontSize ?? appSettings.General.TerminalFontSize;
                 terminalHeightPercent = localDisplay?.TerminalHeightPercent ?? appSettings.General.TerminalHeightPercent;
                 sidebarWidthPercent = localDisplay?.SidebarWidthPercent ?? appSettings.General.SidebarWidthPercent;
+                // ターミナル内URLのコピー動作モード（このデバイス専用、シード無し）を JS 側へ反映
+                await JSRuntime.InvokeVoidAsync("setTerminalLinkCopyMode", localDisplay?.TerminalLinkCopyMode ?? false);
                 if (localDisplay == null)
                 {
                     // 初回アクセス: 現在のサーバー側設定をこのデバイスの初期値として保存

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -325,7 +325,7 @@
                                     <label class="form-label">@L["Settings.Display.SidebarWidth.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
-                                               min="15" max="40" step="1"
+                                               min="15" max="70" step="1"
                                                value="@sidebarWidthPercent"
                                                @oninput="OnSidebarWidthPercentSliderInput" />
                                         <span class="badge bg-secondary" style="min-width: 60px;">@(sidebarWidthPercent)%</span>

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -322,18 +322,6 @@
                                 </div>
 
                                 <div class="mb-4">
-                                    <div class="form-check">
-                                        <input class="form-check-input" type="checkbox" @bind="terminalLinkCopyMode" id="terminalLinkCopyMode">
-                                        <label class="form-check-label" for="terminalLinkCopyMode">
-                                            <i class="bi bi-clipboard me-1"></i>@L["Settings.Display.TerminalLinkCopyMode.Label"]
-                                        </label>
-                                    </div>
-                                    <small class="text-muted">
-                                        @L["Settings.Display.TerminalLinkCopyMode.Help"]
-                                    </small>
-                                </div>
-
-                                <div class="mb-4">
                                     <label class="form-label">@L["Settings.Display.SidebarWidth.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
@@ -358,6 +346,18 @@
                                     </div>
                                     <small class="text-muted">
                                         @L["Settings.Display.TerminalHeightRatio.Help"]
+                                    </small>
+                                </div>
+
+                                <div class="mb-4">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" @bind="terminalLinkCopyMode" id="terminalLinkCopyMode">
+                                        <label class="form-check-label" for="terminalLinkCopyMode">
+                                            <i class="bi bi-clipboard me-1"></i>@L["Settings.Display.TerminalLinkCopyMode.Label"]
+                                        </label>
+                                    </div>
+                                    <small class="text-muted">
+                                        @L["Settings.Display.TerminalLinkCopyMode.Help"]
                                     </small>
                                 </div>
                             </div>

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -322,6 +322,18 @@
                                 </div>
 
                                 <div class="mb-4">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" @bind="terminalLinkCopyMode" id="terminalLinkCopyMode">
+                                        <label class="form-check-label" for="terminalLinkCopyMode">
+                                            <i class="bi bi-clipboard me-1"></i>@L["Settings.Display.TerminalLinkCopyMode.Label"]
+                                        </label>
+                                    </div>
+                                    <small class="text-muted">
+                                        @L["Settings.Display.TerminalLinkCopyMode.Help"]
+                                    </small>
+                                </div>
+
+                                <div class="mb-4">
                                     <label class="form-label">@L["Settings.Display.SidebarWidth.Label"]</label>
                                     <div class="d-flex align-items-center gap-3">
                                         <input type="range" class="form-range flex-grow-1"
@@ -1245,6 +1257,7 @@
     private bool showGitInfo = false;
     private bool gitChangesOnBadgeClick = false;
     private bool hideInputPanel = false;
+    private bool terminalLinkCopyMode = false;
     private string defaultFolderPath = "";
     private string? defaultFolderPathWarning = null;
     private List<string> favoriteFolders = new();
@@ -1419,6 +1432,8 @@
             terminalFontSize = localDisplay?.TerminalFontSize ?? settings.General.TerminalFontSize;
             terminalHeightPercent = localDisplay?.TerminalHeightPercent ?? settings.General.TerminalHeightPercent;
             sidebarWidthPercent = localDisplay?.SidebarWidthPercent ?? settings.General.SidebarWidthPercent;
+            // ターミナル内URLのコピー動作モードはこのデバイス専用（app-settings のシード無し）
+            terminalLinkCopyMode = localDisplay?.TerminalLinkCopyMode ?? false;
 
             // カスタムコマンド
             editingCommands = settings.Commands.CommandsByTerminalType
@@ -1696,7 +1711,11 @@
                 TerminalFontSize = terminalFontSize,
                 TerminalHeightPercent = terminalHeightPercent,
                 SidebarWidthPercent = sidebarWidthPercent,
+                TerminalLinkCopyMode = terminalLinkCopyMode,
             });
+
+            // ターミナル内URLのコピー動作モードを即時反映（再読み込み不要にする）
+            await JSRuntime.InvokeVoidAsync("setTerminalLinkCopyMode", terminalLinkCopyMode);
 
             // 音声入力・カーソルパッド自動切替もデバイス別設定として LocalStorage に保存する
             // (app-settings 側の VoiceInputEnabled は新デバイス初回アクセス時のシードとして機能する)

--- a/TerminalHub/Models/LocalDisplaySettings.cs
+++ b/TerminalHub/Models/LocalDisplaySettings.cs
@@ -15,5 +15,12 @@ namespace TerminalHub.Models
         public int? TerminalFontSize { get; set; }
         public int? SidebarWidthPercent { get; set; }
         public int? TerminalHeightPercent { get; set; }
+
+        /// <summary>
+        /// ターミナル内URLのタップ/クリックで開かずにクリップボードへコピーする。
+        /// モバイル全画面(ホーム画面ショートカット等)では遷移すると戻れなくなるための逃げ道。
+        /// このデバイス専用設定で、app-settings 側のフォールバック値は持たない (null=false 扱い)。
+        /// </summary>
+        public bool? TerminalLinkCopyMode { get; set; }
     }
 }

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -110,6 +110,8 @@
   <data name="Settings.Display.SessionListScale.Help" xml:space="preserve"><value>Scale of the session list (50%–150%).</value></data>
   <data name="Settings.Display.TerminalFontSize.Label" xml:space="preserve"><value>Terminal font size</value></data>
   <data name="Settings.Display.TerminalFontSize.Help" xml:space="preserve"><value>Size of terminal text (8px–28px).</value></data>
+  <data name="Settings.Display.TerminalLinkCopyMode.Label" xml:space="preserve"><value>Copy terminal URLs on tap (don't open)</value></data>
+  <data name="Settings.Display.TerminalLinkCopyMode.Help" xml:space="preserve"><value>For fullscreen mobile shortcuts where you can't navigate back. Saved per device (browser).</value></data>
   <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>Sidebar width</value></data>
   <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>Width of the session list (15%–40%). You can also drag the border.</value></data>
   <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>Terminal / input panel ratio</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -113,7 +113,7 @@
   <data name="Settings.Display.TerminalLinkCopyMode.Label" xml:space="preserve"><value>Copy terminal URLs on tap (don't open)</value></data>
   <data name="Settings.Display.TerminalLinkCopyMode.Help" xml:space="preserve"><value>For fullscreen mobile shortcuts where you can't navigate back. Saved per device (browser).</value></data>
   <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>Sidebar width</value></data>
-  <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>Width of the session list (15%–40%). You can also drag the border.</value></data>
+  <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>Width of the session list (15%–70%). You can also drag the border.</value></data>
   <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>Terminal / input panel ratio</value></data>
   <data name="Settings.Display.TerminalHeightRatio.Help" xml:space="preserve"><value>Height split between terminal and input panel (50:50–90:10). Drag the border to adjust.</value></data>
 

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -110,6 +110,8 @@
   <data name="Settings.Display.SessionListScale.Help" xml:space="preserve"><value>表示倍率（50%〜150%）。</value></data>
   <data name="Settings.Display.TerminalFontSize.Label" xml:space="preserve"><value>ターミナルフォントサイズ</value></data>
   <data name="Settings.Display.TerminalFontSize.Help" xml:space="preserve"><value>フォントサイズ（8px〜28px）。</value></data>
+  <data name="Settings.Display.TerminalLinkCopyMode.Label" xml:space="preserve"><value>ターミナル内URLをタップでコピーする（開かない）</value></data>
+  <data name="Settings.Display.TerminalLinkCopyMode.Help" xml:space="preserve"><value>モバイルの全画面表示など、リンク先から戻れない環境向け。この端末（ブラウザ）にのみ保存されます。</value></data>
   <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>サイドバー幅</value></data>
   <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>幅（15%〜40%）。境界線のドラッグでも変更可能。</value></data>
   <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>ターミナル / 入力パネル比率</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -113,7 +113,7 @@
   <data name="Settings.Display.TerminalLinkCopyMode.Label" xml:space="preserve"><value>ターミナル内URLをタップでコピーする（開かない）</value></data>
   <data name="Settings.Display.TerminalLinkCopyMode.Help" xml:space="preserve"><value>モバイルの全画面表示など、リンク先から戻れない環境向け。この端末（ブラウザ）にのみ保存されます。</value></data>
   <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>サイドバー幅</value></data>
-  <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>幅（15%〜40%）。境界線のドラッグでも変更可能。</value></data>
+  <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>幅（15%〜70%）。境界線のドラッグでも変更可能。</value></data>
   <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>ターミナル / 入力パネル比率</value></data>
   <data name="Settings.Display.TerminalHeightRatio.Help" xml:space="preserve"><value>高さ比率（50:50〜90:10）。境界線のドラッグでも変更可能。</value></data>
 

--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -600,13 +600,15 @@ h1:focus {
         z-index: 999;
     }
 
-    /* サイドバー - モバイル用 */
+    /* サイドバー - モバイル用
+       幅はインラインの width(設定のサイドバー幅%)が優先される。
+       max-width で頭打ちにすると設定を広げても効かないため上限は設けない */
     .session-list-sidebar {
         position: fixed;
         top: 0;
         left: 0;
         width: 85%;
-        max-width: 320px;
+        max-width: none;
         height: 100%;
         z-index: 1000;
         transform: translateX(-100%);

--- a/TerminalHub/wwwroot/js/helpers.js
+++ b/TerminalHub/wwwroot/js/helpers.js
@@ -349,7 +349,7 @@ window.terminalHubHelpers = {
                 const rect = container.getBoundingClientRect();
                 const x = e.clientX - rect.left;
                 let percent = Math.round((x / rect.width) * 100);
-                percent = Math.max(15, Math.min(40, percent));
+                percent = Math.max(15, Math.min(70, percent)); // 上限はモバイルで広く使いたい要望に合わせ70%
 
                 const sidebar = container.querySelector('.session-list-sidebar');
                 if (sidebar) sidebar.style.width = percent + '%';

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -280,8 +280,15 @@ function activateTerminalLink(uri) {
     }
 }
 
-// URLをクリップボードにコピーして画面下部に通知を出す
+// URLをクリップボードにコピーして通知を出す
 function copyLinkToClipboard(uri) {
+    // タップでターミナル(の隠しtextarea)にフォーカスが移り、モバイルでは
+    // ソフトウェアキーボードが開いてしまう。コピーモードでは入力する意図が
+    // 無いので、フォーカスを外してキーボードの出現を抑止する。
+    if (document.activeElement && typeof document.activeElement.blur === 'function') {
+        document.activeElement.blur();
+    }
+
     const notify = (ok) => showLinkCopyNotice(uri, ok);
     if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(uri).then(() => notify(true)).catch(() => notify(false));
@@ -291,13 +298,14 @@ function copyLinkToClipboard(uri) {
 }
 
 // コピー結果の軽量トースト（Blazor を介さず JS だけで完結させる）
+// キーボードや下部パネルに隠れないよう画面上部に表示する
 function showLinkCopyNotice(uri, success) {
     const existing = document.getElementById('terminal-link-copy-notice');
     if (existing) existing.remove();
 
     const div = document.createElement('div');
     div.id = 'terminal-link-copy-notice';
-    div.style.cssText = 'position:fixed;left:50%;bottom:24px;transform:translateX(-50%);' +
+    div.style.cssText = 'position:fixed;left:50%;top:16px;transform:translateX(-50%);' +
         'max-width:90vw;padding:8px 16px;border-radius:8px;z-index:3000;' +
         'font-size:0.85rem;color:#fff;box-shadow:0 2px 8px rgba(0,0,0,.4);' +
         'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;' +

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -263,13 +263,60 @@ class FlowControlManager {
 // グローバルフロー制御マネージャー
 window.flowControlManager = new FlowControlManager();
 
+// ターミナル内リンクの動作モード（true = 開かずにURLをコピーする）。
+// モバイル全画面（ホーム画面ショートカット等）では遷移すると戻れなくなるため、
+// デバイス別設定として Blazor 側から setTerminalLinkCopyMode で反映される。
+let terminalLinkCopyMode = false;
+window.setTerminalLinkCopyMode = function (enabled) {
+    terminalLinkCopyMode = !!enabled;
+};
+
+// リンクのアクティベート処理（WebLinksAddon / フォールバック共通）
+function activateTerminalLink(uri) {
+    if (terminalLinkCopyMode) {
+        copyLinkToClipboard(uri);
+    } else {
+        window.open(uri, '_blank', 'noopener,noreferrer');
+    }
+}
+
+// URLをクリップボードにコピーして画面下部に通知を出す
+function copyLinkToClipboard(uri) {
+    const notify = (ok) => showLinkCopyNotice(uri, ok);
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(uri).then(() => notify(true)).catch(() => notify(false));
+    } else {
+        notify(false);
+    }
+}
+
+// コピー結果の軽量トースト（Blazor を介さず JS だけで完結させる）
+function showLinkCopyNotice(uri, success) {
+    const existing = document.getElementById('terminal-link-copy-notice');
+    if (existing) existing.remove();
+
+    const div = document.createElement('div');
+    div.id = 'terminal-link-copy-notice';
+    div.style.cssText = 'position:fixed;left:50%;bottom:24px;transform:translateX(-50%);' +
+        'max-width:90vw;padding:8px 16px;border-radius:8px;z-index:3000;' +
+        'font-size:0.85rem;color:#fff;box-shadow:0 2px 8px rgba(0,0,0,.4);' +
+        'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;' +
+        (success ? 'background:#198754;' : 'background:#dc3545;');
+    div.textContent = success
+        ? `📋 URLをコピーしました: ${uri}`
+        : `URLをコピーできませんでした: ${uri}`;
+    document.body.appendChild(div);
+    setTimeout(() => div.remove(), 3000);
+}
+
 // URL検出の設定
 function setupUrlDetection(term) {
     // WebLinksAddonが利用可能か確認
     if (typeof WebLinksAddon !== 'undefined' && WebLinksAddon.WebLinksAddon) {
         try {
             // WebLinksAddonを作成（URLをクリック可能にする）
-            const webLinksAddon = new WebLinksAddon.WebLinksAddon();
+            // 既定ハンドラは直接 window.open するため、コピー動作モードを差し込めるようカスタムハンドラを渡す
+            const webLinksAddon = new WebLinksAddon.WebLinksAddon((event, uri) => activateTerminalLink(uri));
             term.loadAddon(webLinksAddon);
             console.log('[URL Detection] WebLinksAddon loaded successfully');
         } catch (error) {
@@ -322,7 +369,7 @@ function setupUrlDetectionFallback(term) {
                         text: match[0],
                         activate: (e, uri) => {
                             console.log('[URL Detection] Link activated:', uri);
-                            window.open(uri, '_blank');
+                            activateTerminalLink(uri);
                         }
                     };
                     links.push(link);


### PR DESCRIPTION
## 概要
モバイル全画面（ホーム画面ショートカット等）での利用改善。リンク遷移で戻れなくなる問題への対処と、サイドバー幅の上限拡大。

## 変更内容

### 1. ターミナル内URLをタップでコピーするモード（デバイス別設定）
- モバイル全画面ではリンク遷移すると戻るUIが無く、Blazor Server の回線も切れて詰むため、**開かずにクリップボードへコピーする動作**を選べるようにした
- 設定 > 表示 に「ターミナル内URLをタップでコピーする（開かない）」を追加（既定OFF、スライダー4つの後ろに配置）
- 保存先は LocalDisplaySettings（LocalStorage・デバイス別）。PC=OFF / モバイル=ON の使い分けを想定。app-settings へのシードは無し
- ON時: WebLinksAddon のカスタムハンドラでコピー＋JS製トースト「📋 URLをコピーしました」を3秒表示（Blazor非依存）。フォールバック実装にも適用
- OFF時: 従来どおり新規タブ（`noopener,noreferrer` を明示するよう改善）
- 設定保存で即時反映（リロード不要）

### 2. サイドバー幅の上限を40%→70%に拡大
- モバイルでセッション一覧を広く使いたい要望に対応
- スライダー・スプリッタードラッグのクランプ・ヘルプ文言（ja/en）を揃えて変更

## 動作確認
- ビルド 0警告0エラー
- 実機確認済み（コピーモードON/OFF・トースト表示・設定位置・サイドバー幅70%）

🤖 Generated with [Claude Code](https://claude.com/claude-code)