### PR TITLE
ターミナル起動時のリサイズと復元経路を整理

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1308,7 +1308,7 @@
 
         // セッション切替中はConPTYリサイズをスキップ
         // showTerminal/InitializeTerminal内のfitAddon.fit()が過渡的なサイズでConPTYに通知するのを防ぐ
-        // 最終的なリサイズはResizeTerminalAsyncで正しいサイズを適用する
+        // DOM表示後にレイアウト確定を待ち、ResizeTerminalAsyncを1回だけ実行して同期する
         _skipConPtyResize = true;
         // 復元完了までライブ出力の直接書き込みを止める（新しい空のxtermへリプレイより先に
         // ライブチャンクが書かれると、以降のCUP絶対座標描画が全部ズレて重複表示になるため）
@@ -1326,19 +1326,25 @@
             // ターミナルを初期化
             await InitializeTerminal(sessionId);
 
-            // メモリ上のバッファから復元（リサイズトリックの代わり）
+            // ブラウザーのレイアウト確定後にfit()を1回だけ実行する。
+            // 切替中フラグは維持しているため、onResize経由ではConPTYへ転送されない。
+            if (activeTerminal != null)
+            {
+                await TerminalService.ResizeTerminalAsync(activeTerminal);
+            }
+
+            // メモリ上の状態バッファから復元
             if (selectedSession != null && activeTerminal != null)
             {
                 // 過去バッファの誤検出を防ぐため、接続時刻を記録
                 selectedSession.LastConnectionTime = DateTime.Now;
 
-                // リプレイ前にエミュレータ/ConPTY を xterm の実サイズへ同期する。
+                // リプレイ前にエミュレータ/ConPTYを、確定したxtermの実サイズへ1回だけ同期する。
                 // 切替中はリサイズ通知を skip しているため、別セッション閲覧中にパネル開閉や
                 // ウィンドウ変更があるとサイズがずれたままになる。エミュレータの行数が xterm より
                 // 大きい状態でリプレイすると、超過分が xterm のスクロールバックへ押し出されて
                 // 「古い画面が上に残る」重複が恒久化する。
-                // ConPTY のリサイズで conhost が新サイズの画面を再描画し、それはリプレイの
-                // テール（またはそれ以降のライブ出力）として正しい順序で届く。
+                // ConPTYの再描画はリプレイのテール（またはそれ以降のライブ出力）として届く。
                 var xtermSize = await TerminalService.GetTerminalSizeAsync(activeTerminal);
                 if (xtermSize is { Cols: >= 20, Rows: >= 10 } size && activeSession != null &&
                     (activeSession.Cols != size.Cols || activeSession.Rows != size.Rows))
@@ -1389,15 +1395,11 @@
                 {
                     _terminalWriteLock.Release();
                 }
-
-                await Task.Delay(50);
             }
 
-            // 最終リサイズ: スキップを解除してからfit()を実行し、正しいサイズをConPTYに通知
-            _skipConPtyResize = false;
+            // サイズはリプレイ前に確定済みなので、復元後は再描画だけ行う。
             if (activeTerminal != null)
             {
-                await TerminalService.ResizeTerminalAsync(activeTerminal);
                 await TerminalService.RefreshTerminalAsync(sessionId);
             }
         }

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -611,7 +611,7 @@
         // ON の間はサンドボックス/承認の指定は無視される（BuildCodexArgs 側で mode=yolo として処理）。
         public bool Yolo { get; set; } = false;
         public bool ResumeLast { get; set; } = false;
-        public bool NoAltScreen { get; set; } = true;
+        public bool NoAltScreen { get; set; } = false;
         // 既定は旧「Auto」相当（workspace-write + on-request）を明示値として持たせる。
         public string SandboxMode { get; set; } = "workspace-write"; // "", read-only, workspace-write, danger-full-access
         public string ApprovalPolicy { get; set; } = "on-request";

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -439,7 +439,7 @@
                     Yolo = savedMode == "yolo",
                     ResumeLast = (options.ContainsKey("resume-last") && options["resume-last"] == "true")
                         || (options.ContainsKey("resume-picker") && options["resume-picker"] == "true"),
