### PR TITLE
refactor: セッション作成の前回値をブラウザからファイル設定へ移行

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -4,7 +4,6 @@
 @using Microsoft.JSInterop
 @using System.IO
 @inject IJSRuntime JSRuntime
-@inject ILocalStorageService LocalStorage
 @inject ILogger<SessionCreateDialog> Logger
 @inject IAppSettingsService AppSettingsService
 @inject IFolderPickerService FolderPicker
@@ -141,15 +140,9 @@
     private SessionOptionsSelector.AntigravityOptionsData antigravityOptions = new();
     private SessionOptionsSelector.GrokOptionsData grokOptions = new();
     private List<string> favoriteFolders = new();
-    private const string LAST_TERMINAL_TYPE_KEY = "lastSelectedTerminalType";
-    private const string LAST_CLAUDE_PERMISSION_MODE_KEY = "lastClaudePermissionMode";
-    private const string LAST_GEMINI_APPROVAL_MODE_KEY = "lastGeminiApprovalMode";
-    private const string LAST_CODEX_SANDBOX_MODE_KEY = "lastCodexSandboxMode";
-    private const string LAST_CODEX_APPROVAL_POLICY_KEY = "lastCodexApprovalPolicy";
-    private const string LAST_CODEX_AUTO_REVIEW_APPROVALS_KEY = "lastCodexAutoReviewApprovals";
-    private const string LAST_CODEX_RESUME_LAST_KEY = "lastCodexResumeLast";
-    private const string LAST_CODEX_NO_ALT_SCREEN_KEY = "lastCodexNoAltScreen";
-    private const string LAST_CODEX_SEARCH_ENABLED_KEY = "lastCodexSearchEnabled";
+    // 「前回の値」はブラウザ localStorage ではなく AppSettings(ファイル) に保存する。
+    // その PC のユーザーの作業習慣であり、ブラウザごとに変えたい性質ではないため。
+    // 保存先は AppSettings.SessionDefaults。値の発生源は本ダイアログに一元化する。
     private bool showCreateFolderDialog = false;
     private bool pendingSessionCreation = false;
 
@@ -214,110 +207,112 @@
         }
     }
 
-    private async Task LoadLastSelectedTerminalType()
+    private Task LoadLastSelectedTerminalType()
     {
         try
         {
-            var savedType = await LocalStorage.GetAsync<int?>(LAST_TERMINAL_TYPE_KEY);
+            var savedType = AppSettingsService.GetSettings().SessionDefaults.LastTerminalType;
             if (savedType.HasValue && Enum.IsDefined(typeof(TerminalType), savedType.Value))
             {
-                selectedType = (TerminalType)savedType.Value;
+                selectedType = savedType.Value;
             }
         }
         catch
         {
             // エラーが発生してもデフォルト値を使用
         }
+        return Task.CompletedTask;
     }
 
-    private async Task SaveLastSelectedTerminalType(TerminalType type)
+    private Task SaveLastSelectedTerminalType(TerminalType type)
     {
         try
         {
-            await LocalStorage.SetAsync(LAST_TERMINAL_TYPE_KEY, (int)type);
+            var settings = AppSettingsService.GetSettings();
+            settings.SessionDefaults.LastTerminalType = type;
+            AppSettingsService.SaveSettings(settings);
         }
         catch
         {
             // エラーが発生しても継続
         }
+        return Task.CompletedTask;
     }
 
-    // 復元値ホワイトリスト: LocalStorage が手動編集等で汚染された場合に
+    // 復元値ホワイトリスト: 設定ファイルが手動編集等で汚染された場合に
     // 不正値で起動引数が壊れるのを防ぐ。SessionOptionsSelector の UI 選択肢と一致させる。
     private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto", "default" };
     private static readonly HashSet<string> ValidGeminiApprovalModes = new() { "default", "auto_edit", "yolo" };
     private static readonly HashSet<string> ValidCodexSandboxModes = new() { "", "read-only", "workspace-write", "danger-full-access" };
     private static readonly HashSet<string> ValidCodexApprovalPolicies = new() { "", "untrusted", "on-request", "never" };
 
-    // CLI モード系ラジオの最終選択値を LocalStorage から復元する。
-    // 値が無い・ホワイトリスト外のキーはデフォルト値（各 OptionsData の初期化値）のまま。
+    // CLI モード系ラジオの最終選択値を AppSettings(ファイル) から復元する。
+    // 値が無い(null)・ホワイトリスト外のキーはデフォルト値（各 OptionsData の初期化値）のまま。
     // 初回利用ユーザーは現状の安全側デフォルト (Claude=bypass 等) を維持する。
