### PR TITLE
feat: ターミナル内のコミットハッシュをクリックでコミット情報ダイアログを表示

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -73,6 +73,10 @@
                         OnDeleteSession="DeleteArchivedSession"
                         OnDeleteAllSessions="DeleteAllArchivedSessions"
                         OnClose="() => showArchivedSessionsDialog = false" />
+<CommitInfoDialog IsVisible="showCommitInfoDialog"
+                  FolderPath="@commitInfoFolderPath"
+                  Info="@commitInfo"
+                  OnClose="() => showCommitInfoDialog = false" />
 
 <div class="container-fluid main-container">
     <div class="d-flex h-100 main-layout">
@@ -795,6 +799,47 @@
             Logger.LogWarning(ex, "[PathClick] パスを開けませんでした: {Path}", path);
         }
         return Task.CompletedTask;
+    }
+
+    // コミット情報ダイアログ（ターミナル内のコミットハッシュクリックで開く）
+    private bool showCommitInfoDialog = false;
+    private string? commitInfoFolderPath;
+    private GitCommitInfo? commitInfo;
+
+    /// <summary>
+    /// ターミナル内のコミットハッシュがクリックされた時の処理（JavaScript から呼び出される）
+    /// セッションの作業フォルダでコミットに解決できればコミット情報ダイアログを開く
+    /// </summary>
+    [JSInvokable]
+    public async Task OnTerminalCommitHashClick(string sessionId, string hash)
+    {
+        try
+        {
+            if (!Guid.TryParse(sessionId, out var guid))
+                return;
+
+            var session = sessions.FirstOrDefault(s => s.SessionId == guid);
+            var basePath = session?.FolderPath;
+            if (string.IsNullOrEmpty(basePath) || string.IsNullOrWhiteSpace(hash))
+                return;
+
+            var info = await GitService.GetCommitInfoAsync(basePath, hash.Trim());
+            if (info == null)
+            {
+                // 16進の英単語等の誤検出クリックはここに落ちる（無害）
+                toast?.ShowWarning(string.Format(L["Root.Toast.CommitNotFoundFormat"], hash.Trim()));
+                return;
+            }
+
+            commitInfo = info;
+            commitInfoFolderPath = basePath;
+            showCommitInfoDialog = true;
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "[CommitHashClick] コミット情報を取得できませんでした: {Hash}", hash);
+        }
     }
 
     private async Task AddSession()