-                    NoAltScreen = !options.TryGetValue("no-alt-screen", out var noAltScreen) || noAltScreen == "true",
+                    NoAltScreen = options.TryGetValue("no-alt-screen", out var noAltScreen) && noAltScreen == "true",
                     SandboxMode = savedSandbox,
                     ApprovalPolicy = savedApproval,
                     AutoReviewApprovals = savedApprovalsReviewer == "auto_review",

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -120,14 +120,12 @@ namespace TerminalHub.Constants
                 args.Add("resume --last");
             }
 
-            // --no-alt-screen を既定 ON にする前は、追加引数欄のプレースホルダー例が
-            // "--no-alt-screen" だった。その名残で extra-args / custom-args に手書きで
-            // --no-alt-screen を入れている既存セッションがあり得るため、その場合は
-            // 自動付与をスキップして二重指定（--no-alt-screen --no-alt-screen）を防ぐ。
+            // extra-args / custom-args に手書きで --no-alt-screen を入れている既存セッションが
+            // あり得るため、UI側の明示指定と重なっても二重指定しない。
             var userSuppliedNoAltScreen =
                 ContainsArgToken(options.GetValueOrDefault("extra-args"), "--no-alt-screen") ||
                 ContainsArgToken(options.GetValueOrDefault("custom-args"), "--no-alt-screen");
