### PR TITLE
fix: DB既定を IsDevelopment 連動にして dev で本番DBを触らないようにする

### DIFF
--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -76,10 +76,15 @@ builder.Services.AddSingleton<ISessionManager, SessionManager>();
 builder.Services.AddScoped<ILocalStorageService, LocalStorageService>();
 
 // SQLiteセッションストレージを登録
-var dbFileName = builder.Configuration.GetValue<string>("Database:FileName") ?? "sessions.db";
-var dbPath = Path.Combine(AppDataPaths.UserDataRoot, dbFileName);
+// DB パスは logs / app-settings と同様に IsDevelopment で既定を切り替える
+// (dev=sessions-dev.db / prod=sessions.db)。Database:FileName 設定があればそれを優先。
+// これにより appsettings.Development.json が無い環境 (別 worktree 等) の Development 実行でも
+// 本番 DB (sessions.db) を誤って触らない。
+var dbPath = AppDataPaths.GetDatabaseFilePath(
+    builder.Environment.IsDevelopment(),
+    builder.Configuration.GetValue<string>("Database:FileName"));
 builder.Logging.AddFilter("TerminalHub.Services.SessionDbContext", LogLevel.Debug);
-Console.WriteLine($"[DB][起動時診断] 使用するDB: Environment={builder.Environment.EnvironmentName} / FileName={dbFileName} / FullPath={dbPath}");
+Console.WriteLine($"[DB][起動時診断] 使用するDB: Environment={builder.Environment.EnvironmentName} / FullPath={dbPath}");
 builder.Services.AddSingleton<SessionDbContext>(sp =>
 {
     var logger = sp.GetRequiredService<ILogger<SessionDbContext>>();

--- a/TerminalHub/Services/AppDataPaths.cs
+++ b/TerminalHub/Services/AppDataPaths.cs
@@ -45,5 +45,21 @@ namespace TerminalHub.Services
                 : (isDevelopment ? "app-settings-dev.json" : "app-settings.json");
             return Path.Combine(UserDataRoot, fileName);
         }
+
+        /// <summary>
+        /// SQLite DB のフルパス。dev では "sessions-dev.db"、prod では "sessions.db"。
+        /// configOverride が指定されていればそちらを優先する (Database:FileName 等)。
+        ///
+        /// logs / app-settings と同じく IsDevelopment で既定を切り替えることで、
+        /// appsettings.Development.json (gitignore 対象) が無い環境 (別 worktree / 新規クローン) で
+        /// Development 実行しても本番 DB (sessions.db) を触らない。設定ファイルの有無に DB 安全性を依存させない。
+        /// </summary>
+        public static string GetDatabaseFilePath(bool isDevelopment, string? configOverride = null)
+        {
+            var fileName = !string.IsNullOrWhiteSpace(configOverride)
+                ? configOverride
+                : (isDevelopment ? "sessions-dev.db" : "sessions.db");
+            return Path.Combine(UserDataRoot, fileName);
+        }
     }
 }


### PR DESCRIPTION
## 背景 / 課題

DB パスの決定だけ、logs / app-settings と違って **dev/prod の自動切替が無かった**:

```csharp
var dbFileName = builder.Configuration.GetValue<string>("Database:FileName") ?? "sessions.db";
```

`Database:FileName` を指定しているのは **`appsettings.Development.json`**（`.gitignore` 対象）で、**別 worktree / 新規クローンには存在しない**。そのため、そこで Development 実行すると設定が無く `sessions.db`（本番の普段使いDB）にフォールバックし、**本番セッションDBを誤って読み書きする**事故につながっていた。

（実際に、worktree から `dotnet run` すると本番 DB を見ていることを確認）

## 変更内容

- `AppDataPaths.GetDatabaseFilePath(isDevelopment, configOverride)` を追加。logs / app-settings と同じ方式で **dev=`sessions-dev.db` / prod=`sessions.db`** を既定に。`Database:FileName` 設定があればそれを優先
- `Program.cs` を上記ヘルパー経由に変更

これで**設定ファイルの有無に DB 安全性を依存させない**（ファイルが在っても無くても、Development 実行は本番DBを触らない）。

## 補足（この PR 外・ローカル作業）

- `appsettings.Development.json`（gitignore）から **MQTT 認証情報を除去**し、`dotnet user-secrets`（リポジトリ外・per-user）へ移動。非秘密の dev 設定は従来どおり `appsettings.Development.json`、秘密は user-secrets、という住み分けに整理
- gitignore 方針は維持（秘密をコミットしないため）

## テスト

- `dotnet build` 成功（0 warning / 0 error）
- 起動時診断ログ `[DB][起動時診断] 使用するDB: ...` で実DBパスを確認可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)
