### PR TITLE
perf: リプレイ書き込みをチャンク分割しセッション切替時のUIブロックを解消

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1324,7 +1324,10 @@
                         {
                             Logger.LogInformation("[SelectSession] バッファ書き込み開始: SessionId={SessionId}, Size={Size}文字",
                                 sessionId, replaySnapshot.Content.Length);
-                            await TerminalService.WriteToTerminalAsync(activeTerminal, replaySnapshot.Content);
+                            // 巨大なリプレイを一発で書くと Blazor サーキットの Dispatcher を長時間占有し、
+                            // 直後の送信などの UI 操作が書き込み完了まで待たされる。チャンク分割して
+                            // 合間に await することで、待機中の操作がチャンクの合間に割り込めるようにする。
+                            await TerminalService.WriteToTerminalChunkedAsync(activeTerminal, replaySnapshot.Content);
                             Logger.LogInformation("[SelectSession] バッファ書き込み完了");
                         }
                     }
@@ -1335,7 +1338,9 @@
 
                     if (!string.IsNullOrEmpty(replayTail))
                     {
-                        await TerminalService.WriteToTerminalAsync(activeTerminal, replayTail);
+                        // テールも同様にチャンク分割（通常は小さいが、リプレイ中に溜まったライブ出力が
+                        // 大きくなるケースに備える）
+                        await TerminalService.WriteToTerminalChunkedAsync(activeTerminal, replayTail);
                     }
                     _restoringSessionId = null;
                 }

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1326,7 +1326,9 @@
                                 sessionId, replaySnapshot.Content.Length);
                             // 巨大なリプレイを一発で書くと Blazor サーキットの Dispatcher を長時間占有し、
                             // 直後の送信などの UI 操作が書き込み完了まで待たされる。チャンク分割して
-                            // 合間に await することで、待機中の操作がチャンクの合間に割り込めるようにする。
+                            // 合間に await することで、_terminalWriteLock を要求しない操作（テキスト送信＝
+                            // ConPTY 入力側など）がチャンクの合間に割り込めるようにする。なお同じロックを
+                            // 取るライブ出力書き込みは従来どおりループ全体の完了まで直列化される（順序保証は不変）。
                             await TerminalService.WriteToTerminalChunkedAsync(activeTerminal, replaySnapshot.Content);
                             Logger.LogInformation("[SelectSession] バッファ書き込み完了");
                         }

--- a/TerminalHub/Services/ITerminalService.cs
+++ b/TerminalHub/Services/ITerminalService.cs
@@ -51,6 +51,13 @@ namespace TerminalHub.Services
         Task WriteToTerminalAsync(IJSObjectReference terminal, string data);
 
         /// <summary>
+        /// ターミナルに大きなデータをチャンク分割して書き込む。
+        /// チャンク間で await して Blazor サーキットの Dispatcher に制御を返すため、
+        /// 巨大なリプレイ書き込み中でも送信などの UI 操作が割り込めるようになる。
+        /// </summary>
+        Task WriteToTerminalChunkedAsync(IJSObjectReference terminal, string data, int chunkSize = 32768);
+
+        /// <summary>
         /// 要素が存在するかチェックする
         /// </summary>
         Task<bool> CheckElementExistsAsync(string elementId);

--- a/TerminalHub/Services/TerminalService.cs
+++ b/TerminalHub/Services/TerminalService.cs
@@ -172,6 +172,30 @@ namespace TerminalHub.Services
             await terminal.InvokeVoidAsync("write", data);
         }
 
