### PR TITLE
fix: 再作成・再起動中のセッション削除でConPTYが辞書に復活する競合を修正

### DIFF
--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -1075,8 +1075,23 @@ namespace TerminalHub.Services
                 // 新しいセッションを作成（Startは呼ばない）
                 ConPtySession newSession = await _conPtyService.CreateSessionAsync(command, args, sessionInfo.FolderPath, cols, rows, sessionInfo.SessionId);
                 AttachServerSideBufferTap(sessionInfo, newSession);
-                _sessions[sessionId] = newSession;
-                sessionInfo.ConPtySession = newSession;
+
+                // ConPtySession登録をロック内で実行（GetSessionAsyncと同じ再確認）。
+                // 削除系はセッション単位ロックを取らないため、CreateSessionAsyncのawait中に
+                // 削除されていると、ここで登録すると削除済みIDのConPTYが辞書に復活してリークする
+                lock (_lockObject)
+                {
+                    if (!_sessionInfos.TryGetValue(sessionId, out var currentInfo) ||
+                        !ReferenceEquals(currentInfo, sessionInfo))
+                    {
+                        _logger.LogWarning("ConPtySession作成後にセッションが削除されていました: SessionId={SessionId}", sessionId);
+                        newSession.Dispose();
+                        return null;
+                    }
+
+                    _sessions[sessionId] = newSession;
+                    sessionInfo.ConPtySession = newSession;
+                }
 
                 _logger.LogInformation("新しいConPtySessionを作成しました（未起動）: {SessionId}", sessionId);
                 return newSession;
@@ -1143,8 +1158,24 @@ namespace TerminalHub.Services
                 // 新しいセッションを作成して起動
                 ConPtySession newSession = await _conPtyService.CreateSessionAsync(command, args, sessionInfo.FolderPath, cols, rows, sessionInfo.SessionId);
                 AttachServerSideBufferTap(sessionInfo, newSession);
