### PR TITLE
fix: idle系Notificationでは通知ベルを再点灯しないように

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -303,9 +303,18 @@
     /// Notification は AskUserQuestion の裏でも飛ぶことがあり、その message が "permission" を含むと
     /// Confirm と誤判定されうる。既に精密イベント(PreToolUse=Select / PermissionRequest=Confirm)で
     /// 要操作ベルが立っている場合は上書きしない（三択待ちが「許可待ち」へ化けるのを防ぐ）。
+    /// また idle 系（"Claude is waiting for your input"、Stop の60秒後に飛ぶリマインダー等）では
+    /// ベルを立てない。処理完了は Stop 時のベルで既に通知済みで、ユーザーが確認して消した後に
+    /// 同じ完了が60秒遅れで再点灯するノイズになるため（実地調査 2026-07-08）。
     /// </summary>
     private void SetNotificationBellFromNotification(Guid sessionId, SessionBellKind kind, string source)
     {
+        if (kind == SessionBellKind.Stopped)
+        {
+            // permission を含まない Notification（idle リマインダー等）はベル対象外
+            RecordBellHistory(sessionId, "SUPPRESSED", kind, $"{source} → idle系Notificationはベルを立てない");
+            return;
+        }
         if (_notificationPendingSessions.TryGetValue(sessionId, out var existing)
             && existing != SessionBellKind.Stopped)
         {

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -329,9 +329,11 @@
     /// Notification イベントの message から通知ベル種別を判別する。
     /// Notification は許可待ち(permission)・アイドル(idle)・認証成功 等で発火するため、
     /// 一律 Confirm（盾＝許可待ち）にすると idle/認証まで「許可待ち」と誤表示してしまう。
-    /// message に "permission" を含むものだけ確認（盾）とし、それ以外は停止（ベル）扱いにする。
+    /// message に "permission" を含むものだけ確認（盾）とし、それ以外は Stopped 扱いにする。
     /// 例: 許可待ち="Claude needs your permission to use Bash" / idle="Claude is waiting for your input"。
-    /// （Claude Code 側の文言変更に弱い substring 判定だが、外れても Stopped に倒れるだけで害は小さい）
+    /// 注意: Stopped 判定の Notification は SetNotificationBellFromNotification でベル対象外（SUPPRESSED）に
+    /// なるため、Claude Code 側の文言変更で permission 判定を外すと許可待ちが無通知になる。substring 判定が
+    /// 外れていそうな挙動を見たら、診断の「ステータス/通知履歴 JSON」の SUPPRESSED 行で message を確認すること。
     /// </summary>
     private static SessionBellKind ClassifyNotificationBell(string? message)
     {
@@ -2608,8 +2610,9 @@
                 // 解除は不要: 入力するにはそのセッションへ切り替える＝SelectSession でベルが自然に消える。
                 //   - PreToolUse        → 選択（質問, bi-ui-radios）
                 //   - PermissionRequest → 確認（Codex の許可待ち, bi-shield-exclamation）
-                //   - Notification      → message で判別。許可待ちのみ確認（盾）、
-                //                         idle/認証成功等は停止（ベル）にして「許可待ち」を誤表示しない。
+                //   - Notification      → message で判別。許可待ち（permission を含む）のみ確認（盾）で点灯。
+                //                         idle/認証成功等はベルを立てない（Stop 時に通知済みの完了が
+                //                         60秒遅れで再点灯するのを防ぐ。SUPPRESSED として履歴には残る）。
                 if (activeSessionId != notification.SessionId)
                 {
                     Logger.LogInformation(

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -328,8 +328,8 @@
     /// <summary>
     /// Notification イベントの message から通知ベル種別を判別する。
     /// Notification は許可待ち(permission)・アイドル(idle)・認証成功 等で発火するため、
-    /// 一律 Confirm（盾＝許可待ち）にすると idle/認証まで「許可待ち」と誤表示してしまう。
-    /// message に "permission" を含むものだけ確認（盾）とし、それ以外は Stopped 扱いにする。
+    /// 一律 Confirm（許可待ち, bi-question-octagon）にすると idle/認証まで「許可待ち」と誤表示してしまう。
+    /// message に "permission" を含むものだけ Confirm とし、それ以外は Stopped 扱いにする。
     /// 例: 許可待ち="Claude needs your permission to use Bash" / idle="Claude is waiting for your input"。
     /// 注意: Stopped 判定の Notification は SetNotificationBellFromNotification でベル対象外（SUPPRESSED）に
     /// なるため、Claude Code 側の文言変更で permission 判定を外すと許可待ちが無通知になる。substring 判定が
@@ -2608,9 +2608,9 @@
                 // Notification / PreToolUse / PermissionRequest は「ユーザーの入力が必要」な状態。
                 // 非アクティブセッションならベル（通知マーク）を立てて、別セッションを見ている時でも気づけるように。
                 // 解除は不要: 入力するにはそのセッションへ切り替える＝SelectSession でベルが自然に消える。
-                //   - PreToolUse        → 選択（質問, bi-ui-radios）
-                //   - PermissionRequest → 確認（Codex の許可待ち, bi-shield-exclamation）
-                //   - Notification      → message で判別。許可待ち（permission を含む）のみ確認（盾）で点灯。
+                //   - PreToolUse        → 選択（質問, bi-list-ol）
+                //   - PermissionRequest → 確認（Codex の許可待ち, bi-question-octagon）
+                //   - Notification      → message で判別。許可待ち（permission を含む）のみ確認（bi-question-octagon）で点灯。
                 //                         idle/認証成功等はベルを立てない（Stop 時に通知済みの完了が
                 //                         60秒遅れで再点灯するのを防ぐ。SUPPRESSED として履歴には残る）。
                 if (activeSessionId != notification.SessionId)

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -102,7 +102,7 @@
                             }
                             @if (NotificationPendingSessions.TryGetValue(session.SessionId, out var bellKind))
                             {
-                                @* 色は共通(赤)。停止=ベル / 確認=盾 / 選択=ラジオ でアイコンの形を変えて区別する *@
+                                @* 色は共通(赤)。停止=ベル / 確認=八角形＋？ / 選択=番号リスト でアイコンの形を変えて区別する *@
                                 <span class="text-danger me-1 session-bell" title="@BellTitle(bellKind)">
                                     <i class="bi @BellIcon(bellKind)"></i>
                                 </span>

--- a/TerminalHub/Models/SessionBellKind.cs
+++ b/TerminalHub/Models/SessionBellKind.cs
@@ -9,9 +9,9 @@ public enum SessionBellKind
     /// <summary>停止: ターンが終わって次の入力待ちで止まっている（bi-bell-fill）</summary>
     Stopped,
 
-    /// <summary>確認: 許可待ち（Notification / permission_prompt）。「実行していい?」（bi-shield-exclamation）</summary>
+    /// <summary>確認: 許可待ち（Notification / permission_prompt）。「実行していい?」（bi-question-octagon）</summary>
     Confirm,
 
-    /// <summary>選択: 質問（PreToolUse / AskUserQuestion）。3択など選んでほしい（bi-ui-radios）</summary>
+    /// <summary>選択: 質問（PreToolUse / AskUserQuestion）。3択など選んでほしい（bi-list-ol）</summary>
     Select
 }


### PR DESCRIPTION
## 概要
「ベルを消したのに、しばらくすると再点灯する」問題の修正です。PR #112 の診断ログ（ステータス/通知履歴）で原因を特定しました。

## 原因
Claude Code は Stop の約60秒後に idle リマインダーとして `Notification`（message: "Claude is waiting for your input"）を送ってくる。TerminalHub はこれを完了通知としてベル点灯対象にしていたため、ユーザーが Stop 時のベルを確認して消した後、同じ完了について60秒遅れでベルが再点灯していた。

診断ログでの実録:
```
04:39:45 ON  Stopped  Hook Stop(処理完了)
04:39:50 OFF          SelectSession(セッション選択)   ← ユーザーが確認
04:40:46 ON  Stopped  Hook Notification: Claude is waiting for your input  ← 再点灯（Stopの61秒後）
```

## 修正
`SetNotificationBellFromNotification` で、permission を含まない Notification（idle リマインダー等、`ClassifyNotificationBell` が Stopped 判定するもの）はベルを立てず、診断履歴に `SUPPRESSED` として記録のみ行う。

- 許可待ち通知（"Claude needs your permission ..."）は従来どおり点灯
- 取りこぼしなし: 処理完了は Stop 時のベルで通知済みで、未確認ならそのベルが点いたまま残る（idle 通知が無くても困らない）

## 検証
- ビルド 0警告0エラー
- 実機確認済み: Stop→ベル消灯→60秒放置で再点灯せず、診断ログに SUPPRESSED が2インスタンス分記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)