### PR TITLE
refactor: Codexのモード3択を廃止しYoloをチェックボックス化

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -144,7 +144,6 @@
     private const string LAST_TERMINAL_TYPE_KEY = "lastSelectedTerminalType";
     private const string LAST_CLAUDE_PERMISSION_MODE_KEY = "lastClaudePermissionMode";
     private const string LAST_GEMINI_APPROVAL_MODE_KEY = "lastGeminiApprovalMode";
-    private const string LAST_CODEX_MODE_KEY = "lastCodexMode";
     private const string LAST_CODEX_SANDBOX_MODE_KEY = "lastCodexSandboxMode";
     private const string LAST_CODEX_APPROVAL_POLICY_KEY = "lastCodexApprovalPolicy";
     private const string LAST_CODEX_RESUME_LAST_KEY = "lastCodexResumeLast";
@@ -246,7 +245,6 @@
     // 不正値で起動引数が壊れるのを防ぐ。SessionOptionsSelector の UI 選択肢と一致させる。
     private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto", "default" };
     private static readonly HashSet<string> ValidGeminiApprovalModes = new() { "default", "auto_edit", "yolo" };
-    private static readonly HashSet<string> ValidCodexModes = new() { "auto", "standard", "yolo" };
     private static readonly HashSet<string> ValidCodexSandboxModes = new() { "", "read-only", "workspace-write", "danger-full-access" };
     private static readonly HashSet<string> ValidCodexApprovalPolicies = new() { "", "untrusted", "on-request", "never" };
 
@@ -269,11 +267,8 @@
                 geminiOptions.ApprovalMode = geminiApproval;
             }
 
-            var codexMode = await LocalStorage.GetAsync<string>(LAST_CODEX_MODE_KEY);
-            if (codexMode != null && ValidCodexModes.Contains(codexMode))
-            {
-                codexOptions.Mode = codexMode;
-            }
+            // Yolo（承認・サンドボックス完全バイパス）は危険なため「最後の選択」を復元せず、
+            // 新規セッションでは常に OFF 既定にする（安全側）。
 
             // Codex SandboxMode / ApprovalPolicy は "" (Default) を有効値として含むため
             // ホワイトリストにも "" を入れている。
@@ -308,7 +303,6 @@
         {
             await LocalStorage.SetAsync(LAST_CLAUDE_PERMISSION_MODE_KEY, claudeCodeOptions.PermissionMode);
             await LocalStorage.SetAsync(LAST_GEMINI_APPROVAL_MODE_KEY, geminiOptions.ApprovalMode);
-            await LocalStorage.SetAsync(LAST_CODEX_MODE_KEY, codexOptions.Mode);
             await LocalStorage.SetAsync(LAST_CODEX_SANDBOX_MODE_KEY, codexOptions.SandboxMode);
             await LocalStorage.SetAsync(LAST_CODEX_APPROVAL_POLICY_KEY, codexOptions.ApprovalPolicy);
             await LocalStorage.SetAsync(LAST_CODEX_RESUME_LAST_KEY, codexOptions.ResumeLast);

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -128,37 +128,15 @@
         <div class="mb-3">
             <label class="form-label">@L["SessionOptions.Codex.Header"]</label>
 
-            <div class="mt-2">
-                <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Mode.Label"]</label>
-                <div class="btn-group d-flex" role="group">
-                    <input type="radio" class="btn-check" name="@($"codexMode{UniqueId}")" id="@($"codexModeAuto{UniqueId}")"
-                           checked="@(CodexOptions.Mode == "auto")"
-                           @onchange="() => SetCodexMode(CodexMode.Auto)" autocomplete="off">
-                    <label class="btn btn-outline-success btn-sm" for="@($"codexModeAuto{UniqueId}")" title="@L["SessionOptions.Codex.Mode.AutoTitle"]">
-                        @L["SessionOptions.Codex.Mode.AutoLabel"]
-                    </label>
-
-                    <input type="radio" class="btn-check" name="@($"codexMode{UniqueId}")" id="@($"codexModeStandard{UniqueId}")"
-                           checked="@(CodexOptions.Mode == "standard")"
-                           @onchange="() => SetCodexMode(CodexMode.Standard)" autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"codexModeStandard{UniqueId}")" title="@L["SessionOptions.Codex.Mode.StandardTitle"]">
-                        @L["SessionOptions.Codex.Mode.StandardLabel"]
-                    </label>
-
-                    <input type="radio" class="btn-check" name="@($"codexMode{UniqueId}")" id="@($"codexModeYolo{UniqueId}")"
-                           checked="@(CodexOptions.Mode == "yolo")"
-                           @onchange="() => SetCodexMode(CodexMode.Yolo)" autocomplete="off">
-                    <label class="btn btn-outline-danger btn-sm" for="@($"codexModeYolo{UniqueId}")" title="@L["SessionOptions.Codex.Mode.YoloTitle"]">
-                        @L["SessionOptions.Codex.Mode.YoloLabel"]
-                    </label>
-                </div>
-                @if (!string.IsNullOrWhiteSpace(GetCodexModeHelp()))
-                {
-                    <div class="form-text small">@GetCodexModeHelp()</div>
-                }
+            <div class="form-check mt-2">
+                <input class="form-check-input" type="checkbox" @bind="CodexOptions.Yolo" id="@($"codexYolo{UniqueId}")">
+                <label class="form-check-label text-danger fw-semibold" for="@($"codexYolo{UniqueId}")">
+                    @L["SessionOptions.Codex.Yolo.Label"]
+                </label>
+                <div class="form-text mt-0">@L["SessionOptions.Codex.Yolo.Help"]</div>
             </div>
 
