### PR TITLE
fix: Gitバッジのクリック領域を目印(赤丸+Gitアイコン)に集約

### DIFF
--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -125,17 +125,16 @@
                                    変更 0 件のときはダイアログを開かずトーストで知らせる。 *@
                                 <span class="badge @(session.IsWorktree ? "bg-warning" : "bg-success") ms-1"
                                       title="@GetGitBadgeTitle(session)">
-                                    <span style="@(GitChangesOnBadgeClick ? "cursor: pointer;" : "")"
+                                    <span class="me-1" style="@(GitChangesOnBadgeClick ? "cursor: pointer;" : "")"
                                           @onclick:stopPropagation="GitChangesOnBadgeClick"
                                           @onclick="async () => await OpenGitChangesAsync(session)">
-                                        @* 赤丸（未コミット変更）を先頭に配置 *@
+                                        @* Gitアイコンを先頭に固定（左端がブレない）、赤丸（未コミット変更）をその後ろに配置 *@
+                                        <i class="bi bi-git"></i>
                                         @if (session.HasUncommittedChanges)
                                         {
-                                            <i class="bi bi-circle-fill text-danger git-status-indicator me-1" title="@L["SessionList.Badge.UncommittedChanges"]"></i>
+                                            <i class="bi bi-circle-fill text-danger git-status-indicator ms-1" title="@L["SessionList.Badge.UncommittedChanges"]"></i>
                                         }
-                                        <i class="bi bi-git"></i>
-                                    </span>
-                                    <span class="ms-1">@session.GitBranch</span>
+                                    </span>@session.GitBranch
                                 </span>
                             }
                             @if (!string.IsNullOrEmpty(session.RemoteControlUrl))

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -120,18 +120,22 @@
                             }
                             @if (ShowGitInfo && session.IsGitRepository && !string.IsNullOrEmpty(session.GitBranch))
                             {
-                                @* オプション有効時のみクリックで変更ファイル一覧を表示（stopPropagation でセッション選択を抑止）。
+                                @* クリック領域は赤丸＋Gitアイコンのみに限定（ブランチ名クリックでは履歴を開かない）。
+                                   オプション有効時のみクリックで変更ファイル一覧を表示（stopPropagation でセッション選択を抑止）。
                                    変更 0 件のときはダイアログを開かずトーストで知らせる。 *@
                                 <span class="badge @(session.IsWorktree ? "bg-warning" : "bg-success") ms-1"
-                                      style="@(GitChangesOnBadgeClick ? "cursor: pointer;" : "")"
-                                      title="@GetGitBadgeTitle(session)"
-                                      @onclick:stopPropagation="GitChangesOnBadgeClick"
-                                      @onclick="async () => await OpenGitChangesAsync(session)">
-                                    <i class="bi @(session.IsWorktree ? "bi-git" : "bi-git") me-1"></i>@session.GitBranch
-                                    @if (session.HasUncommittedChanges)
-                                    {
-                                        <i class="bi bi-circle-fill text-danger git-status-indicator" title="@L["SessionList.Badge.UncommittedChanges"]"></i>
-                                    }
+                                      title="@GetGitBadgeTitle(session)">
+                                    <span style="@(GitChangesOnBadgeClick ? "cursor: pointer;" : "")"
+                                          @onclick:stopPropagation="GitChangesOnBadgeClick"
+                                          @onclick="async () => await OpenGitChangesAsync(session)">
+                                        @* 赤丸（未コミット変更）を先頭に配置 *@
+                                        @if (session.HasUncommittedChanges)
+                                        {
+                                            <i class="bi bi-circle-fill text-danger git-status-indicator me-1" title="@L["SessionList.Badge.UncommittedChanges"]"></i>
+                                        }
+                                        <i class="bi bi-git"></i>
+                                    </span>
+                                    <span class="ms-1">@session.GitBranch</span>
                                 </span>
                             }
                             @if (!string.IsNullOrEmpty(session.RemoteControlUrl))


### PR DESCRIPTION
## 背景 / 課題

Git バッジは全体がクリック領域になっており、`GitChangesOnBadgeClick` 有効時はバッジ内のどこ（ブランチ名テキスト含む）をクリックしても変更ファイル一覧（履歴）ダイアログが開く。

長いブランチ名だと避けるべき範囲が広く、**ブランチ名を無意識にクリックして履歴が開いてしまう誤爆**が起きやすかった。また「目印」が Git アイコン（先頭）と赤丸（末尾）に分かれて付いていた。

## 変更内容

`SessionList.razor` の Git バッジを次のように調整:

- **赤丸（未コミット変更マーク）を先頭へ移動**し、Git アイコンと隣接させて目印を集約（`赤丸 → Gitアイコン → ブランチ名`）
- **クリック（履歴表示）領域を「赤丸＋Gitアイコン」の塊のみに限定**（内側 `<span>` に `@onclick` + `stopPropagation` を寄せる）
- **ブランチ名テキストはクリック対象外**とし、クリックは行選択に伝播（＝行の他の場所を押したのと同じ、誤爆防止）

## 動作イメージ

```
変更前:  [🔵Git] main            ← バッジ全体が履歴クリック領域（赤丸は末尾）
変更後:  [🔴 🔵Git] main
         └クリック領域┘ └テキスト（履歴は開かない／行選択に伝播）
```

## テスト

- `dotnet build` 成功（0 warning / 0 error）
- 実機でのクリック挙動確認は別途実施予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