--- a/TerminalHub/Components/Shared/Dialogs/CommitInfoDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/CommitInfoDialog.razor
@@ -1,0 +1,129 @@
+@using TerminalHub.Services
+@using Microsoft.Extensions.Localization
+@using Microsoft.JSInterop
+@inject IStringLocalizer<SharedResource> L
+@inject ILogger<CommitInfoDialog> Logger
+@inject IJSRuntime JSRuntime
+
+@* ターミナル内のコミットハッシュクリックで開く、コミット情報ダイアログ。
+   diff 本文は表示しない（件名・作者・日時・変更ファイル一覧まで）。
+   取得は親（Root）がクリック時に行い、ここは表示のみを担当する。 *@
+<div class="modal fade @(IsVisible ? "show" : "")" tabindex="-1" style="display: @(IsVisible ? "block" : "none"); background-color: var(--th-surface-overlay);">
+    <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title text-truncate">
+                    <i class="bi bi-git me-2"></i>@L["CommitInfo.Title"]
+                    @if (Info != null)
+                    {
+                        <span class="badge bg-secondary ms-2 font-monospace">@Info.ShortHash</span>
+                        @if (Info.IsMerge)
+                        {
+                            <span class="badge bg-info text-dark ms-1">@L["CommitInfo.MergeBadge"]</span>
+                        }
+                    }
+                </h5>
+                <button type="button" class="btn-close" @onclick="HandleClose"></button>
+            </div>
+            <div class="modal-body">
+                @if (Info != null)
+                {
+                    <div class="small text-muted mb-2 text-truncate" title="@FolderPath">
+                        <i class="bi bi-folder me-1"></i>@FolderPath
+                    </div>
+                    <div class="fw-bold text-break mb-1">@Info.Subject</div>
+                    @if (!string.IsNullOrEmpty(Info.Body))
+                    {
+                        <div class="small text-muted text-break mb-2" style="white-space: pre-wrap;">@Info.Body</div>
+                    }
+                    <div class="small text-muted mb-3">
+                        <i class="bi bi-person me-1"></i>@Info.Author
+                        <i class="bi bi-clock ms-3 me-1"></i>@Info.Date
+                    </div>
+                    @if (Info.Files.Count == 0)
+                    {
+                        <div class="alert alert-secondary py-2 mb-0">
+                            <i class="bi bi-info-circle me-1"></i>@(Info.IsMerge ? L["CommitInfo.NoFilesMerge"] : L["CommitInfo.NoFiles"])
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="small text-muted mb-2">
+                            @string.Format(L["CommitInfo.FileCountFormat"], Info.Files.Count)
+                        </div>
+                        <div class="list-group list-group-flush border rounded" style="max-height: 45vh; overflow-y: auto;">
+                            @foreach (var file in Info.Files)
+                            {
+                                <div class="list-group-item py-1 px-2 d-flex align-items-center gap-2">
+                                    <span class="font-monospace small text-nowrap" style="min-width: 6rem;">
+                                        @if (file.Added.HasValue || file.Deleted.HasValue)
+                                        {
+                                            <span class="text-success">+@(file.Added ?? 0)</span>
+                                            <span class="text-danger ms-1">-@(file.Deleted ?? 0)</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="text-muted">@L["CommitInfo.Binary"]</span>
+                                        }
+                                    </span>
+                                    <span class="font-monospace small text-break">@file.FilePath</span>
+                                </div>
+                            }
+                        </div>
+                    }
+                }
+            </div>
+            <div class="modal-footer">
+                @if (Info != null)
+                {
+                    @* フルハッシュをクリップボードへ。git コマンドや AI への貼り付けを想定 *@
+                    <button type="button" class="btn btn-outline-secondary me-auto" @onclick="CopyHashAsync">
+                        <i class="bi @(hashCopied ? "bi-check2" : "bi-clipboard") me-1"></i>@(hashCopied ? L["CommitInfo.Copied"] : L["CommitInfo.CopyHash"])
+                    </button>
+                }
+                <button type="button" class="btn btn-secondary" @onclick="HandleClose">@L["Common.Close"]</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public string? FolderPath { get; set; }
+    [Parameter] public GitCommitInfo? Info { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+
+    // 「コピーしました」表示用（数秒で元に戻す）
+    private bool hashCopied = false;
+
+    protected override void OnParametersSet()
+    {
+        if (!IsVisible)
+        {
+            hashCopied = false;
+        }
+    }
+
+    private async Task HandleClose()
+    {
+        await OnClose.InvokeAsync();
+    }
+
+    private async Task CopyHashAsync()
+    {
+        if (Info == null) return;
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", Info.FullHash);
+            hashCopied = true;
+            StateHasChanged();
+            await Task.Delay(2000);
+            hashCopied = false;
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[CommitInfoDialog] ハッシュのコピーに失敗");
+        }
+    }
+}

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -530,6 +530,14 @@
   <data name="GitChanges.Status.Renamed" xml:space="preserve"><value>Renamed</value></data>
   <data name="GitChanges.Status.Copied" xml:space="preserve"><value>Copied</value></data>
   <data name="GitChanges.Status.Conflicted" xml:space="preserve"><value>Conflicted</value></data>
+  <data name="CommitInfo.Title" xml:space="preserve"><value>Commit Info</value></data>
+  <data name="CommitInfo.MergeBadge" xml:space="preserve"><value>Merge</value></data>
+  <data name="CommitInfo.FileCountFormat" xml:space="preserve"><value>Changed files: {0}</value></data>
+  <data name="CommitInfo.NoFiles" xml:space="preserve"><value>No changed files</value></data>
+  <data name="CommitInfo.NoFilesMerge" xml:space="preserve"><value>File list is not shown for merge commits</value></data>
+  <data name="CommitInfo.Binary" xml:space="preserve"><value>binary</value></data>
+  <data name="CommitInfo.CopyHash" xml:space="preserve"><value>Copy hash</value></data>
+  <data name="CommitInfo.Copied" xml:space="preserve"><value>Copied</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>Remote control connected</value></data>
   <data name="SessionList.Badge.ChildrenCountFormat" xml:space="preserve"><value>{0} children</value></data>
   <data name="SessionList.Tooltip.Settings" xml:space="preserve"><value>Session settings</value></data>