-            @if (CodexOptions.Mode == "yolo")
+            @if (CodexOptions.Yolo)
             {
                 <div class="alert alert-danger mt-2 py-2 small">
                     <i class="bi bi-exclamation-triangle-fill me-1"></i>
@@ -196,6 +174,7 @@
                 <div class="btn-group d-flex" role="group">
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxNone{UniqueId}")"
                            checked="@(string.IsNullOrEmpty(CodexOptions.SandboxMode))"
+                           disabled="@CodexOptions.Yolo"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.Default)" autocomplete="off">
                     <label class="btn btn-outline-secondary btn-sm" for="@($"codexSandboxNone{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.DefaultTitle"]">
                         @L["SessionOptions.Codex.Sandbox.DefaultLabel"]
@@ -203,6 +182,7 @@
 
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxReadOnly{UniqueId}")"
                            checked="@(CodexOptions.SandboxMode == "read-only")"
+                           disabled="@CodexOptions.Yolo"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.ReadOnly)" autocomplete="off">
                     <label class="btn btn-outline-success btn-sm" for="@($"codexSandboxReadOnly{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.ReadOnlyTitle"]">
                         @L["SessionOptions.Codex.Sandbox.ReadOnlyLabel"]
@@ -210,6 +190,7 @@
 
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxWorkspace{UniqueId}")"
                            checked="@(CodexOptions.SandboxMode == "workspace-write")"
+                           disabled="@CodexOptions.Yolo"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.WorkspaceWrite)" autocomplete="off">
                     <label class="btn btn-outline-primary btn-sm" for="@($"codexSandboxWorkspace{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.WorkspaceTitle"]">
                         @L["SessionOptions.Codex.Sandbox.WorkspaceLabel"]
@@ -217,6 +198,7 @@
 
                     <input type="radio" class="btn-check" name="@($"codexSandbox{UniqueId}")" id="@($"codexSandboxFull{UniqueId}")"
                            checked="@(CodexOptions.SandboxMode == "danger-full-access")"
+                           disabled="@CodexOptions.Yolo"
                            @onchange="() => SetCodexSandboxMode(CodexSandbox.FullAccess)" autocomplete="off">
                     <label class="btn btn-outline-danger btn-sm" for="@($"codexSandboxFull{UniqueId}")" title="@L["SessionOptions.Codex.Sandbox.FullAccessTitle"]">
                         @L["SessionOptions.Codex.Sandbox.FullAccessLabel"]
@@ -231,7 +213,7 @@
 
             <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.ApprovalPolicy.Label"]</label>
-                <select class="form-select form-select-sm" @bind="CodexOptions.ApprovalPolicy">
+                <select class="form-select form-select-sm" @bind="CodexOptions.ApprovalPolicy" disabled="@CodexOptions.Yolo">
                     <option value="">@L["Common.Unspecified"]</option>
                     <option value="untrusted">untrusted</option>
                     <option value="on-request">on-request</option>
@@ -458,19 +440,7 @@
         await SelectedTypeChanged.InvokeAsync(newType);
     }
 
