### PR TITLE
feat: ターミナル内のファイル/フォルダ表記をクリックで開けるように

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -745,35 +745,49 @@
                 return Task.CompletedTask;
 
             var trimmed = path.Trim();
-            string fullPath;
-            try
+
+            // 候補パスを解決して実在すれば開く（フォルダ=エクスプローラー / ファイル=既定アプリ）
+            bool TryOpen(string candidate)
             {
-                fullPath = System.IO.Path.IsPathRooted(trimmed)
-                    ? System.IO.Path.GetFullPath(trimmed)
-                    : System.IO.Path.GetFullPath(System.IO.Path.Combine(basePath, trimmed));
-            }
-            catch
-            {
-                // 不正なパス文字等は黙って無視（誤検出クリックの可能性が高い）
-                return Task.CompletedTask;
+                string fullPath;
+                try
+                {
+                    fullPath = System.IO.Path.IsPathRooted(candidate)
+                        ? System.IO.Path.GetFullPath(candidate)
+                        : System.IO.Path.GetFullPath(System.IO.Path.Combine(basePath, candidate));
+                }
+                catch
+                {
+                    // 不正なパス文字等は開けない扱い（誤検出クリックの可能性が高い）
+                    return false;
+                }
+
+                if (Directory.Exists(fullPath))
+                {
+                    ExplorerLauncher.OpenFolder(fullPath);
+                    return true;
+                }
+                if (File.Exists(fullPath))
+                {
+                    // ファイルは既定のアプリで開く
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = fullPath,
+                        UseShellExecute = true,
+                    });
+                    return true;
+                }
+                return false;
             }
 
-            if (Directory.Exists(fullPath))
+            if (!TryOpen(trimmed))
             {
-                ExplorerLauncher.OpenFolder(fullPath);
-            }
-            else if (File.Exists(fullPath))
-            {
-                // ファイルは既定のアプリで開く
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                // Root.razor:123 のような行番号付き表記は末尾の :数字 を落として再試行
+                var withoutLineNumber = System.Text.RegularExpressions.Regex.Replace(trimmed, @"(?::\d+)+$", "");
+                if (withoutLineNumber == trimmed || !TryOpen(withoutLineNumber))
                 {
-                    FileName = fullPath,
-                    UseShellExecute = true,
-                });
-            }
-            else
-            {
-                toast?.ShowWarning(string.Format(L["Root.Toast.PathNotFoundFormat"], trimmed));
+                    toast?.ShowWarning(string.Format(L["Root.Toast.PathNotFoundFormat"], trimmed));
+                }
             }
         }
         catch (Exception ex)

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -30,6 +30,7 @@
 @inject IStorageServiceFactory StorageServiceFactory
 @inject IAppSettingsService AppSettingsService
 @inject IRawStreamCaptureService RawStreamCapture
+@inject IExplorerLauncherService ExplorerLauncher
 @implements IAsyncDisposable
 @rendermode InteractiveServer
 
@@ -723,6 +724,63 @@
         {
             await SelectSession(guid);
         }