@@ -596,6 +604,7 @@
   <data name="Root.Toast.SessionCreateErrorFormat" xml:space="preserve"><value>Session creation error: {0}</value></data>
   <data name="Root.Toast.SessionInitErrorFormat" xml:space="preserve"><value>Session initialization error: {0}</value></data>
   <data name="Root.Toast.PathNotFoundFormat" xml:space="preserve"><value>Path not found: {0}</value></data>
+  <data name="Root.Toast.CommitNotFoundFormat" xml:space="preserve"><value>Commit not found: {0}</value></data>
   <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>Terminal disposed</value></data>
   <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>Terminal dispose error: {0}</value></data>
   <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>Terminal recreated</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -530,6 +530,14 @@
   <data name="GitChanges.Status.Renamed" xml:space="preserve"><value>リネーム</value></data>
   <data name="GitChanges.Status.Copied" xml:space="preserve"><value>コピー</value></data>
   <data name="GitChanges.Status.Conflicted" xml:space="preserve"><value>競合</value></data>
+  <data name="CommitInfo.Title" xml:space="preserve"><value>コミット情報</value></data>
+  <data name="CommitInfo.MergeBadge" xml:space="preserve"><value>マージ</value></data>
+  <data name="CommitInfo.FileCountFormat" xml:space="preserve"><value>変更ファイル: {0} 件</value></data>
+  <data name="CommitInfo.NoFiles" xml:space="preserve"><value>変更ファイルはありません</value></data>
+  <data name="CommitInfo.NoFilesMerge" xml:space="preserve"><value>マージコミットのため変更ファイル一覧は表示されません</value></data>
+  <data name="CommitInfo.Binary" xml:space="preserve"><value>バイナリ</value></data>
+  <data name="CommitInfo.CopyHash" xml:space="preserve"><value>ハッシュをコピー</value></data>
+  <data name="CommitInfo.Copied" xml:space="preserve"><value>コピーしました</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>リモートコントロール接続中</value></data>
   <data name="SessionList.Badge.ChildrenCountFormat" xml:space="preserve"><value>{0} 件</value></data>
   <data name="SessionList.Tooltip.Settings" xml:space="preserve"><value>セッション設定</value></data>
@@ -596,6 +604,7 @@
   <data name="Root.Toast.SessionCreateErrorFormat" xml:space="preserve"><value>セッション作成エラー: {0}</value></data>
   <data name="Root.Toast.SessionInitErrorFormat" xml:space="preserve"><value>セッション初期化エラー: {0}</value></data>
   <data name="Root.Toast.PathNotFoundFormat" xml:space="preserve"><value>パスが見つかりません: {0}</value></data>
+  <data name="Root.Toast.CommitNotFoundFormat" xml:space="preserve"><value>コミットが見つかりません: {0}</value></data>
   <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>ターミナルを破棄しました</value></data>
   <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>ターミナル破棄エラー: {0}</value></data>
   <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>ターミナルを再作成しました</value></data>

--- a/TerminalHub/Services/GitService.cs
+++ b/TerminalHub/Services/GitService.cs
@@ -413,43 +413,42 @@ namespace TerminalHub.Services
                 if (string.IsNullOrEmpty(hash) || !System.Text.RegularExpressions.Regex.IsMatch(hash, "^[0-9a-fA-F]{7,40}$"))
                     return null;
 
-                if (!await IsGitRepositoryAsync(path))
-                    return null;
-
-                // コミットに解決できるか検証しつつフルハッシュを得る（blob/tree 等は対象外）
+                // コミットに解決できるか検証しつつフルハッシュを得る（blob/tree 等は対象外）。
+                // 非リポジトリのフォルダでもここで失敗するため、事前のリポジトリ判定は不要
                 var resolve = await ExecuteGitCommandAsync(path, $"rev-parse --verify --quiet {hash}^{{commit}}");
                 var fullHash = resolve.Output?.Trim();
                 if (!resolve.Success || string.IsNullOrEmpty(fullHash))
                     return null;
 