-    private enum CodexMode { Auto, Standard, Yolo }
     private enum CodexSandbox { Default, ReadOnly, WorkspaceWrite, FullAccess }
-
-    private void SetCodexMode(CodexMode mode)
-    {
-        CodexOptions.Mode = mode switch
-        {
-            CodexMode.Auto => "auto",
-            CodexMode.Standard => "standard",
-            CodexMode.Yolo => "yolo",
-            _ => "auto"
-        };
-    }
 
     private void SetCodexSandboxMode(CodexSandbox mode)
     {
@@ -536,7 +506,10 @@
                 break;
 
             case TerminalType.CodexCLI:
-                options["mode"] = CodexOptions.Mode;
+                // 後方互換のため保存キーは従来どおり "mode"。Yolo=ON は "yolo"、それ以外は
+                // "standard"（サンドボックス/承認をそのまま渡す）。旧 "auto" は書き出さない
+                // （BuildCodexArgs は既存セッション互換のため "auto" の解釈を残している）。
+                options["mode"] = CodexOptions.Yolo ? "yolo" : "standard";
                 if (CodexOptions.ResumeLast)
                 {
                     options["resume-last"] = "true";
@@ -624,11 +597,14 @@
 
     public class CodexOptionsData
     {
-        public string Mode { get; set; } = "auto"; // auto, standard, yolo
+        // 承認・サンドボックスを完全バイパス（--dangerously-bypass-approvals-and-sandbox）。
+        // ON の間はサンドボックス/承認の指定は無視される（BuildCodexArgs 側で mode=yolo として処理）。
+        public bool Yolo { get; set; } = false;
         public bool ResumeLast { get; set; } = false;
         public bool NoAltScreen { get; set; } = true;
-        public string SandboxMode { get; set; } = ""; // "", read-only, workspace-write, danger-full-access
-        public string ApprovalPolicy { get; set; } = "";
+        // 既定は旧「Auto」相当（workspace-write + on-request）を明示値として持たせる。
+        public string SandboxMode { get; set; } = "workspace-write"; // "", read-only, workspace-write, danger-full-access
+        public string ApprovalPolicy { get; set; } = "on-request";
         public bool SearchEnabled { get; set; }
         public string AdditionalDirectories { get; set; } = "";
         public string ExtraArgs { get; set; } = "";
@@ -677,17 +653,6 @@
             "untrusted" => L["SessionOptions.Codex.ApprovalPolicy.HelpUntrusted"],
             "on-request" => L["SessionOptions.Codex.ApprovalPolicy.HelpOnRequest"],
             "never" => L["SessionOptions.Codex.ApprovalPolicy.HelpNever"],
-            _ => ""
-        };
-    }
-
-    private string GetCodexModeHelp()
-    {
-        return CodexOptions.Mode switch
-        {
-            "auto" => L["SessionOptions.Codex.Mode.HelpAuto"],
-            "standard" => L["SessionOptions.Codex.Mode.HelpStandard"],
-            "yolo" => L["SessionOptions.Codex.Mode.HelpYolo"],
             _ => ""
         };
     }

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -129,22 +129,6 @@
             <label class="form-label">@L["SessionOptions.Codex.Header"]</label>
 
             <div class="form-check mt-2">
-                <input class="form-check-input" type="checkbox" @bind="CodexOptions.Yolo" id="@($"codexYolo{UniqueId}")">
-                <label class="form-check-label text-danger fw-semibold" for="@($"codexYolo{UniqueId}")">
-                    @L["SessionOptions.Codex.Yolo.Label"]
-                </label>
-                <div class="form-text mt-0">@L["SessionOptions.Codex.Yolo.Help"]</div>
-            </div>
-
-            @if (CodexOptions.Yolo)
-            {
-                <div class="alert alert-danger mt-2 py-2 small">
-                    <i class="bi bi-exclamation-triangle-fill me-1"></i>
-                    <strong>@L["SessionOptions.Codex.YoloWarning.Label"]</strong> @L["SessionOptions.Codex.YoloWarning.Message"]
-                </div>
-            }
-
-            <div class="form-check mt-3">
                 <input class="form-check-input" type="checkbox" @bind="CodexOptions.ResumeLast" id="@($"codexResumeLast{UniqueId}")">
                 <label class="form-check-label" for="@($"codexResumeLast{UniqueId}")">
                     @L["SessionOptions.Codex.ResumeLast"]
@@ -165,9 +149,6 @@
                     @L["SessionOptions.Codex.Search"]
                 </label>
             </div>
-
-            <details class="border rounded mt-3 p-2">
-                <summary class="small fw-semibold user-select-none">@L["SessionOptions.Codex.PermissionsDetails"]</summary>
 
             <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.Sandbox.Label"]</label>
@@ -226,16 +207,31 @@
                 }
             </div>
 
