### PR TITLE
fix: ConPTY周りのレビュー指摘4件を修正（購読残留・ロック・API検査・パイプ端）

### DIFF
--- a/TerminalHub/Services/ConPtyConnectionService.cs
+++ b/TerminalHub/Services/ConPtyConnectionService.cs
@@ -47,6 +47,22 @@ namespace TerminalHub.Services
 
             _logger.LogInformation($"Subscribing to session {sessionId}");
 
+            // 同じIDの購読が既にあっても、ConPtySession が別インスタンスなら
+            // セッション再起動・再作成で置き換わったということ。古い購読を解除して
+            // 新しいインスタンスへ登録し直す（残したままだと TryAdd がスキップして
+            // 新プロセスの出力がこのCircuitへ届かなくなる）
+            if (_subscriptions.TryGetValue(sessionId, out var existing))
+            {
+                if (ReferenceEquals(existing.ConPtySession, conPtySession))
+                {
+                    _logger.LogDebug($"Session {sessionId} is already subscribed");
+                    return;
+                }
+
+                _logger.LogInformation($"Session {sessionId} was replaced. Re-subscribing to the new ConPtySession");
+                UnsubscribeFromSession(sessionId);
+            }
+
             // イベントハンドラーを作成
             EventHandler<DataReceivedEventArgs> dataHandler = (sender, args) =>
             {

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -225,10 +225,16 @@ namespace TerminalHub.Services
             {
                 // パイプの作成
                 const uint pipeBufferSize = 65536;
-                CreatePipe(out var hPipeIn, out hWritePipe, IntPtr.Zero, pipeBufferSize);
-                CreatePipe(out hReadPipe, out var hPipeOut, IntPtr.Zero, pipeBufferSize);
-
+                if (!CreatePipe(out var hPipeIn, out hWritePipe, IntPtr.Zero, pipeBufferSize))
+                {
+                    throw new InvalidOperationException($"Failed to create input pipe: {Marshal.GetLastWin32Error()}");
+                }
                 _hPipeIn = hPipeIn;
+
+                if (!CreatePipe(out hReadPipe, out var hPipeOut, IntPtr.Zero, pipeBufferSize))
+                {
+                    throw new InvalidOperationException($"Failed to create output pipe: {Marshal.GetLastWin32Error()}");
+                }
                 _hPipeOut = hPipeOut;
 
             // ConPTYの作成（XTerm互換のための設定）
@@ -244,21 +250,27 @@ namespace TerminalHub.Services
                 throw new InvalidOperationException($"Failed to create pseudo console: {hr:X}");
             }
 
-                // プロセス属性リストの初期化
+                // プロセス属性リストの初期化（1回目は必要サイズの取得。失敗が正常な標準パターン）
                 var lpSize = IntPtr.Zero;
                 InitializeProcThreadAttributeList(IntPtr.Zero, 1, 0, ref lpSize);
                 startupInfo.lpAttributeList = Marshal.AllocHGlobal(lpSize);
-                InitializeProcThreadAttributeList(startupInfo.lpAttributeList, 1, 0, ref lpSize);
+                if (!InitializeProcThreadAttributeList(startupInfo.lpAttributeList, 1, 0, ref lpSize))
+                {
+                    throw new InvalidOperationException($"Failed to initialize proc thread attribute list: {Marshal.GetLastWin32Error()}");
+                }
 
             // 擬似コンソールの属性を設定
-            UpdateProcThreadAttribute(
+            if (!UpdateProcThreadAttribute(
                 startupInfo.lpAttributeList,
                 0,
                 (IntPtr)ConPtyTerminalConstants.ProcThreadAttributePseudoConsole,
                 _hPC,
                 (IntPtr)IntPtr.Size,
                 IntPtr.Zero,
-                IntPtr.Zero);
+                IntPtr.Zero))
+            {
+                throw new InvalidOperationException($"Failed to set pseudo console attribute: {Marshal.GetLastWin32Error()}");
+            }
 
             // プロセスの作成
             var processInfo = new PROCESS_INFORMATION();
@@ -332,9 +344,11 @@ namespace TerminalHub.Services
             }
             catch
             {
-                // エラー時のクリーンアップ
+                // エラー時のクリーンアップ（初期化失敗時はDisposeが呼ばれないため、ConPTY側の端もここで閉じる）
                 if (hWritePipe != IntPtr.Zero) CloseHandle(hWritePipe);
                 if (hReadPipe != IntPtr.Zero) CloseHandle(hReadPipe);
+                if (_hPipeIn != IntPtr.Zero) { CloseHandle(_hPipeIn); _hPipeIn = IntPtr.Zero; }
+                if (_hPipeOut != IntPtr.Zero) { CloseHandle(_hPipeOut); _hPipeOut = IntPtr.Zero; }
                 if (processInfoHandle != IntPtr.Zero) CloseHandle(processInfoHandle);
                 if (threadInfoHandle != IntPtr.Zero) CloseHandle(threadInfoHandle);
                 if (startupInfo.lpAttributeList != IntPtr.Zero)
@@ -576,6 +590,13 @@ namespace TerminalHub.Services
         {
             if (_hPC != IntPtr.Zero)
             {
+                // 0以下・short範囲外はConPTYに渡せない（shortキャストで壊れた値になる）
+                if (cols <= 0 || rows <= 0 || cols > short.MaxValue || rows > short.MaxValue)
+                {
+                    _logger.LogWarning("無効なリサイズ要求を無視: {Cols}x{Rows}", cols, rows);
+                    return;
+                }
+
                 // 同サイズなら何もしない。ConPTY は ResizePseudoConsole のたびに
                 // ビューポート全体を「通常のスクロール出力」として再送してくるため、
                 // 無駄な呼び出しは画面・スクロールバック多重化の原因になる
@@ -584,10 +605,17 @@ namespace TerminalHub.Services
                     return;
                 }
 
+                var size = new COORD { X = (short)cols, Y = (short)rows };
+                var hr = ResizePseudoConsole(_hPC, size);
+                if (hr != 0)
+                {
+                    // 失敗時は Cols/Rows を更新しない（実際のConPTYサイズと状態バッファの不一致を防ぐ）
+                    _logger.LogWarning("ResizePseudoConsole failed with HRESULT: 0x{Hr:X8} ({Cols}x{Rows})", hr, cols, rows);
+                    return;
+                }
+
                 Cols = cols;
                 Rows = rows;
-                var size = new COORD { X = (short)cols, Y = (short)rows };
-                ResizePseudoConsole(_hPC, size);
 
                 // xterm.jsの場合、リサイズ後に追加の処理は不要
                 // xterm.js側でリフローを処理する
@@ -744,8 +772,9 @@ namespace TerminalHub.Services
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern void ClosePseudoConsole(IntPtr hPC);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool ResizePseudoConsole(IntPtr hPC, COORD size);
+        // HRESULT を返すAPI（bool宣言だと S_OK(0)=false と逆転判定になる）
+        [DllImport("kernel32.dll")]
+        private static extern int ResizePseudoConsole(IntPtr hPC, COORD size);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool CloseHandle(IntPtr hObject);

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -250,6 +250,14 @@ namespace TerminalHub.Services
                 throw new InvalidOperationException($"Failed to create pseudo console: {hr:X}");
             }
 
+            // ConPTYへ渡した端は CreatePseudoConsole 内部で複製されるため、親側では即閉じる
+            // （MS公式サンプルと同じ作法）。特に出力パイプの書き込み端をホストが保持し続けると、
+            // ConPTY終了後も読み取り側がEOFにならず、読み取りループが抜けられなくなる
+            CloseHandle(_hPipeIn);
+            _hPipeIn = IntPtr.Zero;
+            CloseHandle(_hPipeOut);
+            _hPipeOut = IntPtr.Zero;
+
                 // プロセス属性リストの初期化（1回目は必要サイズの取得。失敗が正常な標準パターン）
                 var lpSize = IntPtr.Zero;
                 InitializeProcThreadAttributeList(IntPtr.Zero, 1, 0, ref lpSize);

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -995,6 +995,10 @@ namespace TerminalHub.Services
 
         public async Task<ConPtySession?> RecreateSessionAsync(Guid sessionId, bool removeContinueOption = false)
         {
+            // 遅延初期化(GetSessionAsync)と同じセッション単位ロックで直列化し、
+            // 再作成中に並行アクセスがConPTYを二重生成してプロセスをリークするのを防ぐ
+            var initLock = _initializationLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
+            await initLock.WaitAsync();
             try
             {
                 var sessionInfo = GetSessionInfo(sessionId);
@@ -1040,10 +1044,18 @@ namespace TerminalHub.Services
                 _logger.LogError(ex, "セッション再作成でエラーが発生しました: {SessionId}", sessionId);
                 return null;
             }
+            finally
+            {
+                initLock.Release();
+            }
         }
 
         public async Task<bool> RestartSessionAsync(Guid sessionId)
         {
+            // 遅延初期化(GetSessionAsync)と同じセッション単位ロックで直列化し、
+            // 再起動中に並行アクセスがConPTYを二重生成してプロセスをリークするのを防ぐ
+            var initLock = _initializationLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
+            await initLock.WaitAsync();
             try
             {
                 var sessionInfo = GetSessionInfo(sessionId);
@@ -1099,6 +1111,10 @@ namespace TerminalHub.Services
             {
                 _logger.LogError(ex, "セッション再起動でエラーが発生しました: {SessionId}", sessionId);
                 return false;
+            }
+            finally
+            {
+                initLock.Release();
             }
         }
 

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -421,10 +421,13 @@ namespace TerminalHub.Services
             }
 
             // ConPtyセッションがまだ初期化されていない場合は遅延初期化を実行
+            if (!await TryAcquireInitLockAsync(initLock))
+            {
+                _logger.LogWarning("初期化ロックが破棄されていました（セッション削除と競合）: SessionId={SessionId}", sessionId);
+                return null;
+            }
             try
             {
-                await initLock.WaitAsync();
-
                 // セマフォ取得後、セッションが削除されていないか再確認
                 lock (_lockObject)
                 {
@@ -511,7 +514,7 @@ namespace TerminalHub.Services
             }
             finally
             {
-                initLock.Release();
+                ReleaseInitLockSafely(initLock);
             }
         }
 
@@ -837,6 +840,41 @@ namespace TerminalHub.Services
         }
 
         /// <summary>