-            if ((!options.TryGetValue("no-alt-screen", out var noAltScreen) || noAltScreen == "true") &&
+            if (options.TryGetValue("no-alt-screen", out var noAltScreen) && noAltScreen == "true" &&
                 !userSuppliedNoAltScreen)
             {
                 args.Add("--no-alt-screen");

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -43,7 +43,7 @@ public class SessionDefaultsSettings
     public bool? LastCodexAutoReviewApprovals { get; set; }
     /// <summary>Codex の resume --last。</summary>
     public bool? LastCodexResumeLast { get; set; }
-    /// <summary>Codex の --no-alt-screen（既定 true を維持するため nullable）。</summary>
+    /// <summary>Codex の --no-alt-screen。未設定時は false。</summary>
     public bool? LastCodexNoAltScreen { get; set; }
     /// <summary>Codex の --search。</summary>
     public bool? LastCodexSearchEnabled { get; set; }

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -377,8 +377,8 @@
   <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>Warning:</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO mode should only be used in isolated environments (WSL/Docker/VM/CI).</value></data>
   <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>Resume previous session (resume --last)</value></data>
-  <data name="SessionOptions.Codex.NoAltScreen" xml:space="preserve"><value>Inline display (recommended)</value></data>
-  <data name="SessionOptions.Codex.NoAltScreen.Help" xml:space="preserve"><value>Preserves terminal scrollback and improves long-session resume stability (--no-alt-screen).</value></data>
+  <data name="SessionOptions.Codex.NoAltScreen" xml:space="preserve"><value>Inline display</value></data>
+  <data name="SessionOptions.Codex.NoAltScreen.Help" xml:space="preserve"><value>Avoids the alternate screen and keeps Codex output in the terminal scrollback (--no-alt-screen).</value></data>
   <data name="SessionOptions.Codex.AdvancedSettings" xml:space="preserve"><value>Advanced settings</value></data>
   <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>Sandbox mode</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI default</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -377,8 +377,8 @@
   <data name="SessionOptions.Codex.YoloWarning.Label" xml:space="preserve"><value>警告:</value></data>
   <data name="SessionOptions.Codex.YoloWarning.Message" xml:space="preserve"><value>YOLO モードは隔離環境（WSL/Docker/VM/CI）でのみ使用してください。</value></data>
   <data name="SessionOptions.Codex.ResumeLast" xml:space="preserve"><value>直前のセッションに接続 (resume --last)</value></data>
-  <data name="SessionOptions.Codex.NoAltScreen" xml:space="preserve"><value>インライン表示（推奨）</value></data>
-  <data name="SessionOptions.Codex.NoAltScreen.Help" xml:space="preserve"><value>スクロール履歴を保持し、長いセッションの復帰を安定させます（--no-alt-screen）。</value></data>
+  <data name="SessionOptions.Codex.NoAltScreen" xml:space="preserve"><value>インライン表示</value></data>
+  <data name="SessionOptions.Codex.NoAltScreen.Help" xml:space="preserve"><value>代替画面を使わず、Codex の出力をターミナルのスクロール履歴に残します（--no-alt-screen）。</value></data>
   <data name="SessionOptions.Codex.AdvancedSettings" xml:space="preserve"><value>高度な設定</value></data>
   <data name="SessionOptions.Codex.Sandbox.Label" xml:space="preserve"><value>サンドボックスモード</value></data>
   <data name="SessionOptions.Codex.Sandbox.DefaultLabel" xml:space="preserve"><value>CLI 既定</value></data>

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -787,6 +787,12 @@ namespace TerminalHub.Services
                         case ProbeState.Ground:
                             if (ch == '\x1b')
                                 _state = ProbeState.Escape;
+                            else if (ch == '\u009b')
+                                _state = ProbeState.Csi;
+                            else if (ch == '\u009d')
+                                _state = ProbeState.Osc;
+                            else if (ch is '\u0090' or '\u0098' or '\u009e' or '\u009f')
+                                _state = ProbeState.ControlString;
                             else if (!char.IsControl(ch) && !char.IsWhiteSpace(ch))
                                 found = true;
                             break;
@@ -797,8 +803,18 @@ namespace TerminalHub.Services
                                 '[' => ProbeState.Csi,
                                 ']' => ProbeState.Osc,
                                 'P' or 'X' or '^' or '_' => ProbeState.ControlString,
+                                >= ' ' and <= '/' => ProbeState.EscapeIntermediate,
                                 _ => ProbeState.Ground
                             };
+                            break;
+
+                        case ProbeState.EscapeIntermediate:
+                            if (ch == '\x1b')
+                                _state = ProbeState.Escape;
+                            else if (ch is >= '0' and <= '~')
+                                _state = ProbeState.Ground;
+                            else if (ch is not (>= ' ' and <= '/'))
+                                _state = ProbeState.Ground;
                             break;
 
                         case ProbeState.Csi:
@@ -834,6 +850,7 @@ namespace TerminalHub.Services
             {
                 Ground,
                 Escape,
+                EscapeIntermediate,
                 Csi,
                 Osc,
                 OscEscape,

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -75,6 +75,20 @@ namespace TerminalHub.Services
         // 注入し、CLI/エージェントが「自分がどの TerminalHub セッションか」を自己識別できるようにする。
         private readonly Guid? _sessionId;
 
+        // Codex resume 起動停止の診断用。CreateProcess はコンストラクター内、パイプ読み取りは
+        // Start() 後に始まるため、その間隔と「制御シーケンスしか届かない」状態を記録する。
+        // 通常セッションのログを増やさないよう codex resume --last のときだけ有効化する。
+        private readonly Stopwatch _startupStopwatch = Stopwatch.StartNew();
+        private bool _startupDiagnosticsEnabled;
+        private long _processStartedElapsedMs = -1;
+        private long _readerStartedElapsedMs = -1;
+        private long _firstOutputElapsedMs = -1;
+        private long _firstPrintableElapsedMs = -1;
+        private long _lastOutputElapsedMs = -1;
+        private long _startupBytesRead;
+        private int _startupChunksRead;
+        private readonly StartupOutputProbe _startupOutputProbe = new();
+
         // 環境変数フラグ
         private const uint CREATE_UNICODE_ENVIRONMENT = 0x00000400;
         
@@ -166,7 +180,18 @@ namespace TerminalHub.Services
             }
             
             _readCancellationTokenSource = new CancellationTokenSource();
+            _readerStartedElapsedMs = _startupStopwatch.ElapsedMilliseconds;
+            if (_startupDiagnosticsEnabled)
+            {
+                _logger.LogInformation(
+                    "[ConPtyStartup] 出力読み取り開始: SessionId={SessionId}, ProcessId={ProcessId}, ProcessToReaderMs={ProcessToReaderMs}, Size={Cols}x{Rows}",
+                    _sessionId, ProcessId, ElapsedSince(_processStartedElapsedMs, _readerStartedElapsedMs), Cols, Rows);
+            }
             _readTask = Task.Run(() => ReadPipeAsync(_readCancellationTokenSource.Token));
+            if (_startupDiagnosticsEnabled)
+            {
+                _ = Task.Run(() => MonitorStartupOutputAsync(_readCancellationTokenSource.Token));
+            }
         }
 
         private IntPtr CreateEnvironmentBlock()