+    }
+
+    /// <summary>
+    /// ターミナル内のファイル/フォルダ表記クリック時の処理（terminal.js のパス検出から呼ばれる）。
+    /// セッションの作業フォルダ基準で相対パスを解決し、フォルダはエクスプローラーで、
+    /// ファイルは既定のアプリで開く。見つからなければトーストで知らせる。
+    /// </summary>
+    [JSInvokable]
+    public Task OnTerminalPathClick(string sessionId, string path)
+    {
+        try
+        {
+            if (!Guid.TryParse(sessionId, out var guid))
+                return Task.CompletedTask;
+
+            var session = sessions.FirstOrDefault(s => s.SessionId == guid);
+            var basePath = session?.FolderPath;
+            if (string.IsNullOrEmpty(basePath) || string.IsNullOrWhiteSpace(path))
+                return Task.CompletedTask;
+
+            var trimmed = path.Trim();
+            string fullPath;
+            try
+            {
+                fullPath = System.IO.Path.IsPathRooted(trimmed)
+                    ? System.IO.Path.GetFullPath(trimmed)
+                    : System.IO.Path.GetFullPath(System.IO.Path.Combine(basePath, trimmed));
+            }
+            catch
+            {
+                // 不正なパス文字等は黙って無視（誤検出クリックの可能性が高い）
+                return Task.CompletedTask;
+            }
+
+            if (Directory.Exists(fullPath))
+            {
+                ExplorerLauncher.OpenFolder(fullPath);
+            }
+            else if (File.Exists(fullPath))
+            {
+                // ファイルは既定のアプリで開く
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = fullPath,
+                    UseShellExecute = true,
+                });
+            }
+            else
+            {
+                toast?.ShowWarning(string.Format(L["Root.Toast.PathNotFoundFormat"], trimmed));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "[PathClick] パスを開けませんでした: {Path}", path);
+        }
+        return Task.CompletedTask;
     }
 
     private async Task AddSession()

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -110,8 +110,8 @@
   <data name="Settings.Display.SessionListScale.Help" xml:space="preserve"><value>Scale of the session list (50%–150%).</value></data>
   <data name="Settings.Display.TerminalFontSize.Label" xml:space="preserve"><value>Terminal font size</value></data>
   <data name="Settings.Display.TerminalFontSize.Help" xml:space="preserve"><value>Size of terminal text (8px–28px).</value></data>
