### PR TITLE
feat: ターミナル内の #123 をGitHub PR/Issueへのリンクにする

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -863,33 +863,42 @@
 
     /// <summary>
     /// ターミナル内の PR/Issue 番号（#123）がクリックされた時の処理（JavaScript から呼び出される）。
-    /// セッションの作業フォルダの origin が GitHub なら該当 PR ページを既定ブラウザで開く。
-    /// GitHub 以外・解決不可なら警告トーストのみ（クリックしても無害）。
+    /// セッションの作業フォルダの origin が GitHub なら該当 PR ページを解決する。
+    /// 外部ブラウザを開く＝外部遷移するため、コピー動作モード（モバイル全画面向け）を尊重する:
+    /// copyMode=true のときは開かずに URL を返し、JS 側でクリップボードへコピーさせる。
+    /// GitHub 以外・解決不可なら警告トーストのみで null を返す（クリックしても無害）。
     /// </summary>
+    /// <returns>コピー動作モードでコピーすべき URL。開いた場合・解決不可なら null</returns>
     [JSInvokable]
-    public async Task OnTerminalPrNumberClick(string sessionId, string prText)
+    public async Task<string?> OnTerminalPrNumberClick(string sessionId, string prText, bool copyMode)
     {
         try
         {
             if (!Guid.TryParse(sessionId, out var guid))
-                return;
+                return null;
 
             var session = sessions.FirstOrDefault(s => s.SessionId == guid);
             var basePath = session?.FolderPath;
             if (string.IsNullOrEmpty(basePath) || string.IsNullOrWhiteSpace(prText))
-                return;
+                return null;
 
             // "#123" から数字だけ取り出す
             var digits = new string(prText.Where(char.IsDigit).ToArray());
             if (!int.TryParse(digits, out var number) || number <= 0)
-                return;
+                return null;
 
             var url = await GitService.GetGitHubPrUrlAsync(basePath, number);
             if (string.IsNullOrEmpty(url))
             {
                 // origin が GitHub でない or 取得失敗（誤検出クリック含む・無害）
                 toast?.ShowWarning(string.Format(L["Root.Toast.PrNotOnGitHubFormat"], prText.Trim()));
-                return;
+                return null;
+            }
+
+            if (copyMode)
+            {
+                // 開かずに URL を返す（JS 側で copyLinkToClipboard する）
+                return url;
             }
 
             System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
@@ -897,10 +906,12 @@
                 FileName = url,
                 UseShellExecute = true,
             });
+            return null;
         }
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "[PrNumberClick] PR ページを開けませんでした: {PrText}", prText);
+            return null;
         }
     }
 

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -861,6 +861,49 @@
         }
     }
 
+    /// <summary>
+    /// ターミナル内の PR/Issue 番号（#123）がクリックされた時の処理（JavaScript から呼び出される）。
+    /// セッションの作業フォルダの origin が GitHub なら該当 PR ページを既定ブラウザで開く。
+    /// GitHub 以外・解決不可なら警告トーストのみ（クリックしても無害）。
+    /// </summary>
+    [JSInvokable]
+    public async Task OnTerminalPrNumberClick(string sessionId, string prText)
+    {
+        try
+        {
+            if (!Guid.TryParse(sessionId, out var guid))
+                return;
+
+            var session = sessions.FirstOrDefault(s => s.SessionId == guid);
+            var basePath = session?.FolderPath;
+            if (string.IsNullOrEmpty(basePath) || string.IsNullOrWhiteSpace(prText))
+                return;
+
+            // "#123" から数字だけ取り出す
+            var digits = new string(prText.Where(char.IsDigit).ToArray());
+            if (!int.TryParse(digits, out var number) || number <= 0)
+                return;
+
+            var url = await GitService.GetGitHubPrUrlAsync(basePath, number);
+            if (string.IsNullOrEmpty(url))
+            {
+                // origin が GitHub でない or 取得失敗（誤検出クリック含む・無害）
+                toast?.ShowWarning(string.Format(L["Root.Toast.PrNotOnGitHubFormat"], prText.Trim()));
+                return;
+            }
+
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "[PrNumberClick] PR ページを開けませんでした: {PrText}", prText);
+        }
+    }
+
     private async Task AddSession()
     {
         showCreateDialog = true;

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -607,6 +607,7 @@
   <data name="Root.Toast.FolderOpenedFormat" xml:space="preserve"><value>Opened folder: {0}</value></data>
   <data name="Root.Toast.FileOpenedFormat" xml:space="preserve"><value>Opened file: {0}</value></data>
   <data name="Root.Toast.CommitNotFoundFormat" xml:space="preserve"><value>Commit not found: {0}</value></data>
+  <data name="Root.Toast.PrNotOnGitHubFormat" xml:space="preserve"><value>Not a GitHub repository, cannot open: {0}</value></data>
   <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>Terminal disposed</value></data>
   <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>Terminal dispose error: {0}</value></data>
   <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>Terminal recreated</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -607,6 +607,7 @@
   <data name="Root.Toast.FolderOpenedFormat" xml:space="preserve"><value>フォルダを開きました: {0}</value></data>
   <data name="Root.Toast.FileOpenedFormat" xml:space="preserve"><value>ファイルを開きました: {0}</value></data>
   <data name="Root.Toast.CommitNotFoundFormat" xml:space="preserve"><value>コミットが見つかりません: {0}</value></data>
+  <data name="Root.Toast.PrNotOnGitHubFormat" xml:space="preserve"><value>GitHub リポジトリではないため開けません: {0}</value></data>
   <data name="Root.Toast.TerminalDisposed" xml:space="preserve"><value>ターミナルを破棄しました</value></data>
   <data name="Root.Toast.TerminalDisposeErrorFormat" xml:space="preserve"><value>ターミナル破棄エラー: {0}</value></data>
   <data name="Root.Toast.TerminalRecreated" xml:space="preserve"><value>ターミナルを再作成しました</value></data>

--- a/TerminalHub/Services/GitService.cs
+++ b/TerminalHub/Services/GitService.cs
@@ -470,6 +470,39 @@ namespace TerminalHub.Services
             }
         }
 
