### PR TITLE
feat: セッションを開いたら一覧の先頭へ上げるオプション(試験機能・既定OFF)

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1168,6 +1168,12 @@
         if (wasAlreadyActive)
             return;
 
+        // 開くのに失敗（ディレクトリ非存在・初期化失敗）したときは SelectSession が
+        // activeSessionId を null に戻して return する。その場合は昇格しない
+        // （実際に開けて表示できたセッションだけを先頭へ上げる）。
+        if (activeSessionId != sessionId)
+            return;
+
         if (!AppSettingsService.GetSettings().Experimental.PromoteSessionOnOpen)
             return;
 

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -99,7 +99,7 @@
                      WidthPercent=@sidebarWidthPercent
                      NotificationPendingSessions=@_notificationPendingSessions
                      OnAddSession="AddSession"
-                     OnSessionSelect="async (sessionId) => await SelectSession(sessionId)"
+                     OnSessionSelect="async (sessionId) => await HandleSessionSelectFromList(sessionId)"
                      OnSessionRemove="async (sessionId) => await ArchiveSession(sessionId)"
                      OnSettingsClick="ShowSettings"
                      OnCreateWorktree="ShowWorktreeDialog"
@@ -1151,6 +1151,35 @@
         showCreateDialog = false;
     }
 
+
+    // 一覧クリックでセッションを開いたときの入口。
+    // 試験機能「セッションを開いたら一番上へ」が ON のときだけ、開いたセッションの
+    // LastAccessedAt を更新して並びの先頭へ引き上げる。プログラム由来の SelectSession
+    // 呼び出し（起動復元・URL・削除後フォールバック・再起動）では上げたくないので、
+    // 共通の SelectSession ではなくこの入口だけで昇格処理を行う。
+    private async Task HandleSessionSelectFromList(Guid sessionId)
+    {
+        // 今アクティブなセッションの再クリックは順位を動かさない。
+        // （SelectSession は先頭で即 return する no-op になるので、昇格もさせない）
+        var wasAlreadyActive = activeSessionId == sessionId;
+
+        await SelectSession(sessionId);
+
+        if (wasAlreadyActive)
+            return;
+
+        if (!AppSettingsService.GetSettings().Experimental.PromoteSessionOnOpen)
+            return;
+
+        var sessionInfo = SessionManager.GetSessionInfo(sessionId);
+        if (sessionInfo != null)
+        {
+            Logger.LogInformation("[LastAccessedAt更新] きっかけ: セッションを開いたら一番上へ(一覧クリック), セッション: {SessionName}", sessionInfo.GetDisplayName());
+            sessionInfo.LastAccessedAt = DateTime.Now;
+            await SaveSessionToStorageAsync(sessionInfo);
+            StateHasChanged();
+        }
+    }
 
     private async Task SelectSession(Guid sessionId, bool forceReinit = false)
     {

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -1021,6 +1021,25 @@
                                         Claude Code / Codex のみ対応（Gemini 等は非対応）。ポートは起動中の値を使います。全デバイス共通の設定です。
                                     </p>
                                 </div>
+
+                                <hr />
+
+                                @* セッションを一覧クリックで開いたら、そのセッションを一番上へ引き上げる（既定OFF・全デバイス共通） *@
+                                <div class="mb-4">
+                                    <h6 class="mb-2">セッションを開いたら一番上へ</h6>
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" @bind="promoteSessionOnOpenEnabled" id="promoteSessionOnOpenSwitch">
+                                        <label class="form-check-label" for="promoteSessionOnOpenSwitch">
+                                            一覧からセッションを開いたら、最終利用時刻を更新して一覧の先頭に上げる
+                                        </label>
+                                    </div>
+                                    <p class="text-muted small mt-2 mb-0">
+                                        <i class="bi bi-info-circle me-1"></i>
+                                        並び順が「<strong>最終利用順</strong>」のときに効きます。検索で見つけた古いセッションを開くと先頭へ来るので、
+                                        順位を上げるためだけにメッセージを送る必要がなくなります。起動時の復元・再起動・削除後の切替など、
+                                        自分でクリックした以外の選択では上げません。
+                                    </p>
+                                </div>
                             </div>
                         }
                         else if (activeTab == "localMcp")
@@ -1327,6 +1346,7 @@
     // 開発ツール関連
     private bool devToolsEnabled = false;
     private bool autoRegisterMcpEnabled = false;
+    private bool promoteSessionOnOpenEnabled = false;
     private bool autoSwitchCursorPadEnabled = false;
     // ローカルMCP タブ: 配布する instructions（空欄=既定テンプレを配布）
     private string mcpInstructions = "";