+        /// セッション単位の初期化ロックを取得する。
+        /// 削除系メソッド（RemoveSessionAsync/ArchiveSession/DeleteSession）は _initializationLocks から
+        /// TryRemove したセマフォをロック外で Dispose するため、取得がそれと競合すると
+        /// ObjectDisposedException になる。その場合は「セッションは削除中」とみなし false を返す。
+        /// </summary>
+        private static async Task<bool> TryAcquireInitLockAsync(SemaphoreSlim initLock)
+        {
+            try
+            {
+                await initLock.WaitAsync();
+                return true;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 初期化ロックを解放する。保持中にセッション削除側で Dispose された場合の
+        /// ObjectDisposedException は握りつぶす（finally から呼び出し元へ漏らさない）
+        /// </summary>
+        private static void ReleaseInitLockSafely(SemaphoreSlim initLock)
+        {
+            try
+            {
+                initLock.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // 削除と競合して破棄済み。解放不要
+            }
+        }
+
+        /// <summary>
         /// 既存セッションを破棄する共通処理
         /// </summary>
         private async Task DisposeExistingSessionAsync(Guid sessionId, SessionInfo sessionInfo)
@@ -998,7 +1036,11 @@ namespace TerminalHub.Services
             // 遅延初期化(GetSessionAsync)と同じセッション単位ロックで直列化し、
             // 再作成中に並行アクセスがConPTYを二重生成してプロセスをリークするのを防ぐ
             var initLock = _initializationLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
-            await initLock.WaitAsync();
+            if (!await TryAcquireInitLockAsync(initLock))
+            {
+                _logger.LogWarning("セッション再作成を中止: 初期化ロックが破棄されていました（セッション削除と競合）: {SessionId}", sessionId);
+                return null;
+            }
             try
             {
                 var sessionInfo = GetSessionInfo(sessionId);
@@ -1046,7 +1088,7 @@ namespace TerminalHub.Services
             }
             finally
             {
-                initLock.Release();
+                ReleaseInitLockSafely(initLock);
             }
         }
 
@@ -1055,7 +1097,11 @@ namespace TerminalHub.Services
             // 遅延初期化(GetSessionAsync)と同じセッション単位ロックで直列化し、
             // 再起動中に並行アクセスがConPTYを二重生成してプロセスをリークするのを防ぐ
             var initLock = _initializationLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
-            await initLock.WaitAsync();
+            if (!await TryAcquireInitLockAsync(initLock))
+            {
+                _logger.LogWarning("セッション再起動を中止: 初期化ロックが破棄されていました（セッション削除と競合）: {SessionId}", sessionId);
+                return false;
+            }
             try
             {
                 var sessionInfo = GetSessionInfo(sessionId);
@@ -1114,7 +1160,7 @@ namespace TerminalHub.Services
             }
             finally
             {
-                initLock.Release();
+                ReleaseInitLockSafely(initLock);
             }
         }
 