+            <div class="form-check mt-3">
+                <input class="form-check-input" type="checkbox" @bind="CodexOptions.Yolo" id="@($"codexYolo{UniqueId}")">
+                <label class="form-check-label text-danger fw-semibold" for="@($"codexYolo{UniqueId}")">
+                    @L["SessionOptions.Codex.Yolo.Label"]
+                </label>
+                <div class="form-text mt-0">@L["SessionOptions.Codex.Yolo.Help"]</div>
+            </div>
+
+            @if (CodexOptions.Yolo)
+            {
+                <div class="alert alert-danger mt-2 py-2 small">
+                    <i class="bi bi-exclamation-triangle-fill me-1"></i>
+                    <strong>@L["SessionOptions.Codex.YoloWarning.Label"]</strong> @L["SessionOptions.Codex.YoloWarning.Message"]
+                </div>
+            }
+
+            <details class="border rounded mt-3 p-2">
+                <summary class="small fw-semibold user-select-none">@L["SessionOptions.Codex.AdvancedSettings"]</summary>
+
             <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.Codex.AdditionalDirs.Label"]</label>
                 <textarea class="form-control form-control-sm" @bind="CodexOptions.AdditionalDirectories"
                           rows="3" placeholder="@L["SessionOptions.Codex.AdditionalDirs.Placeholder"]"></textarea>
                 <div class="form-text small">@L["SessionOptions.Codex.AdditionalDirs.Help"]</div>
             </div>