-    private async Task LoadLastUsedCliModes()
+    private Task LoadLastUsedCliModes()
     {
         try
         {
-            var claudePerm = await LocalStorage.GetAsync<string>(LAST_CLAUDE_PERMISSION_MODE_KEY);
-            if (claudePerm != null && ValidClaudePermissionModes.Contains(claudePerm))
+            var defaults = AppSettingsService.GetSettings().SessionDefaults;
+
+            if (defaults.LastClaudePermissionMode != null && ValidClaudePermissionModes.Contains(defaults.LastClaudePermissionMode))
             {
-                claudeCodeOptions.PermissionMode = claudePerm;
+                claudeCodeOptions.PermissionMode = defaults.LastClaudePermissionMode;
             }
 
-            var geminiApproval = await LocalStorage.GetAsync<string>(LAST_GEMINI_APPROVAL_MODE_KEY);
-            if (geminiApproval != null && ValidGeminiApprovalModes.Contains(geminiApproval))
+            if (defaults.LastGeminiApprovalMode != null && ValidGeminiApprovalModes.Contains(defaults.LastGeminiApprovalMode))
             {
-                geminiOptions.ApprovalMode = geminiApproval;
+                geminiOptions.ApprovalMode = defaults.LastGeminiApprovalMode;
             }
 
             // Yolo（承認・サンドボックス完全バイパス）は危険なため「最後の選択」を復元せず、
             // 新規セッションでは常に OFF 既定にする（安全側）。
 
             // Codex SandboxMode / ApprovalPolicy は "" (Default) を有効値として含むため
-            // ホワイトリストにも "" を入れている。
-            var codexSandbox = await LocalStorage.GetAsync<string>(LAST_CODEX_SANDBOX_MODE_KEY);
-            if (codexSandbox != null && ValidCodexSandboxModes.Contains(codexSandbox))
+            // ホワイトリストにも "" を入れている（null=未保存 とは区別する）。
+            if (defaults.LastCodexSandboxMode != null && ValidCodexSandboxModes.Contains(defaults.LastCodexSandboxMode))
             {
-                codexOptions.SandboxMode = codexSandbox;
+                codexOptions.SandboxMode = defaults.LastCodexSandboxMode;
             }
 
-            var codexApproval = await LocalStorage.GetAsync<string>(LAST_CODEX_APPROVAL_POLICY_KEY);
-            if (codexApproval != null && ValidCodexApprovalPolicies.Contains(codexApproval))
+            if (defaults.LastCodexApprovalPolicy != null && ValidCodexApprovalPolicies.Contains(defaults.LastCodexApprovalPolicy))
             {
-                codexOptions.ApprovalPolicy = codexApproval;
+                codexOptions.ApprovalPolicy = defaults.LastCodexApprovalPolicy;
             }
 
-            codexOptions.AutoReviewApprovals =
-                await LocalStorage.GetAsync<bool?>(LAST_CODEX_AUTO_REVIEW_APPROVALS_KEY) ?? codexOptions.AutoReviewApprovals;
-
-            codexOptions.ResumeLast =
-                await LocalStorage.GetAsync<bool?>(LAST_CODEX_RESUME_LAST_KEY) ?? codexOptions.ResumeLast;
-            codexOptions.NoAltScreen =
-                await LocalStorage.GetAsync<bool?>(LAST_CODEX_NO_ALT_SCREEN_KEY) ?? codexOptions.NoAltScreen;
-            codexOptions.SearchEnabled =
-                await LocalStorage.GetAsync<bool?>(LAST_CODEX_SEARCH_ENABLED_KEY) ?? codexOptions.SearchEnabled;
+            codexOptions.AutoReviewApprovals = defaults.LastCodexAutoReviewApprovals ?? codexOptions.AutoReviewApprovals;
+            codexOptions.ResumeLast = defaults.LastCodexResumeLast ?? codexOptions.ResumeLast;
+            codexOptions.NoAltScreen = defaults.LastCodexNoAltScreen ?? codexOptions.NoAltScreen;
+            codexOptions.SearchEnabled = defaults.LastCodexSearchEnabled ?? codexOptions.SearchEnabled;
         }
         catch
         {
             // エラーが発生してもデフォルト値を使用
         }
+        return Task.CompletedTask;
     }
 