-  <data name="Settings.Display.TerminalLinkCopyMode.Label" xml:space="preserve"><value>Copy terminal URLs on tap (don't open)</value></data>
-  <data name="Settings.Display.TerminalLinkCopyMode.Help" xml:space="preserve"><value>For fullscreen mobile shortcuts where you can't navigate back. Saved per device (browser).</value></data>
+  <data name="Settings.Display.TerminalLinkCopyMode.Label" xml:space="preserve"><value>Copy terminal URLs and paths on tap (don't open)</value></data>
+  <data name="Settings.Display.TerminalLinkCopyMode.Help" xml:space="preserve"><value>For fullscreen mobile shortcuts where you can't navigate back. File/folder paths are copied too. Saved per device (browser).</value></data>
   <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>Sidebar width</value></data>
   <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>Width of the session list (15%–70%). You can also drag the border.</value></data>
   <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>Terminal / input panel ratio</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -595,6 +595,7 @@
   <!-- Root: Toast messages -->
   <data name="Root.Toast.SessionCreateErrorFormat" xml:space="preserve"><value>Session creation error: {0}</value></data>
   <data name="Root.Toast.SessionInitErrorFormat" xml:space="preserve"><value>Session initialization error: {0}</value></data>
+  <data name="Root.Toast.PathNotFoundFormat" xml:space="preserve"><value>Path not found: {0}</value></data>
   <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>Terminal disposed</value></data>
   <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>Terminal dispose error: {0}</value></data>
   <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>Terminal recreated</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -595,6 +595,7 @@
   <!-- Root: Toast messages -->
   <data name="Root.Toast.SessionCreateErrorFormat" xml:space="preserve"><value>セッション作成エラー: {0}</value></data>
   <data name="Root.Toast.SessionInitErrorFormat" xml:space="preserve"><value>セッション初期化エラー: {0}</value></data>
+  <data name="Root.Toast.PathNotFoundFormat" xml:space="preserve"><value>パスが見つかりません: {0}</value></data>
   <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>ターミナルを破棄しました</value></data>
   <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>ターミナル破棄エラー: {0}</value></data>
   <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>ターミナルを再作成しました</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -110,8 +110,8 @@
   <data name="Settings.Display.SessionListScale.Help" xml:space="preserve"><value>表示倍率（50%〜150%）。</value></data>
   <data name="Settings.Display.TerminalFontSize.Label" xml:space="preserve"><value>ターミナルフォントサイズ</value></data>
   <data name="Settings.Display.TerminalFontSize.Help" xml:space="preserve"><value>フォントサイズ（8px〜28px）。</value></data>
-  <data name="Settings.Display.TerminalLinkCopyMode.Label" xml:space="preserve"><value>ターミナル内URLをタップでコピーする（開かない）</value></data>
-  <data name="Settings.Display.TerminalLinkCopyMode.Help" xml:space="preserve"><value>モバイルの全画面表示など、リンク先から戻れない環境向け。この端末（ブラウザ）にのみ保存されます。</value></data>
+  <data name="Settings.Display.TerminalLinkCopyMode.Label" xml:space="preserve"><value>ターミナル内のURLやパスをタップでコピーする（開かない）</value></data>
+  <data name="Settings.Display.TerminalLinkCopyMode.Help" xml:space="preserve"><value>モバイルの全画面表示など、リンク先から戻れない環境向け。ファイル/フォルダのパスもコピーになります。この端末（ブラウザ）にのみ保存されます。</value></data>
   <data name="Settings.Display.SidebarWidth.Label" xml:space="preserve"><value>サイドバー幅</value></data>
   <data name="Settings.Display.SidebarWidth.Help" xml:space="preserve"><value>幅（15%〜70%）。境界線のドラッグでも変更可能。</value></data>
   <data name="Settings.Display.TerminalHeightRatio.Label" xml:space="preserve"><value>ターミナル / 入力パネル比率</value></data>

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -334,7 +334,8 @@ function setupFilePathDetection(term, sessionId) {
 
     const linkProvider = {
         provideLinks: (bufferLineNumber, callback) => {
-            const line = term.buffer.active.getLine(bufferLineNumber);
+            // bufferLineNumber は 1 始まり、getLine() は 0 始まり
+            const line = term.buffer.active.getLine(bufferLineNumber - 1);
             if (!line) {
                 callback(undefined);
                 return;
@@ -363,8 +364,8 @@ function setupFilePathDetection(term, sessionId) {
 
                 links.push({
                     range: {
-                        start: { x: match.index + 1, y: bufferLineNumber + 1 },
-                        end: { x: match.index + text.length + 1, y: bufferLineNumber + 1 }
+                        start: { x: match.index + 1, y: bufferLineNumber },
+                        end: { x: match.index + text.length + 1, y: bufferLineNumber }
                     },
                     text: text,
                     activate: (e, uri) => activateTerminalPath(sessionId, uri)
@@ -377,6 +378,7 @@ function setupFilePathDetection(term, sessionId) {
 
     try {
         term.registerLinkProvider(linkProvider);
+        console.log('[Path Detection] link provider registered');
     } catch (error) {
         console.error('[Path Detection] Failed to register link provider:', error);
     }
@@ -427,7 +429,8 @@ function setupUrlDetectionFallback(term) {
     if (typeof term.registerLinkProvider === 'function') {
         const linkProvider = {
             provideLinks: (bufferLineNumber, callback) => {
-                const line = term.buffer.active.getLine(bufferLineNumber);
+                // bufferLineNumber は 1 始まり、getLine() は 0 始まり
+                const line = term.buffer.active.getLine(bufferLineNumber - 1);
                 if (!line) {
                     callback(undefined);
                     return;
@@ -450,8 +453,8 @@ function setupUrlDetectionFallback(term) {
                 while ((match = urlRegex.exec(lineText)) !== null) {
                     const link = {
                         range: {
-                            start: { x: match.index + 1, y: bufferLineNumber + 1 },
-                            end: { x: match.index + match[0].length + 1, y: bufferLineNumber + 1 }
+                            start: { x: match.index + 1, y: bufferLineNumber },
+                            end: { x: match.index + match[0].length + 1, y: bufferLineNumber }
                         },
                         text: match[0],
                         activate: (e, uri) => {

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -311,10 +311,89 @@ function showLinkCopyNotice(uri, success) {
         'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;' +
         (success ? 'background:#198754;' : 'background:#dc3545;');
     div.textContent = success
-        ? `📋 URLをコピーしました: ${uri}`
-        : `URLをコピーできませんでした: ${uri}`;
+        ? `📋 コピーしました: ${uri}`
+        : `コピーできませんでした: ${uri}`;
     document.body.appendChild(div);
     setTimeout(() => div.remove(), 3000);
+}
+
+// ファイルパス検出の設定
+// Claude Code 等が出力するファイル/フォルダ表記をクリック可能にする。
+// 検出は割り切り: 「拡張子付きファイル（拡張子は英字始まり、バージョン番号 1.0.65 等を除外）」と
+// 「/ または \ で終わるフォルダ表記」のみ。誤検出してもクリック時に「見つかりません」に落ちるだけ。
+// クリック時: コピー動作モード(terminalLinkCopyMode)ならコピー、通常は C# 側で
+// フォルダ=エクスプローラー / ファイル=既定アプリ で開く。
+function setupFilePathDetection(term, sessionId) {
+    if (typeof term.registerLinkProvider !== 'function') {
+        console.warn('[Path Detection] registerLinkProvider not available');
+        return;
+    }
+
+    // 空白・引用符・括弧・全角句読点は含めない。先頭にドライブレター(C:\)も許容。
+    const pathRegex = /(?:[A-Za-z]:[\\/])?[^\s"'`()\[\]{}<>|;,！？。、（）「」]+(?:\.[A-Za-z][A-Za-z0-9]{0,7}|[\\/])/g;
+
+    const linkProvider = {
+        provideLinks: (bufferLineNumber, callback) => {
+            const line = term.buffer.active.getLine(bufferLineNumber);
+            if (!line) {
+                callback(undefined);
+                return;
+            }
+
+            let lineText = '';
+            for (let i = 0; i < line.length; i++) {
+                const cell = line.getCell(i);
+                if (cell) {
+                    lineText += cell.getChars() || ' ';
+                }
+            }
+
+            const links = [];
+            let match;
+            pathRegex.lastIndex = 0;
+            while ((match = pathRegex.exec(lineText)) !== null) {
+                const text = match[0];
+
+                // URL は URL 検出（WebLinksAddon）側に任せる:
+                // マッチを含む空白区切りトークンに "://" があればスキップ
+                const before = lineText.slice(0, match.index);
+                const tokenStart = before.search(/\S+$/) === -1 ? match.index : before.search(/\S+$/);
+                const token = lineText.slice(tokenStart).split(/\s/)[0];
+                if (token.includes('://')) continue;
+
+                links.push({
+                    range: {
+                        start: { x: match.index + 1, y: bufferLineNumber + 1 },
+                        end: { x: match.index + text.length + 1, y: bufferLineNumber + 1 }
+                    },
+                    text: text,
+                    activate: (e, uri) => activateTerminalPath(sessionId, uri)
+                });
+            }
+
+            callback(links.length > 0 ? links : undefined);
+        }
+    };
+
+    try {
+        term.registerLinkProvider(linkProvider);
+    } catch (error) {
+        console.error('[Path Detection] Failed to register link provider:', error);
+    }
+}
+
+// パスリンクのアクティベート処理
+function activateTerminalPath(sessionId, path) {
+    if (terminalLinkCopyMode) {
+        // コピー動作モード: URL と同様に開かずコピーする（モバイル全画面向け）
+        copyLinkToClipboard(path);
+        return;
+    }
+    if (window.terminalHubDotNetRef) {
+        // C# 側でセッションのフォルダ基準に解決し、フォルダ=Explorer / ファイル=既定アプリ で開く
+        window.terminalHubDotNetRef.invokeMethodAsync('OnTerminalPathClick', sessionId, path)
+            .catch(err => console.error('[Path Detection] open failed:', err));
+    }
 }
 
 // URL検出の設定
@@ -701,6 +780,9 @@ window.terminalFunctions = {
             
             // URL検出機能を追加
             setupUrlDetection(term);
+
+            // ファイルパス検出機能を追加（フォルダ=Explorer/ファイル=既定アプリで開く）
+            setupFilePathDetection(term, sessionId);
 
             // Unicode11Addonをロード（ブロック文字の幅計算を改善）
             if (typeof Unicode11Addon !== 'undefined' && Unicode11Addon.Unicode11Addon) {

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -319,8 +319,10 @@ function showLinkCopyNotice(uri, success) {
 
 // ファイルパス検出の設定
 // Claude Code 等が出力するファイル/フォルダ表記をクリック可能にする。
-// 検出は割り切り: 「拡張子付きファイル（拡張子は英字始まり、バージョン番号 1.0.65 等を除外）」と
-// 「/ または \ で終わるフォルダ表記」のみ。誤検出してもクリック時に「見つかりません」に落ちるだけ。
+// 検出は割り切り: 「/ または \ を含むトークン（末尾まで丸ごと）」と
+// 「拡張子付きファイル（拡張子は英字始まり、バージョン番号 1.0.65 等を除外）」。
+// ドットファイル単体（.gitignore 等）は検出対象外（許容）。
+// フォルダかファイルかは C# 側で実在チェックして判定する。誤検出してもクリック時に「見つかりません」に落ちるだけ。
 // クリック時: コピー動作モード(terminalLinkCopyMode)ならコピー、通常は C# 側で
 // フォルダ=エクスプローラー / ファイル=既定アプリ で開く。
 function setupFilePathDetection(term, sessionId) {
@@ -329,8 +331,9 @@ function setupFilePathDetection(term, sessionId) {
         return;
     }
 
-    // 空白・引用符・括弧・全角句読点は含めない。先頭にドライブレター(C:\)も許容。
-    const pathRegex = /(?:[A-Za-z]:[\\/])?[^\s"'`()\[\]{}<>|;,！？。、（）「」]+(?:\.[A-Za-z][A-Za-z0-9]{0,7}|[\\/])/g;
+    // 空白・引用符・括弧・全角句読点は含めない（: は C:\ のため許容）。
+    // 第1候補: スラッシュ/バックスラッシュを含むトークン全体、第2候補: 拡張子付きファイル名
+    const pathRegex = /[^\s"'`()\[\]{}<>|;,！？。、（）「」]*[\\/][^\s"'`()\[\]{}<>|;,！？。、（）「」]*|[^\s"'`()\[\]{}<>|;,！？。、（）「」]+\.[A-Za-z][A-Za-z0-9]{0,7}/g;
 
     const linkProvider = {
         provideLinks: (bufferLineNumber, callback) => {
@@ -354,6 +357,9 @@ function setupFilePathDetection(term, sessionId) {
             pathRegex.lastIndex = 0;
             while ((match = pathRegex.exec(lineText)) !== null) {
                 const text = match[0];
+
+                // スラッシュだけの並び（罫線的な表記等）はリンク化しない
+                if (/^[\\/]+$/.test(text)) continue;
 
                 // URL は URL 検出（WebLinksAddon）側に任せる:
                 // マッチを含む空白区切りトークンに "://" があればスキップ


### PR DESCRIPTION
## 概要
ターミナル出力中のファイル/フォルダ表記（Claude Code が青く色付けするようなパス表記）をクリック可能にし、フォルダはエクスプローラー、ファイルは既定のアプリで開けるようにします。

## 検出ルール（正規表現のみ・色情報は不使用）
- `/` または `\` を含むトークンは末尾まで丸ごとリンク化（例: `docs/tips-draft.md`、`C:\Users\...\TerminalHub`、`.claude/`）
- 拡張子付きファイル名（拡張子は英字始まり1〜8文字。`1.0.65` のようなバージョン番号は除外。例: `hook-test.txt`、`.mcp.json`）
- ドットファイル単体（`.gitignore` 等）は対象外（許容）
- `://` を含むトークンは URL 検出（WebLinksAddon）側に委譲、スラッシュのみの並びは除外

## クリック時の挙動
- セッションの作業フォルダ基準でパス解決 → **フォルダ = エクスプローラー（前面化付き）／ファイル = 既定のアプリ**（実在チェックで判定）
- `Root.razor:123` のような行番号付き表記は末尾の `:数字` を落として再試行
- 見つからなければ「パスが見つかりません」トースト（`y/n` 等の誤検出クリックは無害に落ちる）
- コピー動作モード（terminalLinkCopyMode）のデバイスでは URL と同様にタップでパスをコピー

## 修正
- xterm.js の registerLinkProvider に渡る行番号は 1 始まりなのに 0 始まりの getLine() へそのまま渡していたオフバイワンを修正（URL フォールバック側の同種バグも修正）

## 検証
- ビルド 0警告0エラー
- 検出正規表現は node で実サンプル検証済み
- 実機確認済み（ホバー→クリックでフォルダ/ファイルが開くこと、誤検出クリックが無害であること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)