### PR TITLE
Codex承認リクエストの自動レビューに対応

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -146,6 +146,7 @@
     private const string LAST_GEMINI_APPROVAL_MODE_KEY = "lastGeminiApprovalMode";
     private const string LAST_CODEX_SANDBOX_MODE_KEY = "lastCodexSandboxMode";
     private const string LAST_CODEX_APPROVAL_POLICY_KEY = "lastCodexApprovalPolicy";
+    private const string LAST_CODEX_AUTO_REVIEW_APPROVALS_KEY = "lastCodexAutoReviewApprovals";
     private const string LAST_CODEX_RESUME_LAST_KEY = "lastCodexResumeLast";
     private const string LAST_CODEX_NO_ALT_SCREEN_KEY = "lastCodexNoAltScreen";
     private const string LAST_CODEX_SEARCH_ENABLED_KEY = "lastCodexSearchEnabled";
@@ -284,6 +285,9 @@
                 codexOptions.ApprovalPolicy = codexApproval;
             }
 
+            codexOptions.AutoReviewApprovals =
+                await LocalStorage.GetAsync<bool?>(LAST_CODEX_AUTO_REVIEW_APPROVALS_KEY) ?? codexOptions.AutoReviewApprovals;
+
             codexOptions.ResumeLast =
                 await LocalStorage.GetAsync<bool?>(LAST_CODEX_RESUME_LAST_KEY) ?? codexOptions.ResumeLast;
             codexOptions.NoAltScreen =
@@ -305,6 +309,7 @@
             await LocalStorage.SetAsync(LAST_GEMINI_APPROVAL_MODE_KEY, geminiOptions.ApprovalMode);
             await LocalStorage.SetAsync(LAST_CODEX_SANDBOX_MODE_KEY, codexOptions.SandboxMode);
             await LocalStorage.SetAsync(LAST_CODEX_APPROVAL_POLICY_KEY, codexOptions.ApprovalPolicy);
+            await LocalStorage.SetAsync(LAST_CODEX_AUTO_REVIEW_APPROVALS_KEY, codexOptions.AutoReviewApprovals);
             await LocalStorage.SetAsync(LAST_CODEX_RESUME_LAST_KEY, codexOptions.ResumeLast);
             await LocalStorage.SetAsync(LAST_CODEX_NO_ALT_SCREEN_KEY, codexOptions.NoAltScreen);
             await LocalStorage.SetAsync(LAST_CODEX_SEARCH_ENABLED_KEY, codexOptions.SearchEnabled);

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -208,6 +208,16 @@
             </div>
 
             <div class="form-check mt-3">
+                <input class="form-check-input" type="checkbox" @bind="CodexOptions.AutoReviewApprovals"
+                       disabled="@(CodexOptions.Yolo || CodexOptions.ApprovalPolicy == "never")"
+                       id="@($"codexAutoReviewApprovals{UniqueId}")">
+                <label class="form-check-label" for="@($"codexAutoReviewApprovals{UniqueId}")">
+                    @L["SessionOptions.Codex.AutoReviewApprovals.Label"]
+                </label>
+                <div class="form-text mt-0">@L["SessionOptions.Codex.AutoReviewApprovals.Help"]</div>
+            </div>
+
+            <div class="form-check mt-3">
                 <input class="form-check-input" type="checkbox" @bind="CodexOptions.Yolo" id="@($"codexYolo{UniqueId}")">
                 <label class="form-check-label text-danger fw-semibold" for="@($"codexYolo{UniqueId}")">
                     @L["SessionOptions.Codex.Yolo.Label"]
@@ -519,6 +529,10 @@
                 {
                     options["ask-for-approval"] = CodexOptions.ApprovalPolicy;
                 }
