### PR TITLE
fix: 破棄済みConPtyConnectionServiceへの購読でObjectDisposedExceptionを握りつぶす

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1127,7 +1127,7 @@
             // SelectSession内でバッファ復元時に設定される
             if (sessionInfo.ConPtySession != null)
             {
-                ConPtyConnection.SubscribeToSession(sessionInfo.SessionId, sessionInfo.ConPtySession);
+                SafeSubscribeToSession(sessionInfo.SessionId, sessionInfo.ConPtySession);
             }
 
             StateHasChanged();
@@ -1201,6 +1201,25 @@
             sessionInfo.LastAccessedAt = DateTime.Now;
             await SaveSessionToStorageAsync(sessionInfo);
             StateHasChanged();
+        }
+    }
+
+    /// <summary>
+    /// ConPtyConnectionService への購読を安全に行う。
+    /// Circuit 破棄と非同期継続（OnAfterRenderAsync 等）の競合で、破棄済みの
+    /// ConPtyConnectionService（Scoped＝Circuitごと）に購読しようとして
+    /// ObjectDisposedException が飛ぶことがある。teardown 時の想定内レースなので、
+    /// 購読先の Circuit がもう無い＝配送先が無いだけなので握りつぶす。
+    /// </summary>
+    private void SafeSubscribeToSession(Guid sessionId, TerminalHub.Services.ConPtySession conPtySession)
+    {
+        try
+        {
+            ConPtyConnection.SubscribeToSession(sessionId, conPtySession);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Circuit は既に破棄済み。配送先が無いので無視する。
         }
     }
 
@@ -1391,7 +1410,7 @@
         var latestSessionInfo = SessionManager.GetSessionInfo(sessionId);
         if (latestSessionInfo?.ConPtySession != null)
         {
-            ConPtyConnection.SubscribeToSession(latestSessionInfo.SessionId, latestSessionInfo.ConPtySession);
+            SafeSubscribeToSession(latestSessionInfo.SessionId, latestSessionInfo.ConPtySession);
         }
         else
         {
@@ -2138,7 +2157,7 @@
                 if (selectedSessionInfo?.ConPtySession != null)
                 {
                     selectedSessionInfo.LastConnectionTime = DateTime.Now;
-                    ConPtyConnection.SubscribeToSession(selectedSessionInfo.SessionId, selectedSessionInfo.ConPtySession);
+                    SafeSubscribeToSession(selectedSessionInfo.SessionId, selectedSessionInfo.ConPtySession);
                 }
 
                 toast?.ShowSuccess(L["Root.Toast.TerminalRecreated"]);
@@ -2913,7 +2932,7 @@
            {
                 // 新しいセッションを購読
                 // 注意: LastConnectionTimeはSelectSession内で設定されるため、ここでは設定しない
-                ConPtyConnection.SubscribeToSession(sessionId, newSession);
+                SafeSubscribeToSession(sessionId, newSession);
                                 // セッションを起動
                 newSession.Start();
                 var defaultCols = Configuration.GetValue<int>("SessionSettings:DefaultCols", TerminalConstants.DefaultCols);

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1220,6 +1220,9 @@
         catch (ObjectDisposedException)
         {
             // Circuit は既に破棄済み。配送先が無いので無視する。
+            // [CircuitLife] 診断方針（dcd7cd9）に合わせ、握りつぶしが多発したとき気づけるよう
+            // 低レベル(Debug)で痕跡だけ残す。想定内の teardown レースなので Warning にはしない。
+            Logger.LogDebug("[CircuitLife] SubscribeToSession skipped: ConPtyConnectionService already disposed (sessionId={SessionId})", sessionId);
         }
     }
 


### PR DESCRIPTION
## 概要
Circuit 破棄と非同期継続の競合で表面化していた `ObjectDisposedException` を握りつぶす。

## 症状
セッション選択などの操作時に、以下の未処理例外が出ることがあった:

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'ConPtyConnectionService'.
   at ConPtyConnectionService.SubscribeToSession(...)
   at Root.SelectSession(...)
   at Root.OnAfterRenderAsync(...)
```

## 原因
`ConPtyConnectionService` は Scoped（Circuit ごと）サービス。Circuit が破棄された直後に、キューに残っていた `OnAfterRenderAsync → SelectSession` が走ると、破棄済みサービスに `SubscribeToSession` してしまい、`SubscribeToSession` 冒頭の破棄チェックが `ObjectDisposedException` を投げる。ページ再読込・タブを閉じる・接続断・再接続などの teardown 時に起こり得る想定内のレース。#129 はロックを追加したが、破棄済み時に throw する挙動自体は据え置きのため、この例外は現状の master でも発生し得る。

## 修正
`Root.razor` の `SubscribeToSession` 呼び出し4箇所を `SafeSubscribeToSession` ヘルパに集約し、`ObjectDisposedException` を安全に無視する。破棄済み＝配送先の Circuit がもう無いだけなので、購読をスキップして問題ない。`SubscribeToSession` 側の throw（#129 の設計）はそのまま残し、呼び出し側で teardown 時のみ飲み込む最小・低リスクの方針。

## テスト
`dotnet build` 成功。報告のあった再現手順で例外が出なくなることをユーザー実機で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
