### PR TITLE
docs: list_sessions の説明から内部概念「アーカイブ」を出さない

### DIFF
--- a/TerminalHub/Mcp/SessionMessagingTools.cs
+++ b/TerminalHub/Mcp/SessionMessagingTools.cs
@@ -36,7 +36,7 @@ namespace TerminalHub.Mcp
 
         [McpServerTool(Name = "list_sessions")]
         [Description(
-            "TerminalHub が管理中の(アーカイブでない)セッション一覧を返す。send_to_session の宛先を選ぶために使う。" +
+            "TerminalHub が管理中のセッション一覧を返す。send_to_session の宛先を選ぶために使う。" +
             "任意のフィルタ引数で絞り込める。各項目の status は ready(受付中=送信可。作業中でも相手CLIのキューに積まれる) / " +
             "waiting_user_input(ユーザーの許可/選択待ち=送信不可) / not_ready(ConPTY未接続=起動が必要・送信不可)。")]
         public static IEnumerable<SessionSummary> ListSessions(


### PR DESCRIPTION
## 変更内容

`list_sessions` の MCP ツール説明から「(アーカイブでない)」を外し、「TerminalHub が管理中のセッション一覧を返す」に変更。

- アーカイブ除外は内部実装（`GetActiveSessions` が `!IsArchived` で除外）のままで挙動は不変
- 「アーカイブ」は外部（MCP クライアント/モデル）に見せる必要のない内部概念なので、説明文言から外す

## テスト
- `dotnet build` 成功（0 warning / 0 error）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