-                // メタ情報: 1〜4行目 = フルハッシュ/親/作者+日時/件名、5行目以降 = 本文
-                var meta = await ExecuteGitCommandAsync(path,
-                    $"show -s --date=format:\"%Y-%m-%d %H:%M\" --format=\"%H%n%P%n%an / %ad%n%s%n%b\" {fullHash}");
-                if (!meta.Success || string.IsNullOrEmpty(meta.Output))
+                // メタ情報と変更ファイル一覧を1コマンドで取得。
+                // 本文(%b)は行数可変のため、format 末尾の %x00 (NUL) でメタ部と numstat 部を区切る
+                var result = await ExecuteGitCommandAsync(path,
+                    $"-c core.quotepath=false show --numstat --date=format:\"%Y-%m-%d %H:%M\" --format=\"%P%n%an%n%ad%n%s%n%b%x00\" {fullHash}");
+                if (!result.Success || string.IsNullOrEmpty(result.Output))
                     return null;
 
-                var lines = meta.Output.Replace("\r", "").Split('\n');
+                var sections = result.Output.Replace("\r", "").Split('\0', 2);
+
+                // メタ部: 1行目 = 親、2行目 = 作者、3行目 = 日時、4行目 = 件名、5行目以降 = 本文
+                var lines = sections[0].Split('\n');
                 if (lines.Length < 4)
                     return null;
 
-                var authorDate = lines[2].Split(" / ", 2);
                 var info = new GitCommitInfo
                 {
-                    FullHash = lines[0],
-                    IsMerge = lines[1].Split(' ', StringSplitOptions.RemoveEmptyEntries).Length >= 2,
-                    Author = authorDate.Length == 2 ? authorDate[0] : lines[2],
-                    Date = authorDate.Length == 2 ? authorDate[1] : "",
+                    FullHash = fullHash,
+                    IsMerge = lines[0].Split(' ', StringSplitOptions.RemoveEmptyEntries).Length >= 2,
+                    Author = lines[1],
+                    Date = lines[2],
                     Subject = lines[3],
                     Body = string.Join('\n', lines.Skip(4)).Trim(),
                 };
 