-    private async Task SaveLastUsedCliModes()
+    private Task SaveLastUsedCliModes()
     {
         try
         {
-            await LocalStorage.SetAsync(LAST_CLAUDE_PERMISSION_MODE_KEY, claudeCodeOptions.PermissionMode);
-            await LocalStorage.SetAsync(LAST_GEMINI_APPROVAL_MODE_KEY, geminiOptions.ApprovalMode);
-            await LocalStorage.SetAsync(LAST_CODEX_SANDBOX_MODE_KEY, codexOptions.SandboxMode);
-            await LocalStorage.SetAsync(LAST_CODEX_APPROVAL_POLICY_KEY, codexOptions.ApprovalPolicy);
-            await LocalStorage.SetAsync(LAST_CODEX_AUTO_REVIEW_APPROVALS_KEY, codexOptions.AutoReviewApprovals);
-            await LocalStorage.SetAsync(LAST_CODEX_RESUME_LAST_KEY, codexOptions.ResumeLast);
-            await LocalStorage.SetAsync(LAST_CODEX_NO_ALT_SCREEN_KEY, codexOptions.NoAltScreen);
-            await LocalStorage.SetAsync(LAST_CODEX_SEARCH_ENABLED_KEY, codexOptions.SearchEnabled);
+            var settings = AppSettingsService.GetSettings();
+            var defaults = settings.SessionDefaults;
+            defaults.LastClaudePermissionMode = claudeCodeOptions.PermissionMode;
+            defaults.LastGeminiApprovalMode = geminiOptions.ApprovalMode;
+            defaults.LastCodexSandboxMode = codexOptions.SandboxMode;
+            defaults.LastCodexApprovalPolicy = codexOptions.ApprovalPolicy;
+            defaults.LastCodexAutoReviewApprovals = codexOptions.AutoReviewApprovals;
+            defaults.LastCodexResumeLast = codexOptions.ResumeLast;
+            defaults.LastCodexNoAltScreen = codexOptions.NoAltScreen;
+            defaults.LastCodexSearchEnabled = codexOptions.SearchEnabled;
+            AppSettingsService.SaveSettings(settings);
         }
         catch
         {
             // エラーが発生しても継続
         }
+        return Task.CompletedTask;
     }
 
     private void SelectFolder(string folder)
@@ -451,7 +446,7 @@
         antigravityOptions = new();
         grokOptions = new();
         // Create 後・次回ダイアログ表示で前回の CLI モード選択が見えるよう、
-        // 新しい OptionsData インスタンスに LocalStorage の値を反映しなおす。
+        // 新しい OptionsData インスタンスに AppSettings の値を反映しなおす。
         await LoadLastUsedCliModes();
         showCreateFolderDialog = false;
         pendingSessionCreation = false;

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -3,6 +3,7 @@
 @using Microsoft.Extensions.Localization
 @inject IGitService GitService
 @inject ILocalStorageService LocalStorage
+@inject IAppSettingsService AppSettingsService
 @inject IFolderPickerService FolderPicker
 @inject IStringLocalizer<SharedResource> L
 
@@ -392,15 +393,8 @@
     private const string LAST_BRANCH_SELECTION_MODE_KEY = "lastBranchSelectionMode";
     private static readonly HashSet<string> ValidBranchSelectionModes = new() { "NewBranch", "ExistingBranch", "Detached" };
 
-    // LocalStorage: 直近の CLI モード選択 (SessionCreateDialog とキーを共有して値を流用)
-    private const string LAST_CLAUDE_PERMISSION_MODE_KEY = "lastClaudePermissionMode";
-    private const string LAST_GEMINI_APPROVAL_MODE_KEY = "lastGeminiApprovalMode";
-    private const string LAST_CODEX_SANDBOX_MODE_KEY = "lastCodexSandboxMode";
-    private const string LAST_CODEX_APPROVAL_POLICY_KEY = "lastCodexApprovalPolicy";
-    private const string LAST_CODEX_AUTO_REVIEW_APPROVALS_KEY = "lastCodexAutoReviewApprovals";
-    private const string LAST_CODEX_RESUME_LAST_KEY = "lastCodexResumeLast";
-    private const string LAST_CODEX_NO_ALT_SCREEN_KEY = "lastCodexNoAltScreen";
-    private const string LAST_CODEX_SEARCH_ENABLED_KEY = "lastCodexSearchEnabled";
+    // 直近の CLI モード選択は AppSettings.SessionDefaults(ファイル) から読む
+    // (値の発生源は SessionCreateDialog に一元化。SubSession 側は読むだけで書き戻さない)。
 
     private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto", "default" };
     private static readonly HashSet<string> ValidGeminiApprovalModes = new() { "default", "auto_edit", "yolo" };