-            </details>
-
-            <details class="border rounded mt-2 p-2">
-                <summary class="small fw-semibold user-select-none">@L["SessionOptions.Codex.AdvancedSettings"]</summary>
 
             <div class="mt-3">
                 <label class="form-label small text-muted mb-1">@L["SessionOptions.ExtraArgs.Label"]</label>

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -422,14 +422,25 @@
             }
             else if (selectedType == TerminalType.CodexCLI)
             {
+                var savedMode = options.ContainsKey("mode") ? options["mode"] : "";
+                var savedSandbox = options.ContainsKey("sandbox-mode") ? options["sandbox-mode"] : "";
+                var savedApproval = options.ContainsKey("ask-for-approval") ? options["ask-for-approval"] : "";
+                // 旧「Auto」モードは空のサンドボックス/承認を BuildCodexArgs 側で
+                // workspace-write / on-request に補完していた。モード廃止に伴い、その暗黙の
+                // 既定を明示値として顕在化させ、再保存しても挙動が変わらないようにする。
+                if (savedMode == "auto")
+                {
+                    if (string.IsNullOrEmpty(savedSandbox)) savedSandbox = "workspace-write";
+                    if (string.IsNullOrEmpty(savedApproval)) savedApproval = "on-request";
+                }
                 codexOptions = new SessionOptionsSelector.CodexOptionsData
                 {
-                    Mode = options.ContainsKey("mode") ? options["mode"] : "auto",
+                    Yolo = savedMode == "yolo",
                     ResumeLast = (options.ContainsKey("resume-last") && options["resume-last"] == "true")
                         || (options.ContainsKey("resume-picker") && options["resume-picker"] == "true"),
                     NoAltScreen = !options.TryGetValue("no-alt-screen", out var noAltScreen) || noAltScreen == "true",
-                    SandboxMode = options.ContainsKey("sandbox-mode") ? options["sandbox-mode"] : "",
-                    ApprovalPolicy = options.ContainsKey("ask-for-approval") ? options["ask-for-approval"] : "",
+                    SandboxMode = savedSandbox,
+                    ApprovalPolicy = savedApproval,
                     SearchEnabled = options.ContainsKey("search") && options["search"] == "true",
                     AdditionalDirectories = options.ContainsKey("add-dir") ? options["add-dir"] : "",
                     ExtraArgs = options.ContainsKey("extra-args") ? options["extra-args"] : ""

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -395,7 +395,6 @@
     // LocalStorage: 直近の CLI モード選択 (SessionCreateDialog とキーを共有して値を流用)
     private const string LAST_CLAUDE_PERMISSION_MODE_KEY = "lastClaudePermissionMode";
     private const string LAST_GEMINI_APPROVAL_MODE_KEY = "lastGeminiApprovalMode";
-    private const string LAST_CODEX_MODE_KEY = "lastCodexMode";
     private const string LAST_CODEX_SANDBOX_MODE_KEY = "lastCodexSandboxMode";
     private const string LAST_CODEX_APPROVAL_POLICY_KEY = "lastCodexApprovalPolicy";
     private const string LAST_CODEX_RESUME_LAST_KEY = "lastCodexResumeLast";
@@ -404,7 +403,6 @@
 
     private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto", "default" };
     private static readonly HashSet<string> ValidGeminiApprovalModes = new() { "default", "auto_edit", "yolo" };
-    private static readonly HashSet<string> ValidCodexModes = new() { "auto", "standard", "yolo" };
     private static readonly HashSet<string> ValidCodexSandboxModes = new() { "", "read-only", "workspace-write", "danger-full-access" };
     private static readonly HashSet<string> ValidCodexApprovalPolicies = new() { "", "untrusted", "on-request", "never" };
     
@@ -658,11 +656,8 @@
                 geminiOptions.ApprovalMode = geminiApproval;
             }
 
-            var codexMode = await LocalStorage.GetAsync<string>(LAST_CODEX_MODE_KEY);
-            if (codexMode != null && ValidCodexModes.Contains(codexMode))
-            {
-                codexOptions.Mode = codexMode;
-            }
+            // Yolo（承認・サンドボックス完全バイパス）は危険なため「最後の選択」を復元せず、
+            // 新規サブセッションでは常に OFF 既定にする（安全側）。
 
             var codexSandbox = await LocalStorage.GetAsync<string>(LAST_CODEX_SANDBOX_MODE_KEY);
             if (codexSandbox != null && ValidCodexSandboxModes.Contains(codexSandbox))

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -372,16 +372,8 @@
 
   <!-- SessionOptionsSelector: Codex CLI -->
   <data name="SessionOptions.Codex.Header" xml:space="preserve"><value>Codex CLI Options</value></data>
-  <data name="SessionOptions.Codex.Mode.Label" xml:space="preserve"><value>Execution mode</value></data>
-  <data name="SessionOptions.Codex.Mode.AutoLabel" xml:space="preserve"><value>Auto (recommended)</value></data>
-  <data name="SessionOptions.Codex.Mode.AutoTitle" xml:space="preserve"><value>Mostly automates edits, builds, and tests</value></data>
-  <data name="SessionOptions.Codex.Mode.StandardLabel" xml:space="preserve"><value>Interactive</value></data>
-  <data name="SessionOptions.Codex.Mode.StandardTitle" xml:space="preserve"><value>No explicit auto-run flags; proceeds interactively</value></data>
-  <data name="SessionOptions.Codex.Mode.YoloLabel" xml:space="preserve"><value>YOLO (dangerous)</value></data>
-  <data name="SessionOptions.Codex.Mode.YoloTitle" xml:space="preserve"><value>Fully automatic execution (dangerous). Isolated environment recommended.</value></data>
-  <data name="SessionOptions.Codex.Mode.HelpAuto" xml:space="preserve"><value>Recommended. Uses `--sandbox workspace-write --ask-for-approval on-request`. Explicit per-setting choices take precedence.</value></data>
-  <data name="SessionOptions.Codex.Mode.HelpStandard" xml:space="preserve"><value>No explicit auto-run flags; proceeds interactively.</value></data>
-  <data name="SessionOptions.Codex.Mode.HelpYolo" xml:space="preserve"><value>Uses `--dangerously-bypass-approvals-and-sandbox` for fully automatic execution (dangerous). Per-setting sandbox and approval choices are ignored.</value></data>
+  <data name="SessionOptions.Codex.Yolo.Label" xml:space="preserve"><value>Bypass all approvals and sandbox (dangerous)</value></data>
+  <data name="SessionOptions.Codex.Yolo.Help" xml:space="preserve"><value>Uses `--dangerously-bypass-approvals-and-sandbox` for fully automatic execution. While on, the sandbox and approval choices are disabled (not applied).</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>Warning:</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO mode should only be used in isolated environments (WSL/Docker/VM/CI).</value></data>
   <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>Resume previous session (resume --last)</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -379,7 +379,6 @@
   <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>Resume previous session (resume --last)</value></data>
   <data name="SessionOptions.Codex.NoAltScreen" xml:space="preserve"><value>Inline display (recommended)</value></data>
   <data name="SessionOptions.Codex.NoAltScreen.Help" xml:space="preserve"><value>Preserves terminal scrollback and improves long-session resume stability (--no-alt-screen).</value></data>
-  <data name="SessionOptions.Codex.PermissionsDetails" xml:space="preserve"><value>Permission details</value></data>
   <data name="SessionOptions.Codex.AdvancedSettings" xml:space="preserve"><value>Advanced settings</value></data>
   <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>Sandbox mode</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI default</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -379,7 +379,6 @@
   <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>直前のセッションに接続 (resume --last)</value></data>
   <data name="SessionOptions.Codex.NoAltScreen" xml:space="preserve"><value>インライン表示（推奨）</value></data>
   <data name="SessionOptions.Codex.NoAltScreen.Help" xml:space="preserve"><value>スクロール履歴を保持し、長いセッションの復帰を安定させます（--no-alt-screen）。</value></data>
-  <data name="SessionOptions.Codex.PermissionsDetails" xml:space="preserve"><value>権限の詳細設定</value></data>
   <data name="SessionOptions.Codex.AdvancedSettings" xml:space="preserve"><value>高度な設定</value></data>
   <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>サンドボックスモード</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI 既定</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -372,16 +372,8 @@
 
   <!-- SessionOptionsSelector: Codex CLI -->
   <data name="SessionOptions.Codex.Header" xml:space="preserve"><value>Codex CLI オプション</value></data>
-  <data name="SessionOptions.Codex.Mode.Label" xml:space="preserve"><value>実行モード</value></data>
-  <data name="SessionOptions.Codex.Mode.AutoLabel" xml:space="preserve"><value>Auto (推奨)</value></data>
-  <data name="SessionOptions.Codex.Mode.AutoTitle" xml:space="preserve"><value>編集＋ビルド/テスト等を基本自動化</value></data>
-  <data name="SessionOptions.Codex.Mode.StandardLabel" xml:space="preserve"><value>Interactive</value></data>
-  <data name="SessionOptions.Codex.Mode.StandardTitle" xml:space="preserve"><value>明示的な自動実行フラグを付けず、対話ベースで進行します</value></data>
-  <data name="SessionOptions.Codex.Mode.YoloLabel" xml:space="preserve"><value>YOLO (危険)</value></data>
-  <data name="SessionOptions.Codex.Mode.YoloTitle" xml:space="preserve"><value>全自動実行（危険）。隔離環境推奨。</value></data>
-  <data name="SessionOptions.Codex.Mode.HelpAuto" xml:space="preserve"><value>推奨。`--sandbox workspace-write --ask-for-approval on-request` で実行します。個別指定がある項目はそちらを優先します。</value></data>
-  <data name="SessionOptions.Codex.Mode.HelpStandard" xml:space="preserve"><value>明示的な自動実行フラグを付けず、対話ベースで進行します。</value></data>
-  <data name="SessionOptions.Codex.Mode.HelpYolo" xml:space="preserve"><value>`--dangerously-bypass-approvals-and-sandbox` で全自動実行します（危険）。サンドボックスと承認の個別指定は適用されません。</value></data>
+  <data name="SessionOptions.Codex.Yolo.Label" xml:space="preserve"><value>承認・サンドボックスを完全バイパス（危険）</value></data>
+  <data name="SessionOptions.Codex.Yolo.Help" xml:space="preserve"><value>`--dangerously-bypass-approvals-and-sandbox` で全自動実行します。ONの間はサンドボックスと承認の指定は無効です（適用されません）。</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>警告:</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO モードは隔離環境（WSL/Docker/VM/CI）でのみ使用してください。</value></data>
   <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>直前のセッションに接続 (resume --last)</value></data>


### PR DESCRIPTION
## 背景

Codex の「実行モード」3択(Auto / Standard / Yolo)は、UI と実際の引数挙動が一致しておらず分かりにくかった。

- Yolo が「モード」の一員として並ぶが、実際は他2つ(サンドボックス/承認)を黙って無視して上書きする(UI 上は Yolo + read-only が同時に選べてしまう)
- Auto の「隠れ補完」(サンドボックス空→`workspace-write` / 承認空→`on-request`)が UI に出ておらず、Standard との違いが分かりにくい

## 変更

- **モード3択を廃止**し、Yolo を単独チェックボックス「承認・サンドボックスを完全バイパス（危険）」に変更。ON の間はサンドボックスラジオと承認セレクトを `disabled` にして「効かないのに選べる」矛盾を解消。
- **新規セッションの既定を旧 Auto 相当**(サンドボックス=`workspace-write` / 承認=`on-request`)に明示値として設定。隠れ補完を廃止し、UI に見える形にした。
- **保存キーは後方互換のため従来どおり `mode`**。Yolo=ON→`yolo`、OFF→`standard`。`BuildCodexArgs` は無改修(既存セッションの `auto` 解釈も温存)。
- **既存セッション読込**(設定ダイアログ)では旧 `auto` の暗黙既定(`workspace-write` / `on-request`)を明示値へ顕在化し、再保存しても挙動が変わらないようにした。
- Yolo は危険なため「最後の選択」を LocalStorage に永続化せず、新規は常に OFF 既定(安全側)。
- 不要になった `SessionOptions.Codex.Mode.*` リソースを en/ja から削除し `Yolo.Label` / `Yolo.Help` を追加(キー数は en/ja とも 506 で一致)。

## 引数マッピング(変更後)

| UI | 生成引数 |
|---|---|
| Yolo ON | `--dangerously-bypass-approvals-and-sandbox`(サンドボックス/承認は無効) |
| Yolo OFF + サンドボックス=workspace-write + 承認=on-request(新規既定) | `--sandbox workspace-write --ask-for-approval on-request` |
| Yolo OFF + サンドボックス=CLI既定 + 承認=未指定 | (どちらも付けない) |

## 検証

- `dotnet build`: 警告0・エラー0
- resx: en/ja とも 506 キーで一致

## 影響ファイル

- `SessionOptionsSelector.razor`(UI + モデル + Get/Set/Help)
- `SessionSettingsDialog.razor`(既存セッションの `mode`→`Yolo` 解析 + `auto` 顕在化)
- `SessionCreateDialog.razor` / `SubSessionDialog.razor`(mode の LocalStorage 永続化を撤去)
- `SharedResource.en.resx` / `SharedResource.ja.resx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)