### PR TITLE
fix: ConPTY の書き込み直列化とセマフォ解放漏れを修正

### DIFF
--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -83,6 +83,10 @@ namespace TerminalHub.Services
         // 書き込みの直列化用。UI・MCP(send_to_session)・RemoteLaunch など複数経路から
         // 同時に WriteAsync が呼ばれると、256文字チャンク＋Delay の隙間で入力が混ざるため排他する
         private readonly SemaphoreSlim _writeLock = new(1, 1);
+        // _writeLock の待機を Dispose 時に解除するためのトークン。
+        // SemaphoreSlim.Dispose() は既に WaitAsync で待機中のタスクを解放しないため、
+        // Dispose で Cancel して待機側を OperationCanceledException で抜けさせ、永久ブロックを防ぐ
+        private readonly CancellationTokenSource _writeLockCts = new();
         private System.Timers.Timer? _flushTimer;
         private readonly StringBuilder _outputBuffer = new();
         private const int FLUSH_INTERVAL_MS = 16; // 約60fps
@@ -356,14 +360,20 @@ namespace TerminalHub.Services
             if (_writer == null || _disposed)
                 return;
 
-            // 複数経路(UI/MCP等)からの同時書き込みを直列化し、チャンクの混線を防ぐ
+            // 複数経路(UI/MCP等)からの同時書き込みを直列化し、チャンクの混線を防ぐ。
+            // 待機中に Dispose されると SemaphoreSlim.Dispose では解放されないため、
+            // _writeLockCts のキャンセルで待機を打ち切る（OperationCanceledException で抜ける）
             try
             {
-                await _writeLock.WaitAsync();
+                await _writeLock.WaitAsync(_writeLockCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                return; // Dispose により待機がキャンセルされた
             }
             catch (ObjectDisposedException)
             {
-                return; // 破棄済みなら何もしない
+                return; // 破棄済みなら何もしない（Cancel 後に CTS が破棄されたケースを含む）
             }
 
             try
@@ -387,6 +397,11 @@ namespace TerminalHub.Services
 
                 // 統計情報を更新
                 TotalBytesWritten += Encoding.UTF8.GetByteCount(input);
+            }
+            catch (Exception ex) when (ex is ObjectDisposedException or IOException)
+            {
+                // 書き込みループの途中で Dispose され _writer/パイプが破棄されたケース。
+                // 呼び出し元(UIイベント/MCP send_to_session)へ例外を伝播させず握りつぶす
             }
             finally
             {
@@ -621,6 +636,16 @@ namespace TerminalHub.Services
             // まず破棄フラグを設定
             _disposed = true;
 
+            // 書き込み待機を解除（_writeLock.WaitAsync で待機中の WriteAsync を抜けさせる）
+            try
+            {
+                _writeLockCts.Cancel();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to cancel write lock waiters during disposal");
+            }
+
             // フロー制御を解除（読み取りタスクがブロックされている場合に備えて）
             lock (_pauseLock)
             {
@@ -706,6 +731,7 @@ namespace TerminalHub.Services
 
             _process?.Dispose();
             _readCancellationTokenSource?.Dispose();
+            _writeLockCts.Dispose();
         }
 
         // P/Invoke定義

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -79,6 +79,10 @@ namespace TerminalHub.Services
         // パフォーマンス最適化設定
         private bool _enableBuffering = true; // バッファリング有効
         private readonly SemaphoreSlim _outputSemaphore = new(1, 1);
+
+        // 書き込みの直列化用。UI・MCP(send_to_session)・RemoteLaunch など複数経路から
+        // 同時に WriteAsync が呼ばれると、256文字チャンク＋Delay の隙間で入力が混ざるため排他する
+        private readonly SemaphoreSlim _writeLock = new(1, 1);
         private System.Timers.Timer? _flushTimer;
         private readonly StringBuilder _outputBuffer = new();
         private const int FLUSH_INTERVAL_MS = 16; // 約60fps
@@ -349,14 +353,30 @@ namespace TerminalHub.Services
         /// <param name="input">送信するデータ</param>
         public async Task WriteAsync(string input)
         {
-            if (_writer != null && !_disposed)
+            if (_writer == null || _disposed)
+                return;
+
+            // 複数経路(UI/MCP等)からの同時書き込みを直列化し、チャンクの混線を防ぐ
+            try
             {
+                await _writeLock.WaitAsync();
+            }
+            catch (ObjectDisposedException)
+            {
+                return; // 破棄済みなら何もしない
+            }
+
+            try
+            {
+                if (_writer == null || _disposed)
+                    return;
+
                 // 256文字単位で分割して送信（こまめにFlushすることで問題を解決）
                 const int CHUNK_SIZE = 256;
-                
+
                 for (int i = 0; i < input.Length; i += CHUNK_SIZE)
                 {
-                    var chunk = i + CHUNK_SIZE < input.Length 
+                    var chunk = i + CHUNK_SIZE < input.Length
                         ? input.Substring(i, CHUNK_SIZE)
                         : input.Substring(i);
 
@@ -367,6 +387,17 @@ namespace TerminalHub.Services
 
                 // 統計情報を更新
                 TotalBytesWritten += Encoding.UTF8.GetByteCount(input);
+            }
+            finally
+            {
+                try
+                {
+                    _writeLock.Release();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // 書き込み中に Dispose されたケース。解放不要
+                }
             }
         }
 
@@ -390,15 +421,16 @@ namespace TerminalHub.Services
                         {
                             var bufferedData = _outputBuffer.ToString();
                             _outputBuffer.Clear();
-                            
+
                             DataReceived?.Invoke(this, new DataReceivedEventArgs(bufferedData));
                         }
                     }
                 }
                 finally
                 {
-                    if (!_disposed)
-                        _outputSemaphore.Release();
+                    // 取得したら必ず解放する。イベント処理中に Dispose された場合でも
+                    // Release しないと待機側が詰まる（破棄済みなら ObjectDisposedException を外側の catch で無視）
+                    _outputSemaphore.Release();
                 }
             }
             catch (ObjectDisposedException)