@@ -1469,6 +1489,7 @@
             // 開発ツール設定
             devToolsEnabled = settings.DevTools.Enabled;
             autoRegisterMcpEnabled = settings.Experimental.AutoRegisterMcp;
+            promoteSessionOnOpenEnabled = settings.Experimental.PromoteSessionOnOpen;
             // 未設定(null/空)なら既定テンプレを表示する（textarea は WYSIWYG）
             mcpInstructions = string.IsNullOrWhiteSpace(settings.Experimental.McpInstructions)
                 ? TerminalHub.Mcp.McpInstructionDefaults.Template
@@ -1723,6 +1744,7 @@
                 Experimental = new ExperimentalSettings
                 {
                     AutoRegisterMcp = autoRegisterMcpEnabled,
+                    PromoteSessionOnOpen = promoteSessionOnOpenEnabled,
                     // 既定テンプレそのまま(未編集) or 空なら null 保存し、将来の既定更新に追従させる。
                     // 書き換えられていればその内容を保存する。
                     // 改行コード(CRLF/LF)差で誤って非 null 保存しないよう、EOL 正規化して比較する

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -31,6 +31,14 @@ public class ExperimentalSettings
     public bool AutoRegisterMcp { get; set; } = false;
 
     /// <summary>
+    /// セッションを一覧からクリックして開いたときに、そのセッションの LastAccessedAt を
+    /// 更新して一覧の先頭へ引き上げる。既定OFF。ONにすると「最終利用順」ソート時に、
+    /// 開いた（＝注目した）セッションが自然に上へ来る。順位を上げるためだけに挨拶を
+    /// 打っていた運用の代替。プログラム由来の選択（起動復元・URL・再起動等）では上げない。
+    /// </summary>
+    public bool PromoteSessionOnOpen { get; set; } = false;
+
+    /// <summary>
     /// MCP サーバーが接続時にモデルへ配布する instructions（取扱説明・運用ルール）。
     /// null または空なら組み込みの既定テンプレ(McpInstructionDefaults.Template)を使う。
     /// ユーザーが書き換えたら、その内容をそのまま配布する（＝ユーザーが著者、TerminalHub は下書きを置くだけ）。


### PR DESCRIPTION
## 概要
一覧からセッションをクリックして開いたとき、そのセッションを一覧の先頭へ引き上げる試験機能を追加する（**既定OFF**）。

「更新日付順（最終利用順）」で並べていると、検索で見つけた古いセッションを開いても、検索を解除すると下の方へ戻ってしまう。これまでは順位を上げるためだけに「こんにちわ」等のメッセージを送って `LastAccessedAt` を更新していた。この運用を、CLIへ何も送らずに実現できるようにする。

## 挙動
昇格（`LastAccessedAt = DateTime.Now`）するのは、次を**すべて**満たすときだけ:
1. **一覧クリックで開いた**（`OnSessionSelect` 経由）。起動復元・URL指定・再起動・削除後フォールバック等の**プログラム由来の選択は対象外**。
2. **設定 `PromoteSessionOnOpen` が ON**（試験機能タブ）。
3. 開いた対象が**今アクティブなセッションの再クリックではない**。

- 起動済み/未起動は問わず、開けば上がる。
- CLI（ConPTY）へは何も書き込まない。UI 側で `LastAccessedAt` を更新して `SessionList` の既存ソート（`SortMode=="lastAccessed"`）に乗せるだけ。
- DB にも軽量に永続化（`SaveSessionToStorageAsync`）するので再起動後も並びは維持。

## 変更ファイル
- `Models/AppSettings.cs`: `ExperimentalSettings.PromoteSessionOnOpen`（bool・既定false）を追加。
- `Components/Pages/Root.razor`: 一覧クリックの入口 `HandleSessionSelectFromList` を新設。共通の `SelectSession` は無改変（副作用を入口に限定）。再クリック判定は `SelectSession` 呼び出し前に `activeSessionId` を捕捉して行う。
- `Components/Shared/Dialogs/SettingsDialog.razor`: 試験機能タブにトグル（説明文つき）＋ロード/保存の配線。

## 設計判断
- **既定OFF**。他ユーザーの現行挙動（活動で自然に浮く）は一切変えない。
- 昇格判定は選択時に `AppSettingsService.GetSettings()` を直読み → 設定保存後すぐ反映、コールバック配線不要。
- 「最終利用順」ソート時のみ意味を持つ旨は説明文に明記。
- `[LastAccessedAt更新] きっかけ: セッションを開いたら一番上へ(一覧クリック)` のログも出力。

## 確認
- ビルド 0警告0エラー。
- 動作確認は各自のローカルビルド→インストール後（ConPTY保護のため自動では起動しない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)