@@ -641,51 +635,45 @@
 
     // SessionCreateDialog が保存した CLI モードの直近選択を、初期値として読むだけ。
     // SubSessionDialog 側で書き戻しはしない (値の発生源は新規セッション作成画面に一元化)。
-    private async Task LoadLastUsedCliModes()
+    private Task LoadLastUsedCliModes()
     {
         try
         {
-            var claudePerm = await LocalStorage.GetAsync<string>(LAST_CLAUDE_PERMISSION_MODE_KEY);
-            if (claudePerm != null && ValidClaudePermissionModes.Contains(claudePerm))
+            var defaults = AppSettingsService.GetSettings().SessionDefaults;
+
+            if (defaults.LastClaudePermissionMode != null && ValidClaudePermissionModes.Contains(defaults.LastClaudePermissionMode))
             {
-                claudeOptions.PermissionMode = claudePerm;
+                claudeOptions.PermissionMode = defaults.LastClaudePermissionMode;
             }
 
-            var geminiApproval = await LocalStorage.GetAsync<string>(LAST_GEMINI_APPROVAL_MODE_KEY);
-            if (geminiApproval != null && ValidGeminiApprovalModes.Contains(geminiApproval))
+            if (defaults.LastGeminiApprovalMode != null && ValidGeminiApprovalModes.Contains(defaults.LastGeminiApprovalMode))
             {
-                geminiOptions.ApprovalMode = geminiApproval;
+                geminiOptions.ApprovalMode = defaults.LastGeminiApprovalMode;
             }
 
             // Yolo（承認・サンドボックス完全バイパス）は危険なため「最後の選択」を復元せず、
             // 新規サブセッションでは常に OFF 既定にする（安全側）。
 
-            var codexSandbox = await LocalStorage.GetAsync<string>(LAST_CODEX_SANDBOX_MODE_KEY);
-            if (codexSandbox != null && ValidCodexSandboxModes.Contains(codexSandbox))
+            if (defaults.LastCodexSandboxMode != null && ValidCodexSandboxModes.Contains(defaults.LastCodexSandboxMode))
             {
-                codexOptions.SandboxMode = codexSandbox;
+                codexOptions.SandboxMode = defaults.LastCodexSandboxMode;
             }
 
-            var codexApproval = await LocalStorage.GetAsync<string>(LAST_CODEX_APPROVAL_POLICY_KEY);
-            if (codexApproval != null && ValidCodexApprovalPolicies.Contains(codexApproval))
+            if (defaults.LastCodexApprovalPolicy != null && ValidCodexApprovalPolicies.Contains(defaults.LastCodexApprovalPolicy))
             {
-                codexOptions.ApprovalPolicy = codexApproval;
+                codexOptions.ApprovalPolicy = defaults.LastCodexApprovalPolicy;
             }
 
-            codexOptions.AutoReviewApprovals =
-                await LocalStorage.GetAsync<bool?>(LAST_CODEX_AUTO_REVIEW_APPROVALS_KEY) ?? codexOptions.AutoReviewApprovals;
-
-            codexOptions.ResumeLast =
-                await LocalStorage.GetAsync<bool?>(LAST_CODEX_RESUME_LAST_KEY) ?? codexOptions.ResumeLast;
-            codexOptions.NoAltScreen =
-                await LocalStorage.GetAsync<bool?>(LAST_CODEX_NO_ALT_SCREEN_KEY) ?? codexOptions.NoAltScreen;
-            codexOptions.SearchEnabled =
-                await LocalStorage.GetAsync<bool?>(LAST_CODEX_SEARCH_ENABLED_KEY) ?? codexOptions.SearchEnabled;
+            codexOptions.AutoReviewApprovals = defaults.LastCodexAutoReviewApprovals ?? codexOptions.AutoReviewApprovals;
+            codexOptions.ResumeLast = defaults.LastCodexResumeLast ?? codexOptions.ResumeLast;
+            codexOptions.NoAltScreen = defaults.LastCodexNoAltScreen ?? codexOptions.NoAltScreen;
+            codexOptions.SearchEnabled = defaults.LastCodexSearchEnabled ?? codexOptions.SearchEnabled;
         }
         catch
         {
             // 失敗してもデフォルト値のまま続行
         }
+        return Task.CompletedTask;
     }
 
     private async Task LoadLastBranchSelectionMode()

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -16,6 +16,37 @@ public class AppSettings
     public CustomCliOptionsSettings CliOptions { get; set; } = new();
     public RemoteLaunchSettings RemoteLaunch { get; set; } = new();
     public ExperimentalSettings Experimental { get; set; } = new();