+        public async Task WriteToTerminalChunkedAsync(IJSObjectReference terminal, string data, int chunkSize = 32768)
+        {
+            if (string.IsNullOrEmpty(data))
+            {
+                return;
+            }
+
+            // チャンクサイズ以下なら分割コスト（interop 往復の増加）をかけず一発で書く。
+            if (data.Length <= chunkSize)
+            {
+                await terminal.InvokeVoidAsync("write", data);
+                return;
+            }
+
+            // 大きなリプレイを分割し、チャンク間で await して Dispatcher に制御を返す。
+            // xterm の write() は連続呼び出しでパーサ状態を保持するため、ANSI エスケープ列の
+            // 途中で分割されても次の write で継続処理され、描画は壊れない。
+            for (var offset = 0; offset < data.Length; offset += chunkSize)
+            {
+                var length = Math.Min(chunkSize, data.Length - offset);
+                await terminal.InvokeVoidAsync("write", data.Substring(offset, length));
+            }
+        }
+
         public async Task RefreshTerminalAsync(Guid sessionId)
         {
             try

--- a/TerminalHub/Services/TerminalService.cs
+++ b/TerminalHub/Services/TerminalService.cs
@@ -189,10 +189,21 @@ namespace TerminalHub.Services
             // 大きなリプレイを分割し、チャンク間で await して Dispatcher に制御を返す。
             // xterm の write() は連続呼び出しでパーサ状態を保持するため、ANSI エスケープ列の
             // 途中で分割されても次の write で継続処理され、描画は壊れない。
-            for (var offset = 0; offset < data.Length; offset += chunkSize)
+            // ただし UTF-16 サロゲートペア（絵文字等の非BMP文字）は別々の write() 呼び出しに
+            // 分かれるとゴミ文字化しうる（過去に PR #95 で潰したクラスのバグ）。境界が高位
+            // サロゲートで終わる場合は 1 文字手前で区切り、ペアを分断しない。
+            var offset = 0;
+            while (offset < data.Length)
             {
                 var length = Math.Min(chunkSize, data.Length - offset);
+                // 末尾が高位サロゲート（＝直後に低位サロゲートが続くペアの前半）なら 1 文字縮める。
+                // まだ続きがある（offset + length < data.Length）ときのみ調整すればよい。
+                if (offset + length < data.Length && char.IsHighSurrogate(data[offset + length - 1]))
+                {
+                    length--;
+                }
                 await terminal.InvokeVoidAsync("write", data.Substring(offset, length));
+                offset += length;
             }
         }
 


### PR DESCRIPTION
## 背景

Webhook 投げっぱなし化(#124)で hook 応答経路のブロックは解消したが、実運用ログで別のひっかかりを確認した。

- セッション切替時、直後のテキスト送信が一瞬効かず、少し経ってから実行される
- 同時刻に `[MQTT] 切断検知(Intentional=False)` が出る = プロセスが一時的に詰まってキープアライブを取りこぼす兆候

## 原因

`SelectSession` のバッファリプレイ書き込みが **200KB超を1回の JS interop**(`WriteToTerminalAsync`)で行っていた。

- Blazor Server は1サーキットあたり Dispatcher が単一で、UIイベント(切替・送信・クリック)を直列処理する
- 巨大な `write` interop が Dispatcher を長時間占有し、待機中の送信イベントが書き込み完了までキューで待たされる
- ロック競合ではない(テキスト送信は `_terminalWriteLock` を取らない)。純粋にサーキットの直列実行待ち

## 変更

`WriteToTerminalChunkedAsync` を追加し、リプレイ本体とテールの書き込みをチャンク分割に差し替え。

- 32KB単位に分割し、**チャンク間で `await` して Dispatcher に制御を返す** → 待機中の送信操作がチャンクの合間に割り込める
- 32KB以下は従来どおり一発書き込み(小さい切替にオーバーヘッドなし)
- `_terminalWriteLock` は保持のままなので**ライブ出力との順序は不変**
- xterm の `write()` は連続呼び出しでパーサ状態を保持するため、**ANSIエスケープ列の途中分割でも描画は壊れない**
- VTエミュレータ(PR #91)や `.raw` テストには非接触

## 検証

- `dotnet build`: 警告0・エラー0
- 実機ブラウザ(localhost)で確認済み:
  - 大きな Claude セッション(TerminalHub / demo バナー)の描画が色・罫線・日本語含め正常、化けなし
  - 連続セッション切替で崩れ・残像なし
  - コンソールエラーなし
- 応答性(送信ひっかかり解消)の体感確認はローカルで実施予定

## 影響ファイル

- `TerminalHub/Services/ITerminalService.cs`
- `TerminalHub/Services/TerminalService.cs`
- `TerminalHub/Components/Pages/Root.razor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)