@@ -428,8 +460,8 @@ namespace TerminalHub.Services
                 }
                 finally
                 {
-                    if (!_disposed)
-                        _outputSemaphore.Release();
+                    // 取得したら必ず解放する（破棄済みなら ObjectDisposedException を外側の catch で無視）
+                    _outputSemaphore.Release();
                 }
             }
             catch (ObjectDisposedException)
@@ -637,6 +669,7 @@ namespace TerminalHub.Services
             
             // セマフォを破棄
             _outputSemaphore?.Dispose();
+            _writeLock?.Dispose();
 
             // プロセスを終了（bun など孫プロセスが残らないようプロセスツリーごと kill）
             if (_process != null && !_process.HasExited)


### PR DESCRIPTION
## 概要
外部レビュー（Codex による ConPTY 周りのレビュー）で挙がった指摘のうち、低リスク・高価値の2件を対応しました。

## 変更内容

### ② WriteAsync の直列化
`ConPtySession.WriteAsync` に `_writeLock`(SemaphoreSlim 1,1) を導入し、書き込み全体を排他化しました。
- UI・MCP(`send_to_session`)・RemoteLaunch など複数経路から同一セッションに同時書き込みすると、256文字チャンク＋`Task.Delay(20)` の隙間で入力が混線する
- 特に `submit=true` の本文送信と末尾 `\r` の間に別入力が割り込むと、送信内容や Enter が壊れる
- チャンクループ全体をロック内に入れて直列化。破棄との競合は `WaitAsync`/`Release` で `ObjectDisposedException` を握って安全に抜ける

### ③ セマフォ解放漏れの修正
`BufferOutput` / `FlushOutputBuffer` の `finally` が `if (!_disposed) Release()` になっており、イベント処理中に Dispose されると `_outputSemaphore.Release()` がスキップされ待機側が詰まる可能性があった。
- 「取得したら必ず解放」に変更。破棄済みで Release が `ObjectDisposedException` を投げるケースは既存の外側 `catch (ObjectDisposedException)` が受け止める

## 対応見送り（別途検討）
同レビューの以下は今回のPRに含めていません。
- ① ConPTY 側パイプ端の即時クローズ（EOF/ProcessExited 発火の副作用があるため単独PRで実機確認を厚めにしたい）
- ③のうちイベント発火をロック外に出す変更（出力順序保証を壊すリスクがあるため設計を詰めてから）
- ④ `cmd.exe /c` の二重ラップ/引用（意図的な既定動作。実害報告が出てから）

## 確認
- ビルド: 警告0・エラー0
- 実機確認: 通常のキー入力・AI CLI 操作、および MCP `send_to_session` 送信中の手入力で混線しないこと（ユーザー確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)