+        public async Task<string?> GetGitHubPrUrlAsync(string path, int number)
+        {
+            try
+            {
+                if (number <= 0)
+                    return null;
+
+                var result = await ExecuteGitCommandAsync(path, "remote get-url origin");
+                if (!result.Success || string.IsNullOrWhiteSpace(result.Output))
+                    return null;
+
+                // 対応する origin URL 形式:
+                //   https://github.com/owner/repo(.git)
+                //   git@github.com:owner/repo(.git)
+                //   ssh://git@github.com/owner/repo(.git)
+                // github.com 以外（GitLab 等）や解析不能なら null（＝リンク無効）
+                var url = result.Output.Trim();
+                var m = System.Text.RegularExpressions.Regex.Match(
+                    url,
+                    @"^(?:https?://|ssh://git@|git@)github\.com[:/](?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?/?$",
+                    System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                if (!m.Success)
+                    return null;
+
+                return $"https://github.com/{m.Groups["owner"].Value}/{m.Groups["repo"].Value}/pull/{number}";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "GitHub PR URL の組み立てに失敗しました: {Path} #{Number}", path, number);
+                return null;
+            }
+        }
+
         private async Task<(bool Success, string? Output, string? Error)> ExecuteGitCommandAsync(string workingDirectory, string arguments)
         {
             try

--- a/TerminalHub/Services/IGitService.cs
+++ b/TerminalHub/Services/IGitService.cs
@@ -77,6 +77,15 @@ namespace TerminalHub.Services
         /// <param name="hash">コミットハッシュ（7〜40桁の16進）</param>
         /// <returns>コミット情報。ハッシュがコミットに解決できない場合は null</returns>
         Task<GitCommitInfo?> GetCommitInfoAsync(string path, string hash);
+
+        /// <summary>
+        /// origin が GitHub リポジトリの場合、指定番号の PR ページ URL を組み立てて返す。
+        /// GitHub の /pull/{n} は対象が Issue なら /issues/{n} へ自動リダイレクトされるため PR/Issue の区別は不要。
+        /// </summary>
+        /// <param name="path">リポジトリのパス</param>
+        /// <param name="number">PR/Issue 番号</param>
+        /// <returns>PR ページ URL。origin が github.com でない・取得失敗時は null</returns>
+        Task<string?> GetGitHubPrUrlAsync(string path, int number);
     }
 
     /// <summary>

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -506,12 +506,7 @@ function setupPrNumberDetection(term, sessionId) {
                         end: { x: match.index + text.length + 1, y: bufferLineNumber }
                     },
                     text: text,
-                    activate: (e, uri) => {
-                        if (window.terminalHubDotNetRef) {
-                            window.terminalHubDotNetRef.invokeMethodAsync('OnTerminalPrNumberClick', sessionId, uri)
-                                .catch(err => console.error('[PR Detection] open failed:', err));
-                        }
-                    }
+                    activate: (e, uri) => activateTerminalPrNumber(sessionId, uri)
                 });
             }
 
@@ -538,6 +533,17 @@ function activateTerminalPath(sessionId, path) {
         window.terminalHubDotNetRef.invokeMethodAsync('OnTerminalPathClick', sessionId, path)
             .catch(err => console.error('[Path Detection] open failed:', err));
     }
+}
+
+// PR/Issue リンクのアクティベート処理。
+// 外部ブラウザを開く（＝外部遷移する）ため、URL/パスと同様にコピー動作モードを尊重する。
+// C# 側は copyMode=true のとき開かずに PR ページ URL を返すので、それをクリップボードへコピーする
+// （モバイル全画面向け。#123 の生テキストではなく解決後の URL をコピーする方が有用なため）。
+function activateTerminalPrNumber(sessionId, prText) {
+    if (!window.terminalHubDotNetRef) return;
+    window.terminalHubDotNetRef.invokeMethodAsync('OnTerminalPrNumberClick', sessionId, prText, terminalLinkCopyMode)
+        .then(url => { if (url) copyLinkToClipboard(url); })
+        .catch(err => console.error('[PR Detection] open failed:', err));
 }
 
 // URL検出の設定

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -470,6 +470,62 @@ function setupCommitHashDetection(term, sessionId) {
     }
 }
 
