### PR TITLE
fix: セッション昇格を新規ConPTY接続時のみに限定

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1157,11 +1157,19 @@
     // LastAccessedAt を更新して並びの先頭へ引き上げる。プログラム由来の SelectSession
     // 呼び出し（起動復元・URL・削除後フォールバック・再起動）では上げたくないので、
     // 共通の SelectSession ではなくこの入口だけで昇格処理を行う。
+    // 昇格対象は「この選択で新規に ConPTY へ接続したセッション」のみ。既に起動済み
+    // （一覧で通常表示）のセッションを選び直しただけでは順位を動かさない。
     private async Task HandleSessionSelectFromList(Guid sessionId)
     {
         // 今アクティブなセッションの再クリックは順位を動かさない。
         // （SelectSession は先頭で即 return する no-op になるので、昇格もさせない）
         var wasAlreadyActive = activeSessionId == sessionId;
+
+        // 選択「前」の ConPTY 接続状態を捕捉する。判定は一覧の「薄く表示（未接続）」と
+        // 同じ述語（SessionList.GetConnectionOpacityClass）に合わせる: プロセスが生きて
+        // 接続済みなら通常表示＝昇格しない、null/終了済み（薄く表示）なら今回の選択で
+        // 新規接続する＝昇格対象。
+        var wasConnected = SessionManager.GetSessionInfo(sessionId)?.ConPtySession is { HasExited: false };
 
         await SelectSession(sessionId);
 
@@ -1172,6 +1180,10 @@
         // activeSessionId を null に戻して return する。その場合は昇格しない
         // （実際に開けて表示できたセッションだけを先頭へ上げる）。
         if (activeSessionId != sessionId)
+            return;
+
+        // 既に接続済み（通常表示）だった＝新規接続ではないので昇格しない。
+        if (wasConnected)
             return;
 
         if (!AppSettingsService.GetSettings().Experimental.PromoteSessionOnOpen)

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1166,10 +1166,15 @@
         var wasAlreadyActive = activeSessionId == sessionId;
 
         // 選択「前」の ConPTY 接続状態を捕捉する。判定は一覧の「薄く表示（未接続）」と
-        // 同じ述語（SessionList.GetConnectionOpacityClass）に合わせる: プロセスが生きて
-        // 接続済みなら通常表示＝昇格しない、null/終了済み（薄く表示）なら今回の選択で
-        // 新規接続する＝昇格対象。
-        var wasConnected = SessionManager.GetSessionInfo(sessionId)?.ConPtySession is { HasExited: false };
+        // 同じ述語（SessionList.GetConnectionOpacityClass）に合わせる: 接続処理中
+        // （IsConnecting）または プロセスが生きて接続済み（ConPtySession が非 null かつ
+        // 未終了）なら通常表示＝昇格しない。null/終了済み（薄く表示）なら今回の選択で
+        // 新規接続する＝昇格対象。IsConnecting を含めないと、接続処理中の窓
+        // （GetSessionAsync が IsConnecting を立ててから ConPtySession をセットするまで）に
+        // 別ブラウザ等から選択された場合に「通常表示なのに昇格」してしまうため、3 分岐を揃える。
+        var beforeInfo = SessionManager.GetSessionInfo(sessionId);
+        var wasConnected = beforeInfo?.IsConnecting == true
+            || beforeInfo?.ConPtySession is { HasExited: false };
 
         await SelectSession(sessionId);
 


### PR DESCRIPTION
## 背景

試験機能「セッションを開いたら一番上へ」(#8b417e6, 既定OFF)が、意図と異なる挙動になっていた。

- **意図**: 新規に ConPTY へ接続したセッションのみを先頭へ昇格したい
- **実際**: 別セッションを一覧クリックするたびに(既に起動済みでも)`LastAccessedAt` が更新され、常に先頭へ移動していた

## 原因

`HandleSessionSelectFromList` の昇格条件が「アクティブでない別セッション」かつ「設定ON」だけで、**ConPTY が起動済みか未起動かを見ていなかった**。

## 修正

`SelectSession` 呼び出しの**前**に接続状態を捕捉し、既に接続済み(プロセス生存)だった場合は昇格しないガードを追加。

判定述語は一覧の「薄く表示(未接続)」= `SessionList.GetConnectionOpacityClass` と同じ `ConPtySession is { HasExited: false }` に揃え、**見た目(薄い/通常)と昇格挙動を一致**させた。

| 操作 | 昇格 |
|---|---|
| 薄い(未接続)セッションを開く → 新規ConPTY接続 | ✅ 上がる |
| 既に動いている(通常表示)セッションを選び直す | ❌ 上がらない |
| アクティブなセッションを再クリック | ❌ 上がらない(従来どおり) |
| 起動復元・URL・再起動・削除後フォールバック | ❌ 対象外(従来どおり) |

## 検証

- `dotnet build`: 警告0・エラー0
- 変更は `HandleSessionSelectFromList` の +12 行のみ。既定OFFの試験機能なので通常運用への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)