@@ -293,6 +318,10 @@ namespace TerminalHub.Services
             var fullCommand = string.IsNullOrWhiteSpace(arguments) ? command : $"{command} {arguments}";
             var cmdline = $"cmd.exe /c {fullCommand}";
 
+            _startupDiagnosticsEnabled =
+                cmdline.Contains("codex", StringComparison.OrdinalIgnoreCase) &&
+                cmdline.Contains("resume --last", StringComparison.OrdinalIgnoreCase);
+
             _logger.LogInformation($"Creating process: {cmdline} in directory: {workingDirectory ?? "current"}");
             
             // XTerm互換のための環境変数を設定
@@ -328,6 +357,13 @@ namespace TerminalHub.Services
             }
 
             _process = Process.GetProcessById((int)processInfo.dwProcessId);
+            _processStartedElapsedMs = _startupStopwatch.ElapsedMilliseconds;
+            if (_startupDiagnosticsEnabled)
+            {
+                _logger.LogInformation(
+                    "[ConPtyStartup] Codex resume プロセス起動: SessionId={SessionId}, ProcessId={ProcessId}, Size={Cols}x{Rows}",
+                    _sessionId, _process.Id, Cols, Rows);
+            }
 
                 processInfoHandle = processInfo.hProcess;
                 threadInfoHandle = processInfo.hThread;
@@ -604,6 +640,8 @@ namespace TerminalHub.Services
                         var charsRead = _utf8Decoder.GetChars(byteBuffer, 0, bytesRead, charBuffer, 0);
                         var data = new string(charBuffer, 0, charsRead);
 
