### PR TITLE
Codexオプションを整理してインライン表示を既定化

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -147,6 +147,9 @@
     private const string LAST_CODEX_MODE_KEY = "lastCodexMode";
     private const string LAST_CODEX_SANDBOX_MODE_KEY = "lastCodexSandboxMode";
     private const string LAST_CODEX_APPROVAL_POLICY_KEY = "lastCodexApprovalPolicy";
+    private const string LAST_CODEX_RESUME_LAST_KEY = "lastCodexResumeLast";
+    private const string LAST_CODEX_NO_ALT_SCREEN_KEY = "lastCodexNoAltScreen";
+    private const string LAST_CODEX_SEARCH_ENABLED_KEY = "lastCodexSearchEnabled";
     private bool showCreateFolderDialog = false;
     private bool pendingSessionCreation = false;
 
@@ -285,6 +288,13 @@
             {
                 codexOptions.ApprovalPolicy = codexApproval;
             }
+
+            codexOptions.ResumeLast =
+                await LocalStorage.GetAsync<bool?>(LAST_CODEX_RESUME_LAST_KEY) ?? codexOptions.ResumeLast;
+            codexOptions.NoAltScreen =
+                await LocalStorage.GetAsync<bool?>(LAST_CODEX_NO_ALT_SCREEN_KEY) ?? codexOptions.NoAltScreen;
+            codexOptions.SearchEnabled =
+                await LocalStorage.GetAsync<bool?>(LAST_CODEX_SEARCH_ENABLED_KEY) ?? codexOptions.SearchEnabled;
         }
         catch
         {
@@ -301,6 +311,9 @@
             await LocalStorage.SetAsync(LAST_CODEX_MODE_KEY, codexOptions.Mode);
             await LocalStorage.SetAsync(LAST_CODEX_SANDBOX_MODE_KEY, codexOptions.SandboxMode);
             await LocalStorage.SetAsync(LAST_CODEX_APPROVAL_POLICY_KEY, codexOptions.ApprovalPolicy);
+            await LocalStorage.SetAsync(LAST_CODEX_RESUME_LAST_KEY, codexOptions.ResumeLast);
+            await LocalStorage.SetAsync(LAST_CODEX_NO_ALT_SCREEN_KEY, codexOptions.NoAltScreen);
+            await LocalStorage.SetAsync(LAST_CODEX_SEARCH_ENABLED_KEY, codexOptions.SearchEnabled);
         }
         catch
         {

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -173,6 +173,24 @@
                 </label>
             </div>
 
+            <div class="form-check mt-2">
+                <input class="form-check-input" type="checkbox" @bind="CodexOptions.NoAltScreen" id="@($"codexNoAltScreen{UniqueId}")">
+                <label class="form-check-label" for="@($"codexNoAltScreen{UniqueId}")">
+                    @L["SessionOptions.Codex.NoAltScreen"]
+                </label>
+                <div class="form-text mt-0">@L["SessionOptions.Codex.NoAltScreen.Help"]</div>
+            </div>
+
+            <div class="form-check mt-2">
+                <input class="form-check-input" type="checkbox" @bind="CodexOptions.SearchEnabled" id="@($"codexSearch{UniqueId}")">
+                <label class="form-check-label" for="@($"codexSearch{UniqueId}")">
+                    @L["SessionOptions.Codex.Search"]
+                </label>
+            </div>
+
+            <details class="border rounded mt-3 p-2">
+                <summary class="small fw-semibold user-select-none">@L["SessionOptions.Codex.PermissionsDetails"]</summary>
+
             <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Sandbox.Label"]</label>
                 <div class="btn-group d-flex" role="group">
@@ -226,19 +244,16 @@
                 }
             </div>
 
-            <div class="form-check mt-3">
-                <input class="form-check-input" type="checkbox" @bind="CodexOptions.SearchEnabled" id="@($"codexSearch{UniqueId}")">
-                <label class="form-check-label" for="@($"codexSearch{UniqueId}")">
-                    @L["SessionOptions.Codex.Search"]
-                </label>
-            </div>
-
             <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.AdditionalDirs.Label"]</label>
                 <textarea class="form-control form-control-sm" @bind="CodexOptions.AdditionalDirectories"
                           rows="3" placeholder="@L["SessionOptions.Codex.AdditionalDirs.Placeholder"]"></textarea>
                 <div class="form-text small">@L["SessionOptions.Codex.AdditionalDirs.Help"]</div>
             </div>
+            </details>
+
+            <details class="border rounded mt-2 p-2">
+                <summary class="small fw-semibold user-select-none">@L["SessionOptions.Codex.AdvancedSettings"]</summary>
 
             <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>
@@ -249,6 +264,7 @@
 
             <CustomCliOptionsSection Options="codexCustomOptions" States="customOptionStates"
                                      Prefix="@($"codex{UniqueId}")" OnStateChanged="OnCustomOptionToggled" />
+            </details>
         </div>
     }
     else if (SelectedType == TerminalType.Antigravity && Configuration.GetValue<bool>("ExternalTools:UseAntigravityCli", true))