-                _sessions[sessionId] = newSession;
-                sessionInfo.ConPtySession = newSession;
+
+                // ConPtySession登録をロック内で実行（GetSessionAsyncと同じ再確認）。
+                // 削除系はセッション単位ロックを取らないため、CreateSessionAsyncのawait中に
+                // 削除されていると、ここで登録・起動すると到達不能なゾンビプロセスが残る
+                lock (_lockObject)
+                {
+                    if (!_sessionInfos.TryGetValue(sessionId, out var currentInfo) ||
+                        !ReferenceEquals(currentInfo, sessionInfo))
+                    {
+                        _logger.LogWarning("ConPtySession作成後にセッションが削除されていました: SessionId={SessionId}", sessionId);
+                        newSession.Dispose();
+                        return false;
+                    }
+
+                    _sessions[sessionId] = newSession;
+                    sessionInfo.ConPtySession = newSession;
+                }
+
                 newSession.Start();
                 // 状態バッファのグリッドも ConPTY と同サイズに揃える（寸法不一致による折返し乱れを防ぐ）
                 sessionInfo.ResizeTerminalBuffer(cols, rows);

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -475,10 +475,12 @@ namespace TerminalHub.Services
                 // ConPtySession登録をロック内で実行
                 lock (_lockObject)
                 {
-                    // 登録前に再度セッションが削除されていないか確認
-                    if (!_sessionInfos.ContainsKey(sessionId))
+                    // 登録前に再度セッションが削除・アーカイブされていないか確認
+                    // （ArchiveSession は _sessionInfos からエントリを消さず IsArchived を立てるだけなので、
+                    //  存在チェックだけでは捕捉できない）
+                    if (!_sessionInfos.TryGetValue(sessionId, out var currentInfo) || currentInfo.IsArchived)
                     {
-                        _logger.LogWarning("ConPtySession作成後にセッションが削除されていました: SessionId={SessionId}", sessionId);
+                        _logger.LogWarning("ConPtySession作成後にセッションが削除またはアーカイブされていました: SessionId={SessionId}", sessionId);
                         newSession.Dispose();
                         return null;
                     }
@@ -1078,13 +1080,15 @@ namespace TerminalHub.Services
 
                 // ConPtySession登録をロック内で実行（GetSessionAsyncと同じ再確認）。
                 // 削除系はセッション単位ロックを取らないため、CreateSessionAsyncのawait中に
-                // 削除されていると、ここで登録すると削除済みIDのConPTYが辞書に復活してリークする
+                // 削除されていると、ここで登録すると削除済みIDのConPTYが辞書に復活してリークする。
+                // ArchiveSession はエントリを残して IsArchived を立てるだけなので、フラグも確認する
                 lock (_lockObject)
                 {
                     if (!_sessionInfos.TryGetValue(sessionId, out var currentInfo) ||
-                        !ReferenceEquals(currentInfo, sessionInfo))
+                        !ReferenceEquals(currentInfo, sessionInfo) ||
+                        currentInfo.IsArchived)
                     {
-                        _logger.LogWarning("ConPtySession作成後にセッションが削除されていました: SessionId={SessionId}", sessionId);
+                        _logger.LogWarning("ConPtySession作成後にセッションが削除またはアーカイブされていました: SessionId={SessionId}", sessionId);
                         newSession.Dispose();
                         return null;
                     }
@@ -1161,13 +1165,15 @@ namespace TerminalHub.Services
 
                 // ConPtySession登録をロック内で実行（GetSessionAsyncと同じ再確認）。
                 // 削除系はセッション単位ロックを取らないため、CreateSessionAsyncのawait中に
-                // 削除されていると、ここで登録・起動すると到達不能なゾンビプロセスが残る
+                // 削除されていると、ここで登録・起動すると到達不能なゾンビプロセスが残る。
+                // ArchiveSession はエントリを残して IsArchived を立てるだけなので、フラグも確認する
                 lock (_lockObject)
                 {
                     if (!_sessionInfos.TryGetValue(sessionId, out var currentInfo) ||
-                        !ReferenceEquals(currentInfo, sessionInfo))
+                        !ReferenceEquals(currentInfo, sessionInfo) ||
+                        currentInfo.IsArchived)
                     {
-                        _logger.LogWarning("ConPtySession作成後にセッションが削除されていました: SessionId={SessionId}", sessionId);
+                        _logger.LogWarning("ConPtySession作成後にセッションが削除またはアーカイブされていました: SessionId={SessionId}", sessionId);
                         newSession.Dispose();
                         return false;
                     }


### PR DESCRIPTION
## 概要
PR #122 のフォローアップ。再作成・再起動と削除の競合でConPTYプロセスがリークする問題を修正します。

## 問題
削除系メソッド（`RemoveSessionAsync` / `ArchiveSession` / `DeleteSession`）はセッション単位ロック（`_initializationLocks`）を取得せず、`_lockObject` で辞書から消して初期化ロックをDisposeするだけ。そのため `RecreateSessionAsync` / `RestartSessionAsync` がロックを保持していても削除はブロックされず、`CreateSessionAsync` の `await` 中に削除が完了すると:

- その後の `_sessions[sessionId] = newSession` で**削除済みIDのConPTYが辞書に復活**
- `RestartSessionAsync` では `Start()` まで呼ばれ、UIからもMCPからも到達できないゾンビプロセスが残る

`GetSessionAsync`（遅延初期化）には登録前の再確認が元々あり（`SessionManager.cs` の「登録前に再度セッションが削除されていないか確認」）、Recreate/Restart にだけ同じガードが無かった。

## 修正
`GetSessionAsync` と同じパターンを両メソッドに適用:
- 登録直前に `_lockObject` 内で `_sessionInfos` の存在＋同一性（`ReferenceEquals`）を再確認
- 消えていれば `newSession.Dispose()` して中止（Recreate=null / Restart=false）
- `RestartSessionAsync` の `Start()` は登録確定後に移動

`ReferenceEquals` チェックにより「削除→同IDで復元」で `SessionInfo` インスタンスが差し替わったケースも弾く。

## 残課題（本PR対象外）
削除系がセッション単位ロックを取得してから状態変更する「理想形」は、削除系の同期構造（`_lockObject` ベース）の変更が大きいため見送り。待機中セマフォのDispose（`SemaphoreSlim.Dispose` は待機タスクを解放しない）による理論上のハングも既存挙動のまま。

## 動作確認
- Releaseビルド 警告0・エラー0
- 競合タイミングの実機再現は困難なため、通常経路（再起動・削除）はマージ後の通常利用で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)