+                        RecordStartupOutput(bytesRead, data);
+
                         if (_enableBuffering)
                         {
                             // バッファリングが有効な場合
@@ -643,9 +681,165 @@ namespace TerminalHub.Services
 
             // 終了通知より先に、短時間バッファに残った末尾出力を配送する。
             FlushRemainingOutput(waitForDispatch: true);
+
+            LogStartupSummary("読み取り終了");
             
             // プロセスが終了したことを通知
             RaiseProcessExited();
+        }
+
+        private void RecordStartupOutput(int bytesRead, string data)
+        {
+            if (!_startupDiagnosticsEnabled)
+                return;
+
+            var now = _startupStopwatch.ElapsedMilliseconds;
+            Interlocked.Add(ref _startupBytesRead, bytesRead);
+            Interlocked.Increment(ref _startupChunksRead);
+            Volatile.Write(ref _lastOutputElapsedMs, now);
+
+            if (Interlocked.CompareExchange(ref _firstOutputElapsedMs, now, -1) == -1)
+            {
+                _logger.LogInformation(
+                    "[ConPtyStartup] 最初の出力受信: SessionId={SessionId}, ProcessId={ProcessId}, Bytes={Bytes}, Chars={Chars}, ProcessToOutputMs={ProcessToOutputMs}, ReaderToOutputMs={ReaderToOutputMs}",
+                    _sessionId, ProcessId, bytesRead, data.Length,
+                    ElapsedSince(_processStartedElapsedMs, now), ElapsedSince(_readerStartedElapsedMs, now));
+            }
+
+            if (_startupOutputProbe.FeedAndDetectPrintable(data) &&
+                Interlocked.CompareExchange(ref _firstPrintableElapsedMs, now, -1) == -1)
+            {
+                _logger.LogInformation(
+                    "[ConPtyStartup] 最初の表示文字受信: SessionId={SessionId}, ProcessId={ProcessId}, ProcessToPrintableMs={ProcessToPrintableMs}, BytesSoFar={Bytes}, ChunksSoFar={Chunks}",
+                    _sessionId, ProcessId, ElapsedSince(_processStartedElapsedMs, now),
+                    Interlocked.Read(ref _startupBytesRead), Volatile.Read(ref _startupChunksRead));
+            }
+        }
+
+        private async Task MonitorStartupOutputAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
+                LogStartupCheckpoint(3);
+
+                await Task.Delay(TimeSpan.FromSeconds(7), cancellationToken);
+                LogStartupCheckpoint(10);
+            }
+            catch (OperationCanceledException)
+            {
+                // セッション終了・破棄時の通常経路。
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "[ConPtyStartup] 起動診断タスクでエラー: SessionId={SessionId}", _sessionId);
+            }
+        }
+
+        private void LogStartupCheckpoint(int seconds)
+        {
+            if (!_startupDiagnosticsEnabled || Volatile.Read(ref _firstPrintableElapsedMs) >= 0)
+                return;
+
+            _logger.LogWarning(
+                "[ConPtyStartup] {Seconds}秒経過しても表示文字なし: SessionId={SessionId}, ProcessId={ProcessId}, Bytes={Bytes}, Chunks={Chunks}, FirstOutputMs={FirstOutputMs}, LastOutputMs={LastOutputMs}, HasExited={HasExited}, OutputPaused={OutputPaused}, Size={Cols}x{Rows}, ProcessToReaderMs={ProcessToReaderMs}",
+                seconds, _sessionId, ProcessId,
+                Interlocked.Read(ref _startupBytesRead), Volatile.Read(ref _startupChunksRead),
+                ElapsedSince(_processStartedElapsedMs, Volatile.Read(ref _firstOutputElapsedMs)),
+                ElapsedSince(_processStartedElapsedMs, Volatile.Read(ref _lastOutputElapsedMs)),
+                HasExited, _outputPaused, Cols, Rows,
+                ElapsedSince(_processStartedElapsedMs, Volatile.Read(ref _readerStartedElapsedMs)));
+        }
+
+        private void LogStartupSummary(string reason)
+        {
+            if (!_startupDiagnosticsEnabled)
+                return;
+
+            _logger.LogInformation(
+                "[ConPtyStartup] {Reason}: SessionId={SessionId}, ProcessId={ProcessId}, Bytes={Bytes}, Chunks={Chunks}, FirstOutputMs={FirstOutputMs}, FirstPrintableMs={FirstPrintableMs}, LastOutputMs={LastOutputMs}, HasExited={HasExited}",
+                reason, _sessionId, ProcessId,
+                Interlocked.Read(ref _startupBytesRead), Volatile.Read(ref _startupChunksRead),
+                ElapsedSince(_processStartedElapsedMs, Volatile.Read(ref _firstOutputElapsedMs)),
+                ElapsedSince(_processStartedElapsedMs, Volatile.Read(ref _firstPrintableElapsedMs)),
+                ElapsedSince(_processStartedElapsedMs, Volatile.Read(ref _lastOutputElapsedMs)),
+                HasExited);
+        }
+
+        private static long ElapsedSince(long start, long end)
+            => start >= 0 && end >= start ? end - start : -1;
+
+        /// <summary>
+        /// ANSI/OSC/DCS をまたいで、画面に表示される空白以外の文字を検出する。
+        /// チャンク境界でシーケンスが分断されても CSI の終端文字（K/h等）を本文扱いしない。
+        /// </summary>
+        private sealed class StartupOutputProbe
+        {
+            private ProbeState _state;
+
+            public bool FeedAndDetectPrintable(string data)
+            {
+                var found = false;
+                foreach (var ch in data)
+                {
+                    switch (_state)
+                    {
+                        case ProbeState.Ground:
+                            if (ch == '\x1b')
+                                _state = ProbeState.Escape;
+                            else if (!char.IsControl(ch) && !char.IsWhiteSpace(ch))
+                                found = true;
+                            break;
+
+                        case ProbeState.Escape:
+                            _state = ch switch
+                            {
+                                '[' => ProbeState.Csi,
+                                ']' => ProbeState.Osc,
+                                'P' or 'X' or '^' or '_' => ProbeState.ControlString,
+                                _ => ProbeState.Ground
+                            };
+                            break;
+
+                        case ProbeState.Csi:
+                            if (ch is >= '@' and <= '~')
+                                _state = ProbeState.Ground;
+                            break;
+
+                        case ProbeState.Osc:
+                            if (ch == '\a')
+                                _state = ProbeState.Ground;
+                            else if (ch == '\x1b')
+                                _state = ProbeState.OscEscape;
+                            break;
+
+                        case ProbeState.OscEscape:
+                            _state = ch == '\\' ? ProbeState.Ground : ProbeState.Osc;
+                            break;
+
+                        case ProbeState.ControlString:
+                            if (ch == '\x1b')
+                                _state = ProbeState.ControlStringEscape;
+                            break;
+
+                        case ProbeState.ControlStringEscape:
+                            _state = ch == '\\' ? ProbeState.Ground : ProbeState.ControlString;
+                            break;
+                    }
+                }
+                return found;
+            }
+
+            private enum ProbeState
+            {
+                Ground,
+                Escape,
+                Csi,
+                Osc,
+                OscEscape,
+                ControlString,
+                ControlStringEscape
+            }
         }
 
         public void Resize(int cols, int rows)