@@ -525,6 +541,7 @@
                 {
                     options["resume-last"] = "true";
                 }
+                options["no-alt-screen"] = CodexOptions.NoAltScreen ? "true" : "false";
                 if (!string.IsNullOrWhiteSpace(CodexOptions.SandboxMode))
                 {
                     options["sandbox-mode"] = CodexOptions.SandboxMode;
@@ -609,6 +626,7 @@
     {
         public string Mode { get; set; } = "auto"; // auto, standard, yolo
         public bool ResumeLast { get; set; } = false;
+        public bool NoAltScreen { get; set; } = true;
         public string SandboxMode { get; set; } = ""; // "", read-only, workspace-write, danger-full-access
         public string ApprovalPolicy { get; set; } = "";
         public bool SearchEnabled { get; set; }

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -427,6 +427,7 @@
                     Mode = options.ContainsKey("mode") ? options["mode"] : "auto",
                     ResumeLast = (options.ContainsKey("resume-last") && options["resume-last"] == "true")
                         || (options.ContainsKey("resume-picker") && options["resume-picker"] == "true"),
+                    NoAltScreen = !options.TryGetValue("no-alt-screen", out var noAltScreen) || noAltScreen == "true",
                     SandboxMode = options.ContainsKey("sandbox-mode") ? options["sandbox-mode"] : "",
                     ApprovalPolicy = options.ContainsKey("ask-for-approval") ? options["ask-for-approval"] : "",
                     SearchEnabled = options.ContainsKey("search") && options["search"] == "true",

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -398,6 +398,9 @@
     private const string LAST_CODEX_MODE_KEY = "lastCodexMode";
     private const string LAST_CODEX_SANDBOX_MODE_KEY = "lastCodexSandboxMode";
     private const string LAST_CODEX_APPROVAL_POLICY_KEY = "lastCodexApprovalPolicy";
+    private const string LAST_CODEX_RESUME_LAST_KEY = "lastCodexResumeLast";
+    private const string LAST_CODEX_NO_ALT_SCREEN_KEY = "lastCodexNoAltScreen";
+    private const string LAST_CODEX_SEARCH_ENABLED_KEY = "lastCodexSearchEnabled";
 
     private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto", "default" };
     private static readonly HashSet<string> ValidGeminiApprovalModes = new() { "default", "auto_edit", "yolo" };
@@ -672,6 +675,13 @@
             {
                 codexOptions.ApprovalPolicy = codexApproval;
             }
+
+            codexOptions.ResumeLast =
+                await LocalStorage.GetAsync<bool?>(LAST_CODEX_RESUME_LAST_KEY) ?? codexOptions.ResumeLast;
+            codexOptions.NoAltScreen =
+                await LocalStorage.GetAsync<bool?>(LAST_CODEX_NO_ALT_SCREEN_KEY) ?? codexOptions.NoAltScreen;
+            codexOptions.SearchEnabled =
+                await LocalStorage.GetAsync<bool?>(LAST_CODEX_SEARCH_ENABLED_KEY) ?? codexOptions.SearchEnabled;
         }
         catch
         {

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -120,7 +120,15 @@ namespace TerminalHub.Constants
                 args.Add("resume --last");
             }
 
-            if (!options.TryGetValue("no-alt-screen", out var noAltScreen) || noAltScreen == "true")
+            // --no-alt-screen を既定 ON にする前は、追加引数欄のプレースホルダー例が
+            // "--no-alt-screen" だった。その名残で extra-args / custom-args に手書きで
+            // --no-alt-screen を入れている既存セッションがあり得るため、その場合は
+            // 自動付与をスキップして二重指定（--no-alt-screen --no-alt-screen）を防ぐ。
+            var userSuppliedNoAltScreen =
+                ContainsArgToken(options.GetValueOrDefault("extra-args"), "--no-alt-screen") ||
+                ContainsArgToken(options.GetValueOrDefault("custom-args"), "--no-alt-screen");
+            if ((!options.TryGetValue("no-alt-screen", out var noAltScreen) || noAltScreen == "true") &&
+                !userSuppliedNoAltScreen)
             {
                 args.Add("--no-alt-screen");
             }
@@ -229,6 +237,19 @@ namespace TerminalHub.Constants
             AppendCustomArgs(args, options);
 
             return string.Join(" ", args);
+        }
+
+        // 空白区切りの引数文字列（extra-args / custom-args）に、指定トークンが
+        // 独立した引数として含まれるかを判定する（--no-alt-screen の二重指定防止に使用）。
+        private static bool ContainsArgToken(string? rawArgs, string token)
+        {
+            if (string.IsNullOrWhiteSpace(rawArgs))
+            {
+                return false;
+            }
+
+            var tokens = rawArgs.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            return Array.IndexOf(tokens, token) >= 0;
         }
 
         // ユーザー定義カスタムオプションで ON にされた行を、まとめて末尾に追記する。

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -113,6 +113,8 @@ namespace TerminalHub.Constants
         {
             var args = new List<string>();
 
+            // 現行 Codex CLI は復帰履歴がない初回フォルダでも、ディレクトリの信頼確認後に
+            // 新規セッションとして継続できるため、resume --last 失敗時の再作成処理は不要。
             if (options.ContainsKey("resume-last") && options["resume-last"] == "true")
             {
                 args.Add("resume --last");

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -118,6 +118,11 @@ namespace TerminalHub.Constants
                 args.Add("resume --last");
             }
 
+            if (!options.TryGetValue("no-alt-screen", out var noAltScreen) || noAltScreen == "true")
+            {
+                args.Add("--no-alt-screen");
+            }
+
             if (options.ContainsKey("search") && options["search"] == "true")
             {
                 args.Add("--search");

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -385,6 +385,10 @@
   <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>Warning:</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO mode should only be used in isolated environments (WSL/Docker/VM/CI).</value></data>
   <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>Resume previous session (resume --last)</value></data>
+  <data name="SessionOptions.Codex.NoAltScreen" xml:space="preserve"><value>Inline display (recommended)</value></data>
+  <data name="SessionOptions.Codex.NoAltScreen.Help" xml:space="preserve"><value>Preserves terminal scrollback and improves long-session resume stability (--no-alt-screen).</value></data>
+  <data name="SessionOptions.Codex.PermissionsDetails" xml:space="preserve"><value>Permission details</value></data>
+  <data name="SessionOptions.Codex.AdvancedSettings" xml:space="preserve"><value>Advanced settings</value></data>
   <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>Sandbox mode</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI default</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultTitle" xml:space="preserve"><value>Do not add --sandbox; use the Codex CLI default.</value></data>
@@ -405,7 +409,7 @@
   <data name="SessionOptions.Codex.AdditionalDirs.Label" xml:space="preserve"><value>Additional directories</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Placeholder" xml:space="preserve"><value>One directory per line</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Help" xml:space="preserve"><value>Each line is passed as --add-dir</value></data>
-  <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --no-alt-screen</value></data>
+  <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>e.g., --model gpt-5</value></data>
   <data name="SessionOptions.Codex.PassToCli" xml:space="preserve"><value>Passed as-is to Codex CLI</value></data>
 
   <!-- Antigravity CLI Options -->

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -385,6 +385,10 @@
   <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>警告:</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO モードは隔離環境（WSL/Docker/VM/CI）でのみ使用してください。</value></data>
   <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>直前のセッションに接続 (resume --last)</value></data>
+  <data name="SessionOptions.Codex.NoAltScreen" xml:space="preserve"><value>インライン表示（推奨）</value></data>
+  <data name="SessionOptions.Codex.NoAltScreen.Help" xml:space="preserve"><value>スクロール履歴を保持し、長いセッションの復帰を安定させます（--no-alt-screen）。</value></data>
+  <data name="SessionOptions.Codex.PermissionsDetails" xml:space="preserve"><value>権限の詳細設定</value></data>
+  <data name="SessionOptions.Codex.AdvancedSettings" xml:space="preserve"><value>高度な設定</value></data>
   <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>サンドボックスモード</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI 既定</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultTitle" xml:space="preserve"><value>--sandbox を付けず、Codex CLI の既定値に任せます。</value></data>
@@ -405,7 +409,7 @@
   <data name="SessionOptions.Codex.AdditionalDirs.Label" xml:space="preserve"><value>追加ディレクトリ</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Placeholder" xml:space="preserve"><value>1 行に 1 ディレクトリずつ指定</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Help" xml:space="preserve"><value>各行を `--add-dir` として渡します</value></data>
-  <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --no-alt-screen</value></data>
+  <data name="SessionOptions.Codex.ExtraArgsPlaceholder" xml:space="preserve"><value>例: --model gpt-5</value></data>
   <data name="SessionOptions.Codex.PassToCli" xml:space="preserve"><value>そのまま Codex CLI に渡します</value></data>
 
   <!-- Antigravity CLI Options -->


### PR DESCRIPTION
## 概要

Codex CLI のオプション画面を整理し、TerminalHub で安定して利用できるインライン表示を標準化します。

## 変更内容

- `--no-alt-screen` を「インライン表示（推奨）」として追加し、保存値がない場合は既定で有効化
- 前回セッションの復帰、インライン表示、Web検索の選択を次回の新規作成へ引き継ぎ
- サブセッション作成でも同じ前回値を利用
- 権限関連と高度な設定を折りたたみ、通常表示を簡潔化
- 日本語・英語の表示文言を追加・更新

## 背景

長時間利用した Codex セッションを `resume --last` で復帰すると、代替画面の大量再描画によりTerminalHub上で停止したように見える場合がありました。`--no-alt-screen` では安定して復帰できることを確認したため、TerminalHub向けの推奨設定として標準化します。

## 影響

- 新規・既存セッションで、明示的に無効化していない限り `--no-alt-screen` が付与されます。
- 設定画面でOFFにした値も保存・継承されます。
- 既存のCodex実行モード、サンドボックス、承認ポリシーとの互換性は維持します。

## 確認

- `dotnet build TerminalHub/TerminalHub.csproj -c Release --no-restore`
- 警告0、エラー0
- `git diff --check`