+    public SessionDefaultsSettings SessionDefaults { get; set; } = new();
+}
+
+/// <summary>
+/// セッション作成ダイアログの「前回選んだ値」（入力補助の既定値）。
+/// 従来はブラウザ localStorage に保存していたが、ブラウザごとに変えたい性質のものではない
+/// （その PC のユーザーの作業習慣）ため、ファイルベースの設定へ移した。値の発生源は
+/// 新規セッション作成ダイアログに一元化し、サブセッション側は読むだけ（書き戻さない）。
+/// null は「未保存」を意味し、各 OptionsData の初期値を維持する。
+/// Yolo（承認・サンドボックス完全バイパス）は危険なため、ここには保持しない（毎回 OFF 既定）。
+/// </summary>
+public class SessionDefaultsSettings
+{
+    /// <summary>前回選んだターミナル種別。</summary>
+    public TerminalType? LastTerminalType { get; set; }
+    /// <summary>Claude Code の権限モード（"bypass" | "auto" | "default"）。</summary>
+    public string? LastClaudePermissionMode { get; set; }
+    /// <summary>Gemini CLI の承認モード（"default" | "auto_edit" | "yolo"）。</summary>
+    public string? LastGeminiApprovalMode { get; set; }
+    /// <summary>Codex のサンドボックスモード（"" | "read-only" | "workspace-write" | "danger-full-access"）。</summary>
+    public string? LastCodexSandboxMode { get; set; }
+    /// <summary>Codex の承認ポリシー（"" | "untrusted" | "on-request" | "never"）。</summary>
+    public string? LastCodexApprovalPolicy { get; set; }
+    /// <summary>Codex の承認リクエスト自動レビュー。</summary>
+    public bool? LastCodexAutoReviewApprovals { get; set; }
+    /// <summary>Codex の resume --last。</summary>
+    public bool? LastCodexResumeLast { get; set; }
+    /// <summary>Codex の --no-alt-screen（既定 true を維持するため nullable）。</summary>
+    public bool? LastCodexNoAltScreen { get; set; }
+    /// <summary>Codex の --search。</summary>
+    public bool? LastCodexSearchEnabled { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## 概要

セッション作成ダイアログの「前回選んだ値」の保存先を、ブラウザ localStorage から
ファイルベースの設定（`AppSettings`）へ移しました。

これらの値はブラウザごとに変えたい性質のものではなく、その PC のユーザーの作業習慣なので、
`GeneralSettings.DefaultFolderPath` や `SortMode` など同種の"作業デフォルト"が既にある
ファイル側（`%LOCALAPPDATA%\TerminalHub\` 配下、dev/prod 分離）に置くのが自然という判断です。

**移行の効果**: 別ブラウザ / プロファイル / シークレットウィンドウでも前回値が引き継がれます。

## 変更点

- `AppSettings` に `SessionDefaults` セクションを新設（9項目、`null`=未保存で各既定値を維持）
- `SessionCreateDialog`: 前回値の読み書きを `AppSettingsService`（ファイル）経由に変更。
  未使用になった `LocalStorage` 注入とキー定数を削除
- `SubSessionDialog`: CLI モードの読み込みを AppSettings 経由に変更（書き戻しは従来どおり無し。
  値の発生源は新規セッション作成ダイアログに一元化）。ブランチ選択モードは別性質のため localStorage のまま

## スコープ外・方針

- **どのオプションを保存するかは現状維持**（全オプションの保存/非保存を棚卸しした上で、現状で問題なしと判断）
- **Yolo は従来どおり非保持**（危険なため毎回OFF既定）
- **移行処理は入れない**（次回セッション作成時から新方式で貯まる）。旧 localStorage キーは放置（実害なし）

## 確認

- ビルド成功（0 警告 / 0 エラー）
- 動作確認済み（ユーザー実機）

🤖 Generated with [Claude Code](https://claude.com/claude-code)