--- a/TerminalHub/wwwroot/js/helpers.js
+++ b/TerminalHub/wwwroot/js/helpers.js
@@ -47,7 +47,6 @@ window.terminalHubHelpers = {
                     console.log(`  - element.parentNode: ${!!termInfo.terminal.element.parentNode}`);
                     console.log(`  - rows: ${termInfo.terminal.rows}, cols: ${termInfo.terminal.cols}`);
                 }
-                console.log(`  - isFirstWrite: ${termInfo.isFirstWrite}`);
                 console.log(`  - fitAddon存在: ${!!termInfo.fitAddon}`);
             });
         } else {

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -879,14 +879,6 @@ window.terminalFunctions = {
             
             // xterm.jsのリサイズイベントリスナーを追加
             term.onResize((size) => {
-                // リサイズイベントをトラック
-                const terminalInfo = window.multiSessionTerminals[sessionId];
-                if (terminalInfo) {
-                    if (terminalInfo.isFirstWrite) {
-                        terminalInfo.resizeCount = 1;
-                    }
-                }
-
                 notifyResize(size.cols, size.rows, 'onResize', '');
             });
 
@@ -994,9 +986,6 @@ window.terminalFunctions = {
             // console.log(`[JS] ターミナル作成成功: sessionId=${sessionId}`);
             // console.log(`[JS] 現在のターミナル数: ${Object.keys(window.multiSessionTerminals).length}`);
 
-            // ターミナルごとの状態を保存（if (element) ブロック内に移動）
-            window.multiSessionTerminals[sessionId].isFirstWrite = true;
-            window.multiSessionTerminals[sessionId].resizeCount = 0;
         } else {
             // DOM要素が見つからない場合はエラーログを出力
             console.error(`[JS] createMultiSessionTerminal: DOM要素が見つかりません terminalId=${terminalId}`);
@@ -1005,7 +994,6 @@ window.terminalFunctions = {
 
         return {
             write: (data) => {
-                const terminalInfo = window.multiSessionTerminals[sessionId];
                 const dataLength = data.length;
 
                 // デバッグ: 大きなデータの書き込みを検出
@@ -1035,63 +1023,18 @@ window.terminalFunctions = {
                     });
                 };
 
-                // terminalInfoが存在しない場合は単純にデータを書き込み
-                if (!terminalInfo) {
-                    writeWithCallback(data);
-                    return;
-                }
-
-                // リサイズ直後の書き込みはカウント
-                if (terminalInfo.resizeCount > 0 && terminalInfo.resizeCount < 3) {
-                    terminalInfo.resizeCount++;
-                    // リサイズ後の書き込み
-                    // リサイズデータは通常通り処理
-                    writeWithCallback(data);
-
-                    if (terminalInfo.resizeCount >= 2) {
-                        // リサイズ完了 - スクロールバック復元完了
-                        // リサイズ完了 - スクロールバック復元
-                        terminalInfo.resizeCount = 0;
-
-                    }
-                }
-                // セッション切り替え直後の最初の書き込みを検出（リサイズトリック前）
-                else if (terminalInfo.isFirstWrite && data.includes('\x1b[2J') && (data.match(/\x1b\[K/g) || []).length > 10) {
-                    // 画面クリアをスキップして、カーソル位置のみ適用
-                    let processedData = data;
-
-                    // 画面クリア(\x1b[2J)を削除
-                    processedData = processedData.replace(/\x1b\[2J/g, '');
-                    // ホーム位置への移動(\x1b[H)も一時的に削除
-                    processedData = processedData.replace(/\x1b\[H/g, '');
-
-                    // 改行を追加して続きから表示
-                    const separator = '\r\n--- セッション再開 ---\r\n';
-                    term.write(separator);
-                    writeWithCallback(processedData);
-
-                    // セッション切り替え検出 - スクロールバック保持
-                    terminalInfo.isFirstWrite = false;
-
-                    // リサイズトリックを待つ
-                    terminalInfo.resizeCount = 1;
-                } else {
-                    // 通常の書き込み
-                    const beforeViewportY = term.buffer.active.viewportY;
-                    const beforeLength = term.buffer.active.length;
-                    const isAtBottom = beforeViewportY + term.rows >= beforeLength;
-
-                    writeWithCallback(data);
-
-                    if (terminalInfo) {
-                        terminalInfo.isFirstWrite = false;
-                    }
-                }
+                // サーバー側の状態バッファが復元順序を保証するため、ANSIシーケンスを
+                // 加工せず、そのままxtermへ渡す。
+                writeWithCallback(data);
             },
             clear: () => term.clear(),
             focus: () => term.focus(),
-            resize: () => {
-                // fit()でサイズが変わった場合はonResizeイベント経由でC#側にログが記録される
+            resize: async () => {
+                // DOMの表示切替とBlazorの描画が完了した後のレイアウトでfitする。
+                // 固定時間待機ではなく、ブラウザーの描画フレームに同期する。
+                await new Promise(resolve =>
+                    requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
                 if (fitAddon) {
                     try {
                         fitAddon.fit();
@@ -1146,11 +1089,7 @@ window.terminalFunctions = {
             console.log(`[JS] showTerminal: ターミナルを表示に設定`);
             console.log(`[JS] showTerminal: 設定後 display=${terminal.style.display}, offsetWidth=${terminal.offsetWidth}, offsetHeight=${terminal.offsetHeight}`);
             
-            // セッション表示時に初回書き込みフラグをリセット
             if (window.multiSessionTerminals && window.multiSessionTerminals[sessionId]) {
-                window.multiSessionTerminals[sessionId].isFirstWrite = true;
-                console.log(`[JS] showTerminal: 初回書き込みフラグをリセット`);
-                
                 // xtermオブジェクトの存在確認
                 const termObj = window.multiSessionTerminals[sessionId];
                 console.log(`[JS] showTerminal: xterm存在確認 - terminal=${!!termObj.terminal}, element=${!!termObj.terminal?.element}`);
@@ -1182,12 +1121,8 @@ window.terminalFunctions = {
                             terminal.appendChild(termObj.terminal.element);
                         }
                         
-                        // 表示復帰時の再描画トリガー（WebGL コンテキスト喪失時は onContextLoss で DOM レンダラーへフォールバック済み。ここではサイズ同期のみ）
-                        // fit()でサイズが変わった場合はonResizeイベント経由でC#側にログが記録される
-                        if (termObj.fitAddon) {
-                            termObj.fitAddon.fit();
-                        }
-
+                        // 表示復帰時は再描画だけ行う。サイズ同期は呼び出し元または
+                        // ResizeObserverに一本化し、ここではfit()しない。
                         termObj.terminal.focus();
                         termObj.terminal.refresh(0, termObj.terminal.rows - 1);
                         console.log(`[JS] showTerminal: フォーカスとリフレッシュ実行`);
@@ -1217,10 +1152,8 @@ window.terminalFunctions = {
             terminal.style.opacity = '0';
             terminal.style.display = 'block';
             
-            // セッション表示時に初回書き込みフラグをリセット
             if (window.multiSessionTerminals && window.multiSessionTerminals[sessionId]) {
                 const terminalInfo = window.multiSessionTerminals[sessionId];
-                terminalInfo.isFirstWrite = true;
                 terminalInfo.pendingShow = true;
                 // セッションを一時非表示に設定
                 
@@ -1317,14 +1250,10 @@ window.terminalFunctions = {
         if (window.multiSessionTerminals && window.multiSessionTerminals[sessionId]) {
             const terminalInfo = window.multiSessionTerminals[sessionId];
             const term = terminalInfo.terminal;
-            const fitAddon = terminalInfo.fitAddon;
 
-            if (term && fitAddon) {
+            if (term) {
                 try {
-                    // fit()を実行して確実にサイズを合わせる
-                    fitAddon.fit();
-
-                    // 全行をリフレッシュして表示を更新
+                    // サイズ変更は行わず、全行の再描画だけを実行する。
                     term.refresh(0, term.rows - 1);
 
                     console.log(`[JS] refreshTerminal: リフレッシュ完了 sessionId=${sessionId}, cols=${term.cols}, rows=${term.rows}`);

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -1031,9 +1031,26 @@ window.terminalFunctions = {
             focus: () => term.focus(),
             resize: async () => {
                 // DOMの表示切替とBlazorの描画が完了した後のレイアウトでfitする。
-                // 固定時間待機ではなく、ブラウザーの描画フレームに同期する。
-                await new Promise(resolve =>
-                    requestAnimationFrame(() => requestAnimationFrame(resolve)));
+                // 通常はブラウザーの描画フレームに同期する。バックグラウンドタブでは
+                // requestAnimationFrameが停止するため即時に進み、途中で非表示になった
+                // 場合にも安全弁で復元処理を止めない。
+                await new Promise(resolve => {
+                    let completed = false;
+                    const finish = () => {
+                        if (completed) return;
+                        completed = true;
+                        clearTimeout(fallbackTimer);
+                        resolve();
+                    };
+                    const fallbackTimer = setTimeout(finish, 250);
+
+                    if (document.visibilityState !== 'visible') {
+                        finish();
+                        return;
+                    }
+
+                    requestAnimationFrame(() => requestAnimationFrame(finish));
+                });
 
                 if (fitAddon) {
                     try {


### PR DESCRIPTION
## 概要

ターミナル起動・復元時のリサイズ経路を整理し、古いCLI向けに残っていた出力加工とリサイズトリックを撤去します。

## 変更内容

- DOM表示後、ブラウザーの描画フレームに同期して `fit()` を1回だけ実行
- 確定したサイズを状態バッファとConPTYへ1回だけ同期
- `showTerminal` / `refreshTerminal` の重複 `fit()` を撤去
- 初回出力の `ESC[2J` / `ESC[H` 除去と「セッション再開」挿入を撤去
- `isFirstWrite` / `resizeCount` による特殊処理を撤去
- Codex `resume --last` の起動診断ログを追加
- Codexのインライン表示（`--no-alt-screen`）を新規既定OFFへ変更

## 原因

起動時に複数箇所から `fit()` が実行され、短時間に `152→150→152` のようなサイズ変更がConPTYへ連続通知されていました。Codex `resume --last` では、このタイミングでTUI初期描画前にプロセスが生存したまま出力停止するケースがありました。

また、サーバー側の状態バッファによる正規のリプレイと、旧来のJavaScript側ANSI加工が重複していました。

## 影響

Claude Code、Codex、Gemini、通常ターミナルを同じ単純な復元経路へ統一します。通常のウィンドウサイズ変更は引き続きResizeObserverから即時反映されます。

## 検証

- `node --check TerminalHub/wwwroot/js/terminal.js`
- `node --check TerminalHub/wwwroot/js/helpers.js`
- `dotnet build TerminalHub/TerminalHub.csproj`（警告0、エラー0）
- `dotnet test TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj`（59件成功）
- Codex `resume --last` の停止再現とリサイズ列をrawキャプチャ／診断ログで比較
- Claude Codeおよび他ツールの起動を手動確認

追加の反復確認を行うためドラフトで作成します。