+// ===== PR/Issue 番号検出（#123 クリックで GitHub の該当 PR ページを開く） =====
+// 実データ調査より: 実ターミナル出力の #数字 は大半が本物の PR/Issue 参照で、
+// 唯一の恒常的な誤検出源は Claude Code の画像貼り付け UI「[Image #1]」だけだったため、それのみ除外する。
+function setupPrNumberDetection(term, sessionId) {
+    if (typeof term.registerLinkProvider !== 'function') {
+        return;
+    }
+
+    const prRegex = /#\d{1,6}/g;
+
+    const linkProvider = {
+        provideLinks: (bufferLineNumber, callback) => {
+            // bufferLineNumber は 1 始まり、getLine() は 0 始まり
+            const line = term.buffer.active.getLine(bufferLineNumber - 1);
+            if (!line) {
+                callback(undefined);
+                return;
+            }
+
+            const lineText = getBufferLineText(line);
+
+            const links = [];
+            let match;
+            prRegex.lastIndex = 0;
+            while ((match = prRegex.exec(lineText)) !== null) {
+                const text = match[0];
+
+                // 「Image #1」（画像貼り付けマーカー）は PR 参照ではないので除外
+                if (/Image\s*$/i.test(lineText.slice(0, match.index))) continue;
+
+                links.push({
+                    range: {
+                        start: { x: match.index + 1, y: bufferLineNumber },
+                        end: { x: match.index + text.length + 1, y: bufferLineNumber }
+                    },
+                    text: text,
+                    activate: (e, uri) => {
+                        if (window.terminalHubDotNetRef) {
+                            window.terminalHubDotNetRef.invokeMethodAsync('OnTerminalPrNumberClick', sessionId, uri)
+                                .catch(err => console.error('[PR Detection] open failed:', err));
+                        }
+                    }
+                });
+            }
+
+            callback(links.length > 0 ? links : undefined);
+        }
+    };
+
+    try {
+        term.registerLinkProvider(linkProvider);
+    } catch (error) {
+        console.error('[PR Detection] Failed to register link provider:', error);
+    }
+}
+
 // パスリンクのアクティベート処理
 function activateTerminalPath(sessionId, path) {
     if (terminalLinkCopyMode) {
@@ -867,6 +923,7 @@ window.terminalFunctions = {
             // ファイルパス検出機能を追加（フォルダ=Explorer/ファイル=既定アプリで開く）
             setupFilePathDetection(term, sessionId);
             setupCommitHashDetection(term, sessionId);
+            setupPrNumberDetection(term, sessionId);
 
             // Unicode11Addonをロード（ブロック文字の幅計算を改善）
             if (typeof Unicode11Addon !== 'undefined' && Unicode11Addon.Unicode11Addon) {


### PR DESCRIPTION
## 概要

ターミナル内に出てくる `#123` のような PR/Issue 番号をクリック可能にし、origin が GitHub のとき該当 PR ページを既定ブラウザで開きます。（URL / パス / コミットハッシュに続く**4つ目のリンクプロバイダ**）

Image #6 で共有されたステータス行 `… · PR #52 · ← for agents` のような表記もそのまま拾えます。

## 仕様の根拠（実データ調査）

実際のターミナルキャプチャ・ログ・`gh` 経由の PR/Issue/コミット本文を集計して仕様を決めました。

- **実 GitHub テキストの `#数字`（264件）はほぼ100%が本物の PR/Issue 参照**。誤爆源は Claude Code の画像貼り付けUI **`[Image #1]` だけ**（キャプチャ内の `#数字` 212件が全部これ）。
- 直前トークン分布: `(#52)` 括弧内 27% / `PR #` 20% / `pull request #`（マージコミット）18% / 素の `#116`・装飾など残り。
  → **`PR` 前置を必須にすると拾えるのは約2割**になり取りこぼすため、素の `#\d+` を拾う方針に。
- 唯一の恒常的誤検出 `[Image #N]` のみ除外すれば実ノイズは消える。

## 変更

- **terminal.js**: `setupPrNumberDetection`（`#\d{1,6}`、直前が `Image` の場合のみ除外）
- **GitService.GetGitHubPrUrlAsync**: `remote get-url origin` から `https/ssh/git@` 各形式の `owner/repo` を抽出し `/pull/{n}` を組み立て（Issue でも GitHub が `/issues/{n}` に自動リダイレクトするため区別不要）。github.com 以外は null＝リンク無効
- **Root.OnTerminalPrNumberClick**: 該当PRを既定ブラウザで開く。GitHub 以外・解決不可なら警告トーストのみ（クリックしても無害）
- **resx (ja/en)**: `Root.Toast.PrNotOnGitHubFormat` 追加

## 動作確認

- ユーザー実機で動作確認済み
- URL形式（https/ssh/git@/末尾スラッシュ/ドット入りrepo名）・GitLab除外・`[Image #1]`除外・連続 `#2 #3` / `#3/#4`・`#fff`非マッチ をスクリプトで検証済み
- `dotnet build` 0エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)