### PR TITLE
ローカルビルドにもプレビュー版メタデータ（HEAD SHA等）を埋め込む

### DIFF
--- a/build-and-install.bat
+++ b/build-and-install.bat
@@ -13,7 +13,19 @@ if exist "publish" (
     echo     Cleaning old publish folder...
     rd /s /q "publish"
 )
-dotnet publish TerminalHub/TerminalHub.csproj -c Release -r win-x64 --self-contained true -o ./publish
+
+echo     Collecting build metadata from git HEAD...
+set "BUILD_COMMIT="
+set "BUILD_PR="
+set "BUILD_DATE="
+for /f "delims=" %%i in ('git rev-parse --short HEAD 2^>nul') do set "BUILD_COMMIT=%%i"
+for /f "tokens=4" %%i in ('git log --grep^="Merge pull request #" -1 --pretty^=%%s 2^>nul') do set "MERGE_PR_TOKEN=%%i"
+if defined MERGE_PR_TOKEN set "BUILD_PR=!MERGE_PR_TOKEN:#=!"
+for /f "delims=" %%i in ('powershell -NoProfile -Command "(Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')" 2^>nul') do set "BUILD_DATE=%%i"
+echo     Channel=preview PR=#!BUILD_PR! Commit=!BUILD_COMMIT! Date=!BUILD_DATE!
+echo.
+
+dotnet publish TerminalHub/TerminalHub.csproj -c Release -r win-x64 --self-contained true -o ./publish /p:BuildChannel=preview /p:BuildPr=!BUILD_PR! /p:BuildCommit=!BUILD_COMMIT! /p:BuildDate=!BUILD_DATE!
 if !errorlevel! neq 0 (
     echo [ERROR] Publish failed.
     pause


### PR DESCRIPTION
## 概要
`build-and-install.bat` によるローカルビルド→インストールでも、Webインストール（CIプレビュー版）と同様に**設定画面にビルド元の情報を表示**できるようにする。

## 変更内容
- `build-and-install.bat` の publish 直前に git HEAD からメタデータを算出:
  - **Commit**: `git rev-parse --short HEAD`
  - **PR**: 直近の「Merge pull request #NN」から番号抽出
  - **Date**: UTC `yyyy-MM-dd`
- CIプレビュー版と同一の MSBuild プロパティを `dotnet publish` に渡す:
  `/p:BuildChannel=preview /p:BuildPr=.. /p:BuildCommit=.. /p:BuildDate=..`

## 仕組み（C#側は無改修）
1. `/p:Build*` → `TerminalHub.csproj` の `AssemblyMetadata` に埋め込み
2. `VersionCheckService.PreviewBuild` が `BuildChannel=="preview"` のときだけ読み出す
3. 設定画面のバージョン欄に「プレビュー版」バッジ＋`PR #NN / SHA (日付)`＋コミットリンクを表示

正式リリース版（vタグビルド）は `BuildChannel=release` なのでバッジは出ず、**ローカルビルドだけプレビューバッジが付く**ため、どちらで入れたか一目で分かる。

## 動作確認
- git メタデータ算出を cmd で実測し、`PR=#136 Commit=d4107a6 Date=2026-07-14` を確認済み。
- 埋め込み→バッジ表示の経路はCIが同一プロパティで既に実証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)