-                // 変更ファイル一覧（追加/削除行数付き）。マージコミットは numstat が空になるが、そのまま扱う
-                var stat = await ExecuteGitCommandAsync(path, $"-c core.quotepath=false show --numstat --format= {fullHash}");
-                if (stat.Success && !string.IsNullOrEmpty(stat.Output))
+                // numstat 部: "追加\t削除\tパス"（バイナリは "-\t-\tパス"）。マージコミットは空になるが、そのまま扱う
+                if (sections.Length == 2)
                 {
-                    foreach (var line in stat.Output.Replace("\r", "").Split('\n'))
+                    foreach (var line in sections[1].Split('\n'))
                     {
-                        // numstat 形式: "追加\t削除\tパス"（バイナリは "-\t-\tパス"）
                         var parts = line.Split('\t', 3);
                         if (parts.Length != 3 || string.IsNullOrWhiteSpace(parts[2]))
                             continue;

--- a/TerminalHub/Services/GitService.cs
+++ b/TerminalHub/Services/GitService.cs
@@ -405,6 +405,72 @@ namespace TerminalHub.Services
                     : s;
         }
 
+        public async Task<GitCommitInfo?> GetCommitInfoAsync(string path, string hash)
+        {
+            try
+            {
+                // 正規表現由来の入力だが、コマンド組み立てに使うため念のため形式を検証する
+                if (string.IsNullOrEmpty(hash) || !System.Text.RegularExpressions.Regex.IsMatch(hash, "^[0-9a-fA-F]{7,40}$"))
+                    return null;
+
+                if (!await IsGitRepositoryAsync(path))
+                    return null;
+
+                // コミットに解決できるか検証しつつフルハッシュを得る（blob/tree 等は対象外）
+                var resolve = await ExecuteGitCommandAsync(path, $"rev-parse --verify --quiet {hash}^{{commit}}");
+                var fullHash = resolve.Output?.Trim();
+                if (!resolve.Success || string.IsNullOrEmpty(fullHash))
+                    return null;
+
+                // メタ情報: 1〜4行目 = フルハッシュ/親/作者+日時/件名、5行目以降 = 本文
+                var meta = await ExecuteGitCommandAsync(path,
+                    $"show -s --date=format:\"%Y-%m-%d %H:%M\" --format=\"%H%n%P%n%an / %ad%n%s%n%b\" {fullHash}");
+                if (!meta.Success || string.IsNullOrEmpty(meta.Output))
+                    return null;
+
+                var lines = meta.Output.Replace("\r", "").Split('\n');
+                if (lines.Length < 4)
+                    return null;
+
+                var authorDate = lines[2].Split(" / ", 2);
+                var info = new GitCommitInfo
+                {
+                    FullHash = lines[0],
+                    IsMerge = lines[1].Split(' ', StringSplitOptions.RemoveEmptyEntries).Length >= 2,
+                    Author = authorDate.Length == 2 ? authorDate[0] : lines[2],
+                    Date = authorDate.Length == 2 ? authorDate[1] : "",
+                    Subject = lines[3],
+                    Body = string.Join('\n', lines.Skip(4)).Trim(),
+                };
+
+                // 変更ファイル一覧（追加/削除行数付き）。マージコミットは numstat が空になるが、そのまま扱う
+                var stat = await ExecuteGitCommandAsync(path, $"-c core.quotepath=false show --numstat --format= {fullHash}");
+                if (stat.Success && !string.IsNullOrEmpty(stat.Output))
+                {
+                    foreach (var line in stat.Output.Replace("\r", "").Split('\n'))
+                    {
+                        // numstat 形式: "追加\t削除\tパス"（バイナリは "-\t-\tパス"）
+                        var parts = line.Split('\t', 3);
+                        if (parts.Length != 3 || string.IsNullOrWhiteSpace(parts[2]))
+                            continue;
+                        info.Files.Add(new GitCommitFileChange
+                        {
+                            Added = int.TryParse(parts[0], out var a) ? a : null,
+                            Deleted = int.TryParse(parts[1], out var d) ? d : null,
+                            FilePath = parts[2],
+                        });
+                    }
+                }
+
+                return info;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "コミット情報の取得でエラーが発生しました: {Path} {Hash}", path, hash);
+                return null;
+            }
+        }
+
         private async Task<(bool Success, string? Output, string? Error)> ExecuteGitCommandAsync(string workingDirectory, string arguments)
         {
             try

--- a/TerminalHub/Services/IGitService.cs
+++ b/TerminalHub/Services/IGitService.cs
@@ -69,6 +69,43 @@ namespace TerminalHub.Services
         /// <param name="path">リポジトリのパス</param>
         /// <returns>変更ファイルのリスト。取得失敗時は null（変更なしの空リストと区別する）</returns>
         Task<List<GitChangedFile>?> GetChangedFilesAsync(string path);
+
+        /// <summary>
+        /// コミットハッシュ（短縮形可）からコミット情報を取得
+        /// </summary>
+        /// <param name="path">リポジトリのパス</param>
+        /// <param name="hash">コミットハッシュ（7〜40桁の16進）</param>
+        /// <returns>コミット情報。ハッシュがコミットに解決できない場合は null</returns>
+        Task<GitCommitInfo?> GetCommitInfoAsync(string path, string hash);
+    }
+
+    /// <summary>
+    /// コミット情報ダイアログ用のコミット詳細（diff 本文は持たない）
+    /// </summary>
+    public class GitCommitInfo
+    {
+        public string FullHash { get; set; } = string.Empty;
+        public string ShortHash => FullHash.Length > 7 ? FullHash.Substring(0, 7) : FullHash;
+        public string Author { get; set; } = string.Empty;
+        public string Date { get; set; } = string.Empty;
+        public string Subject { get; set; } = string.Empty;
+        /// <summary>コミットメッセージ本文（subject 以降）。無ければ空</summary>
+        public string Body { get; set; } = string.Empty;
+        /// <summary>マージコミット（親が2つ以上）か</summary>
+        public bool IsMerge { get; set; }
+        public List<GitCommitFileChange> Files { get; set; } = new();
+    }
+
+    /// <summary>
+    /// git show --numstat の1行に対応する変更ファイル情報
+    /// </summary>
+    public class GitCommitFileChange
+    {
+        /// <summary>追加行数。バイナリファイルは null</summary>
+        public int? Added { get; set; }
+        /// <summary>削除行数。バイナリファイルは null</summary>
+        public int? Deleted { get; set; }
+        public string FilePath { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -317,6 +317,20 @@ function showLinkCopyNotice(uri, success) {
     setTimeout(() => div.remove(), 3000);
 }
 
+// バッファ行のテキストを取得（各リンクプロバイダー共通）
+// ワイド文字（全角等）の2セル目は getChars() が空を返すためスペースで埋め、
+// 文字列インデックスとターミナル列番号を揃える
+function getBufferLineText(line) {
+    let lineText = '';
+    for (let i = 0; i < line.length; i++) {
+        const cell = line.getCell(i);
+        if (cell) {
+            lineText += cell.getChars() || ' ';
+        }
+    }
+    return lineText;
+}
+
 // ファイルパス検出の設定
 // Claude Code 等が出力するファイル/フォルダ表記をクリック可能にする。
 // 検出は割り切り: 「/ または \ を含むトークン（末尾まで丸ごと）」と
@@ -344,13 +358,7 @@ function setupFilePathDetection(term, sessionId) {
                 return;
             }
 
-            let lineText = '';
-            for (let i = 0; i < line.length; i++) {
-                const cell = line.getCell(i);
-                if (cell) {
-                    lineText += cell.getChars() || ' ';
-                }
-            }
+            const lineText = getBufferLineText(line);
 
             const links = [];
             let match;
@@ -360,6 +368,10 @@ function setupFilePathDetection(term, sessionId) {
 
                 // スラッシュだけの並び（罫線的な表記等）はリンク化しない
                 if (/^[\\/]+$/.test(text)) continue;
+
+                // コミットハッシュの範囲表記（68bf789..9931160 等、fetch/push 出力）は
+                // 拡張子パターンに誤マッチするためスキップし、ハッシュリンク側に任せる
+                if (/^[0-9a-f]{7,40}\.\.[0-9a-f]{7,40}$/i.test(text)) continue;
 
                 // URL は URL 検出（WebLinksAddon）側に任せる:
                 // マッチを含む空白区切りトークンに "://" があればスキップ
@@ -412,13 +424,7 @@ function setupCommitHashDetection(term, sessionId) {
                 return;
             }
 
-            let lineText = '';
-            for (let i = 0; i < line.length; i++) {
-                const cell = line.getCell(i);
-                if (cell) {
-                    lineText += cell.getChars() || ' ';
-                }
-            }
+            const lineText = getBufferLineText(line);
 
             const links = [];
             let match;
@@ -517,14 +523,8 @@ function setupUrlDetectionFallback(term) {
                 }
                 
                 // 行のテキストを取得
-                let lineText = '';
-                for (let i = 0; i < line.length; i++) {
-                    const cell = line.getCell(i);
-                    if (cell) {
-                        lineText += cell.getChars() || ' ';
-                    }
-                }
-                
+                const lineText = getBufferLineText(line);
+
                 // URLを検出
                 const links = [];
                 let match;

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -390,6 +390,80 @@ function setupFilePathDetection(term, sessionId) {
     }
 }
 
+// コミットハッシュ検出の設定
+// ターミナル出力中の Git コミットハッシュ（7〜40桁の16進）をクリック可能にする。
+// クリックで C# 側がコミットを実在チェックし、コミット情報ダイアログを開く。
+// アプリ内ダイアログでページ遷移しないため、コピー動作モードでも同じ挙動とする。
+// 誤検出対策: 数字のみ/英字のみは除外（バージョン番号や英単語 "defaced" 等を拾わない）、
+// 前後が - . / \ _ に隣接するものは除外（GUID の断片やファイル名の一部を拾わない）。
+function setupCommitHashDetection(term, sessionId) {
+    if (typeof term.registerLinkProvider !== 'function') {
+        return;
+    }
+
+    const hashRegex = /\b[0-9a-f]{7,40}\b/g;
+
+    const linkProvider = {
+        provideLinks: (bufferLineNumber, callback) => {
+            // bufferLineNumber は 1 始まり、getLine() は 0 始まり
+            const line = term.buffer.active.getLine(bufferLineNumber - 1);
+            if (!line) {
+                callback(undefined);
+                return;
+            }
+
+            let lineText = '';
+            for (let i = 0; i < line.length; i++) {
+                const cell = line.getCell(i);
+                if (cell) {
+                    lineText += cell.getChars() || ' ';
+                }
+            }
+
+            const links = [];
+            let match;
+            hashRegex.lastIndex = 0;
+            while ((match = hashRegex.exec(lineText)) !== null) {
+                const text = match[0];
+
+                // 数字のみ（タイムスタンプ等）・英字のみ（英単語）は除外
+                if (!/[a-f]/.test(text) || !/[0-9]/.test(text)) continue;
+
+                // GUID の断片（f49cfab0-13ff-...）やファイル名・パスの一部を拾わない。
+                // ただし ".." は範囲表記（68bf789..9931160、push 出力等）なので両側とも許可する
+                const prev = lineText[match.index - 1];
+                const next = lineText[match.index + text.length];
+                const prevIsRange = prev === '.' && lineText[match.index - 2] === '.';
+                const nextIsRange = next === '.' && lineText[match.index + text.length + 1] === '.';
+                if (prev && /[-.\\/_]/.test(prev) && !prevIsRange) continue;
+                if (next && /[-.\\/_]/.test(next) && !nextIsRange) continue;
+
+                links.push({
+                    range: {
+                        start: { x: match.index + 1, y: bufferLineNumber },
+                        end: { x: match.index + text.length + 1, y: bufferLineNumber }
+                    },
+                    text: text,
+                    activate: (e, uri) => {
+                        if (window.terminalHubDotNetRef) {
+                            window.terminalHubDotNetRef.invokeMethodAsync('OnTerminalCommitHashClick', sessionId, uri)
+                                .catch(err => console.error('[Hash Detection] open failed:', err));
+                        }
+                    }
+                });
+            }
+
+            callback(links.length > 0 ? links : undefined);
+        }
+    };
+
+    try {
+        term.registerLinkProvider(linkProvider);
+    } catch (error) {
+        console.error('[Hash Detection] Failed to register link provider:', error);
+    }
+}
+
 // パスリンクのアクティベート処理
 function activateTerminalPath(sessionId, path) {
     if (terminalLinkCopyMode) {
@@ -792,6 +866,7 @@ window.terminalFunctions = {
 
             // ファイルパス検出機能を追加（フォルダ=Explorer/ファイル=既定アプリで開く）
             setupFilePathDetection(term, sessionId);
+            setupCommitHashDetection(term, sessionId);
 
             // Unicode11Addonをロード（ブロック文字の幅計算を改善）
             if (typeof Unicode11Addon !== 'undefined' && Unicode11Addon.Unicode11Addon) {


### PR DESCRIPTION
## 概要
ターミナル出力中の Git コミットハッシュ（`852d703` や範囲表記 `68bf789..9931160` の左側など）をクリック可能にし、コミット情報ダイアログを表示します。パスリンク（PR #113）の姉妹機能です。

## 検出ルール
- 7〜40桁の16進で、**数字と英字(a-f)の両方を含む**トークン
- 除外: GUID の断片（`f49cfab0-13ff-...`）・パス/ファイル名の一部・URL内（ハイフン/ドット等の隣接で判定）、数字のみ（タイムスタンプ）、英字のみ（`defaced` 等の16進英単語）
- 例外: 範囲表記 `a..b` のドット隣接は許可（push 出力で頻出のため）

## クリック時の挙動
- C# 側で `git rev-parse --verify <hash>^{commit}` により実在チェック（入力は形式検証済み）
- **コミット情報ダイアログ**を表示: 件名・メッセージ本文・作者・日時・変更ファイル一覧（±行数、バイナリ表記）・マージバッジ。**diff 本文は表示しない**割り切り仕様
- フッターに「ハッシュをコピー」（フル40桁）
- 解決できない場合は「コミットが見つかりません」トースト（誤検出クリックは無害）
- アプリ内ダイアログで遷移しないため、コピー動作モードでも同じ挙動

## 実装
- `terminal.js`: `setupCommitHashDetection`（リンクプロバイダー3本目）
- `GitService.GetCommitInfoAsync`: `git show -s --format` + `--numstat` をパース（`core.quotepath=false` で日本語パス対応）
- `CommitInfoDialog.razor`: GitChangesDialog を下敷きにした表示専用ダイアログ（取得は Root 側がクリック時に実施）

## 検証
- ビルド 0警告0エラー
- 検出ロジックは node で10ケース検証済み、git コマンドのパースは実リポジトリで確認済み
- 実機確認済み（ダイアログ表示・ファイル一覧・±行数）

🤖 Generated with [Claude Code](https://claude.com/claude-code)