+                if (CodexOptions.AutoReviewApprovals)
+                {
+                    options["approvals-reviewer"] = "auto_review";
+                }
                 if (CodexOptions.SearchEnabled)
                 {
                     options["search"] = "true";
@@ -601,6 +615,7 @@
         // 既定は旧「Auto」相当（workspace-write + on-request）を明示値として持たせる。
         public string SandboxMode { get; set; } = "workspace-write"; // "", read-only, workspace-write, danger-full-access
         public string ApprovalPolicy { get; set; } = "on-request";
+        public bool AutoReviewApprovals { get; set; } = false;
         public bool SearchEnabled { get; set; }
         public string AdditionalDirectories { get; set; } = "";
         public string ExtraArgs { get; set; } = "";

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -425,6 +425,7 @@
                 var savedMode = options.ContainsKey("mode") ? options["mode"] : "";
                 var savedSandbox = options.ContainsKey("sandbox-mode") ? options["sandbox-mode"] : "";
                 var savedApproval = options.ContainsKey("ask-for-approval") ? options["ask-for-approval"] : "";
+                var savedApprovalsReviewer = options.ContainsKey("approvals-reviewer") ? options["approvals-reviewer"] : "";
                 // 旧「Auto」モードは空のサンドボックス/承認を BuildCodexArgs 側で
                 // workspace-write / on-request に補完していた。モード廃止に伴い、その暗黙の
                 // 既定を明示値として顕在化させ、再保存しても挙動が変わらないようにする。
@@ -441,6 +442,7 @@
                     NoAltScreen = !options.TryGetValue("no-alt-screen", out var noAltScreen) || noAltScreen == "true",
                     SandboxMode = savedSandbox,
                     ApprovalPolicy = savedApproval,
+                    AutoReviewApprovals = savedApprovalsReviewer == "auto_review",
                     SearchEnabled = options.ContainsKey("search") && options["search"] == "true",
                     AdditionalDirectories = options.ContainsKey("add-dir") ? options["add-dir"] : "",
                     ExtraArgs = options.ContainsKey("extra-args") ? options["extra-args"] : ""

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -397,6 +397,7 @@
     private const string LAST_GEMINI_APPROVAL_MODE_KEY = "lastGeminiApprovalMode";
     private const string LAST_CODEX_SANDBOX_MODE_KEY = "lastCodexSandboxMode";
     private const string LAST_CODEX_APPROVAL_POLICY_KEY = "lastCodexApprovalPolicy";
+    private const string LAST_CODEX_AUTO_REVIEW_APPROVALS_KEY = "lastCodexAutoReviewApprovals";
     private const string LAST_CODEX_RESUME_LAST_KEY = "lastCodexResumeLast";
     private const string LAST_CODEX_NO_ALT_SCREEN_KEY = "lastCodexNoAltScreen";
     private const string LAST_CODEX_SEARCH_ENABLED_KEY = "lastCodexSearchEnabled";
@@ -670,6 +671,9 @@
             {
                 codexOptions.ApprovalPolicy = codexApproval;
             }
+
+            codexOptions.AutoReviewApprovals =
+                await LocalStorage.GetAsync<bool?>(LAST_CODEX_AUTO_REVIEW_APPROVALS_KEY) ?? codexOptions.AutoReviewApprovals;
 
             codexOptions.ResumeLast =
                 await LocalStorage.GetAsync<bool?>(LAST_CODEX_RESUME_LAST_KEY) ?? codexOptions.ResumeLast;

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -152,6 +152,7 @@ namespace TerminalHub.Constants
             var mode = options.GetValueOrDefault("mode");
             var sandboxMode = options.GetValueOrDefault("sandbox-mode");
             var approvalPolicy = options.GetValueOrDefault("ask-for-approval");
+            var approvalsReviewer = options.GetValueOrDefault("approvals-reviewer");
 
             // 保存済みのモード名は維持し、現行CLIの明示的な設定へ変換する。
             if (mode == "yolo")
@@ -175,6 +176,12 @@ namespace TerminalHub.Constants
                 if (!string.IsNullOrEmpty(approvalPolicy))
                 {
                     args.Add($"--ask-for-approval {approvalPolicy}");
+                }
+
+                // 承認を一切求めない設定ではレビュー対象が存在しないため付与しない。
+                if (approvalsReviewer == "auto_review" && approvalPolicy != "never")
+                {
+                    args.Add("-c approvals_reviewer=auto_review");
                 }
             }
 

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -396,6 +396,8 @@
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>Treat as untrusted. Prompts for every operation.</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>Prompts only when needed (near-default behavior).</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpNever" xml:space="preserve"><value>Never prompts (dangerous).</value></data>
+  <data name="SessionOptions.Codex.AutoReviewApprovals.Label" xml:space="preserve"><value>Automatically review approval requests</value></data>
+  <data name="SessionOptions.Codex.AutoReviewApprovals.Help" xml:space="preserve"><value>A reviewer agent evaluates actions that require approval. This uses additional model calls, and actions are not run when review fails.</value></data>
   <data name="SessionOptions.Codex.Search" xml:space="preserve"><value>Enable web search (--search)</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Label" xml:space="preserve"><value>Additional directories</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Placeholder" xml:space="preserve"><value>One directory per line</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -396,6 +396,8 @@
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpUntrusted" xml:space="preserve"><value>未信頼扱い。すべての操作で承認を求めます。</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpOnRequest" xml:space="preserve"><value>必要なときだけ承認を求めます（デフォルトに近い挙動）。</value></data>
   <data name="SessionOptions.Codex.ApprovalPolicy.HelpNever" xml:space="preserve"><value>承認を求めません（危険）。</value></data>
+  <data name="SessionOptions.Codex.AutoReviewApprovals.Label" xml:space="preserve"><value>承認リクエストを自動レビュー</value></data>
+  <data name="SessionOptions.Codex.AutoReviewApprovals.Help" xml:space="preserve"><value>承認が必要な操作をレビューエージェントが評価します。追加の使用量が発生し、レビューに失敗した操作は実行されません。</value></data>
   <data name="SessionOptions.Codex.Search" xml:space="preserve"><value>Web 検索を有効化 (--search)</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Label" xml:space="preserve"><value>追加ディレクトリ</value></data>
   <data name="SessionOptions.Codex.AdditionalDirs.Placeholder" xml:space="preserve"><value>1 行に 1 ディレクトリずつ指定</value></data>


### PR DESCRIPTION
## 概要

Codex CLIの自動承認レビュー設定 `approvals_reviewer = "auto_review"` をTerminalHubのセッションオプションから利用できるようにします。

## 変更内容

- 「承認リクエストを自動レビュー」チェックボックスを追加
- 有効時に `-c approvals_reviewer=auto_review` をCodex CLIへ渡す
- YOLOモードまたは承認ポリシー `never` の場合はUIとコマンド生成の両方で無効化
- 新規セッション、サブセッション、既存セッション設定で選択状態を保存・復元
- 日本語・英語の説明文を追加

## 背景

従来は承認が必要な操作をユーザーが都度確認していました。Codex CLIの自動レビュー機能を選択可能にすることで、サンドボックス境界を維持しつつ、適格な承認要求をレビューエージェントへ委ねられます。

追加のモデル呼び出しが発生し、レビュー失敗時は操作が実行されないため、既定値はOFFとしています。

## 検証

- `dotnet build TerminalHub/TerminalHub.csproj --no-restore -c Release`
- `dotnet test TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj --no-restore -c Release`
- 59件すべて成功
- `git diff --check` 問題なし