### PR DESCRIPTION
## 概要
コードレビューで指摘されたConPTY関連の4件を修正します。

## 修正内容

### 高① セッション再起動後に購読が古いConPtySessionのまま残る問題
非アクティブセッションを設定画面から再起動すると、Circuitに残った旧ConPtySessionへの購読を `TryAdd` が検出して再登録をスキップし、新プロセスの出力がブラウザへ届かなくなっていた。`SubscribeToSession` で既存購読の `ConPtySession` 参照が異なる場合は解除して再登録するようにした（呼び出し側全経路とマルチブラウザにも効く根本対処）。

### 中③ 再作成・再起動をセッション単位ロックで直列化
`RecreateSessionAsync` / `RestartSessionAsync` が `_initializationLocks` の外で動いていたため、MCP・リモート起動経由の `GetSessionAsync` と競合するとConPTYを二重生成しプロセスをリークし得た。遅延初期化と同じロックで直列化。

### 中④ ネイティブAPIの戻り値検査
- `CreatePipe` / `InitializeProcThreadAttributeList`(2回目) / `UpdateProcThreadAttribute` の失敗時に例外を送出
- `ResizePseudoConsole` はHRESULTを返すAPIのため `bool` 宣言を `int` に修正し、失敗時は `Cols/Rows` を更新しない
- リサイズ要求のサイズ検証（0以下・short範囲外を拒否）を追加
- 初期化失敗時のクリーンアップでConPTY側パイプ端も閉じる

### 高② CreatePseudoConsole成功後にConPTY側パイプ端を閉じる
ConPTYへ渡したパイプ端は内部で複製されるため、親側では即閉じる（MS公式サンプルと同じ作法）。出力パイプの書き込み端をホストが保持し続けると、読み取り側がEOFにならず終了検知を妨げるため。

## 動作確認（実機・localhost:5081）
- 新規Terminalセッションの起動・入出力・リサイズ正常
- **①の再現手順**（非アクティブセッションを設定から再起動→再選択）で新プロセスの出力がライブ表示されることを確認。ログにも `Session ... was replaced. Re-subscribing to the new ConPtySession` を確認
- `exit` でシェルプロセスがOSレベルで終了、再起動時のDisposeで conhost.exe も消滅（リークなし）
- セッション切替時のバッファ復元・画面崩れなし、ブラウザコンソールエラーなし
- ③の競合タイミング再現は不可のため通常経路のみ確認（コードレビュー担保）

🤖 Generated with [Claude Code](https://claude.com/claude-code)