### PR TITLE
fix: シェルパネルの初期化順序を正常化し、固定待機と強制DOM修復を除去

### DIFF
--- a/TerminalHub/Components/Shared/BottomPanels/ShellPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/ShellPanel.razor
@@ -1,3 +1,4 @@
+@using TerminalHub.Constants
 @using TerminalHub.Models
 @using TerminalHub.Services
 @using Microsoft.JSInterop
@@ -41,28 +42,11 @@
                 WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             }
 
-            // ConPTYセッション作成
-            var conPtyService = new ConPtyService(LoggerFactory.CreateLogger<ConPtyService>());
-            shellSession = await conPtyService.CreateSessionAsync(ShellExecutable, "", WorkingDirectory, 120, 30);
-
-            shellSession.DataReceived += OnDataReceived;
-            shellSession.ProcessExited += OnProcessExited;
-            shellSession.Start();
-
-            // ConPTYの初期化が完了するまで少し待つ
-            await Task.Delay(100);
-
-            // DOM要素の存在を確認
-            var elementExists = await JSRuntime.InvokeAsync<bool>("eval", $@"
-                !!document.getElementById('{ContainerId}')
-            ");
-
-            if (!elementExists)
-            {
-                await Task.Delay(200);
-            }
-
-            // XTermを作成
+            // 先に xterm を用意してから ConPTY を起動する。
+            // 逆順にすると Start() 後・xterm 作成前に届いた出力が OnDataReceived の
+            // terminal == null で捨てられるため、シェルの初期プロンプトが欠ける。
+            // コンテナ div はこのコンポーネントのマークアップにあり、OnAfterRenderAsync
+            // (firstRender) の時点でレンダリング済みなので、DOM の存在待ちは不要。
             terminal = await JSRuntime.InvokeAsync<IJSObjectReference>(
                 "terminalFunctions.createMultiSessionTerminal",
                 ContainerId,
@@ -70,18 +54,22 @@
                 DotNetRef
             );
 
-            // フォーカスとリサイズ
-            await JSRuntime.InvokeVoidAsync("eval", $@"
-                (function() {{
-                    const termObj = window.multiSessionTerminals && window.multiSessionTerminals['{TerminalId}'];
-                    if (termObj && termObj.terminal) {{
-                        termObj.terminal.focus();
-                        if (termObj.fitAddon) {{
-                            termObj.fitAddon.fit();
-                        }}
-                    }}
-                }})()
-            ");
+            // createMultiSessionTerminal 内で fit 済み。その初期サイズ通知
+            // (OnTerminalSizeChanged → SendResize) は shellSession がまだ null のため
+            // 捨てられるので、ここで実サイズを取得して ConPTY の初期サイズに使う。
+            var size = await GetTerminalSizeAsync();
+            var cols = size?.Cols is >= 20 ? size.Cols : TerminalConstants.DefaultCols;
+            var rows = size?.Rows is >= 5 ? size.Rows : TerminalConstants.DefaultRows;
+
+            // ConPTY を生成し、購読してから読み取りを開始する（Start 前に購読するので取りこぼさない）
+            var conPtyService = new ConPtyService(LoggerFactory.CreateLogger<ConPtyService>());
+            shellSession = await conPtyService.CreateSessionAsync(ShellExecutable, "", WorkingDirectory, cols, rows);
+
+            shellSession.DataReceived += OnDataReceived;
+            shellSession.ProcessExited += OnProcessExited;
+            shellSession.Start();
+
+            await FocusTerminalAsync();
 
             isInitialized = true;
             OnPanelReady?.Invoke(this);
@@ -90,7 +78,7 @@
         {
             Logger.LogError(ex, "シェルパネルの初期化エラー: {PanelId}", PanelId);
 
-            // JS初期化失敗時に起動済みConPTYを片付ける
+            // 起動済みConPTYを片付ける
             if (shellSession != null)
             {
                 try
@@ -106,7 +94,52 @@
                 }
                 shellSession = null;
             }
+
+            // xterm を先に作るようになったため、ConPTY 側で失敗した場合に作成済みの
+            // xterm が取り残されないよう破棄する
+            if (terminal != null)
+            {
+                try
+                {
+                    await DisposeTerminalAsync();
+                }
+                catch (Exception disposeEx)
+                {
+                    Logger.LogWarning(disposeEx, "xterm破棄エラー: {PanelId}", PanelId);
+                }
+            }
         }
+    }
+
+    private async Task<TerminalSize?> GetTerminalSizeAsync()
+    {
+        try
+        {
+            return terminal is null ? null : await terminal.InvokeAsync<TerminalSize>("getSize");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "シェルパネルのサイズ取得エラー: {PanelId}", PanelId);
+            return null;
+        }
+    }
+
+    private async Task FocusTerminalAsync()
+    {
+        await JSRuntime.InvokeVoidAsync("eval", $@"
+            (function() {{
+                const termObj = window.multiSessionTerminals && window.multiSessionTerminals['{TerminalId}'];
+                if (termObj && termObj.terminal) {{
+                    termObj.terminal.focus();
+                }}
+            }})()
+        ");
+    }
+
+    private sealed class TerminalSize
+    {
+        public int Cols { get; set; }
+        public int Rows { get; set; }
     }
 
     private async void OnDataReceived(object? sender, DataReceivedEventArgs args)
@@ -186,22 +219,7 @@
             }
 
             // XTermの破棄
-            if (terminal != null)
-            {
-                await JSRuntime.InvokeVoidAsync("eval", $@"
-                    (function() {{
-                        const terminalId = '{TerminalId}';
-                        const termObj = window.multiSessionTerminals && window.multiSessionTerminals[terminalId];
-                        if (termObj) {{
-                            termObj.terminal.dispose();
-                            delete window.multiSessionTerminals[terminalId];
-                        }}
-                    }})()
-                ");
-
-                await terminal.DisposeAsync();
-                terminal = null;
-            }
+            await DisposeTerminalAsync();
 
             // ConPTYセッションの破棄
             if (shellSession != null)
@@ -214,5 +232,27 @@
         {
             Logger.LogError(ex, "シェルパネルの破棄エラー: {PanelId}", PanelId);
         }
+    }
+
+    private async Task DisposeTerminalAsync()
+    {
+        if (terminal == null)
+        {
+            return;
+        }
+
+        await JSRuntime.InvokeVoidAsync("eval", $@"
+            (function() {{
+                const terminalId = '{TerminalId}';
+                const termObj = window.multiSessionTerminals && window.multiSessionTerminals[terminalId];
+                if (termObj) {{
+                    termObj.terminal.dispose();
+                    delete window.multiSessionTerminals[terminalId];
+                }}
+            }})()
+        ");
+
+        await terminal.DisposeAsync();
+        terminal = null;
     }
 }

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -9,11 +9,7 @@
         public const int MinRows = 24;
         
         // タイミング（ミリ秒）
-        public const int ResizeDelay = 20;           // リサイズ後の待機（最小値）
         public const int DomUpdateDelay = 50;         // DOM更新待機
-        public const int InitializationDelay = 500;   // 初期化待機（必要最小限）
-        public const int MinimalDelay = 10;           // 最小待機時間
-        public const int ButtonPressAnimationDelay = 150; // ボタン押下アニメーション
         
         // プロセス
         public const uint ExtendedStartupinfoPresent = 0x00080000;

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -1008,68 +1008,18 @@ window.terminalFunctions = {
         console.log('[JS] hideAllTerminals: 完了');
     },
 
+    // コンテナの表示を戻すだけ。hideAllTerminals が display:none にしたのを対で戻す。
+    // xterm 内部DOMの修復（子要素の総当たり再表示・親への再アタッチ）は、Blazor が DOM を
+    // 差し替えていた時代の対症療法で、xterm が意図的に隠す内部要素まで触るリスクがあった。
+    // 呼び出し元(SelectSession)は直後に xterm を作り直してリプレイするため、
+    // ここでの focus/refresh も不要。
     showTerminal: function(sessionId) {
-        console.log(`[JS] showTerminal: 開始 sessionId=${sessionId}`);
         const terminal = document.getElementById(`terminal-${sessionId}`);
-        if (terminal) {
-            console.log(`[JS] showTerminal: ターミナル要素が見つかりました`);
-            console.log(`[JS] showTerminal: 設定前 display=${terminal.style.display}, visibility=${terminal.style.visibility}, opacity=${terminal.style.opacity}`);
-            terminal.style.display = 'block';
-            console.log(`[JS] showTerminal: ターミナルを表示に設定`);
-            console.log(`[JS] showTerminal: 設定後 display=${terminal.style.display}, offsetWidth=${terminal.offsetWidth}, offsetHeight=${terminal.offsetHeight}`);
-            
-            if (window.multiSessionTerminals && window.multiSessionTerminals[sessionId]) {
-                // xtermオブジェクトの存在確認
-                const termObj = window.multiSessionTerminals[sessionId];
-                console.log(`[JS] showTerminal: xterm存在確認 - terminal=${!!termObj.terminal}, element=${!!termObj.terminal?.element}`);
-                if (termObj.terminal && termObj.terminal.element) {
-                    console.log(`[JS] showTerminal: xterm.element - display=${termObj.terminal.element.style.display}, 親要素=${!!termObj.terminal.element.parentElement}`);
-                    
-                    // xterm要素を強制的に表示
-                    if (termObj.terminal.element.style.display === 'none' || !termObj.terminal.element.style.display) {
-                        console.log(`[JS] showTerminal: xterm要素を強制表示`);
-                        termObj.terminal.element.style.display = 'block';
-                    }
-                    
-                    // 子要素も確認
-                    const children = termObj.terminal.element.children;
-                    console.log(`[JS] showTerminal: xterm子要素数=${children.length}`);
-                    for (let i = 0; i < children.length; i++) {
-                        if (children[i].style.display === 'none') {
-                            console.log(`[JS] showTerminal: 子要素${i}を表示に変更`);
-                            children[i].style.display = '';
-                        }
-                    }
-                    
-                    // 強制的にフォーカスとリフレッシュ
-                    try {
-                        // xterm要素が正しい親要素にあるか確認
-                        if (termObj.terminal.element.parentNode !== terminal) {
-                            console.log(`[JS] showTerminal: ★★★ 警告: xterm要素が正しい親要素にありません！`);
-                            console.log(`[JS] showTerminal: 修復: xterm要素を再アタッチ`);
-                            terminal.appendChild(termObj.terminal.element);
-                        }
-                        
-                        // 表示復帰時は再描画だけ行う。サイズ同期は呼び出し元または
-                        // ResizeObserverに一本化し、ここではfit()しない。
-                        termObj.terminal.focus();
-                        termObj.terminal.refresh(0, termObj.terminal.rows - 1);
-                        console.log(`[JS] showTerminal: フォーカスとリフレッシュ実行`);
-                    } catch (e) {
-                        console.log(`[JS] showTerminal: フォーカス/リフレッシュエラー: ${e.message}`);
-                    }
-                }
-            } else {
-                console.log(`[JS] showTerminal: ★★★ 警告: multiSessionTerminalsが見つからない sessionId=${sessionId}`);
-                console.log(`[JS] showTerminal: デバッグ - window.multiSessionTerminals=${!!window.multiSessionTerminals}`);
-                if (window.multiSessionTerminals) {
-                    console.log(`[JS] showTerminal: 利用可能なセッション: ${Object.keys(window.multiSessionTerminals).join(', ')}`);
-                }
-            }
-            console.log(`[JS] showTerminal: 完了`);
-        } else {
-            console.log(`[JS] showTerminal: ★★★ エラー: ターミナル要素が見つからない terminal-${sessionId}`);
+        if (!terminal) {
+            console.error(`[JS] showTerminal: ターミナル要素が見つからない terminal-${sessionId}`);
+            return;
         }
+        terminal.style.display = 'block';
     },
     
     terminalExists: function(sessionId) {


### PR DESCRIPTION
外部レビュー（Codex）の指摘のうち、まだ残っていた3件に対応した。指摘1（再作成時の `\r\n` 注入）と未使用の修復関数は #139 で対応済み。

## 1. ShellPanel の初期化順序（初期出力の欠落を修正）

従来の順序:

```
ConPTY起動 → Start() → Task.Delay(100) → DOM確認 → なければ更に Delay(200) → xterm作成
```

`OnDataReceived` は `if (terminal != null)` でガードしているため、**xterm ができるまでの 100〜300ms に届いた出力は捨てられる**。固定待機は欠落を防ぐどころか**欠落する時間を延ばしていた**。ShellPanel は状態バッファを持たないので、捨てた出力は復元されない（シェルの初期プロンプトが欠ける）。

新しい順序:

```
xterm作成 → getSize で実サイズ取得 → ConPTY生成 → 購読 → Start()
```

`Start()` の前に購読を済ませるので取りこぼさない。コンテナ div は自身のマークアップにあり `OnAfterRenderAsync(firstRender)` の時点でレンダリング済みなので、DOM の存在確認と待機は不要。

**副次的な修正**: xterm 作成時の `fit()` は `notifyResize('init')` で親に通知するが、この時点では `shellSession` がまだ null なので `SendResize` は静かに捨てられる。従来は **ConPTY が 120x30 固定のまま**だった。`getSize` で実サイズを取得して初期サイズに渡すようにした。

順序変更に伴い、ConPTY 側で失敗した場合に作成済みの xterm が取り残されないよう後始末を追加（xterm 破棄処理は `DisposeAsync` と共通化）。

## 2. showTerminal を表示制御だけに縮小

強制修復（xterm本体の強制表示・子要素の総当たり再表示・親への再アタッチ・強制フォーカス・全行 `refresh()`）を除去し、コンテナの `display` を戻すだけにした。

- Blazor が DOM を差し替えていた時代の対症療法で、**xterm が意図的に隠す内部要素まで触るリスク**があった
- 対の `hideAllTerminals` はコンテナの `display` しか触らないので、戻す側もそれだけでよい
- 唯一の呼び出し元（`Root.razor:1360` = SelectSession）は**直後に xterm を作り直してリプレイする**ため、focus/refresh も不要

## 3. 未使用の待機定数を削除

`ResizeDelay` / `InitializationDelay` / `MinimalDelay` / `ButtonPressAnimationDelay` の**4件が参照ゼロ**（レビューでは3件とされていたが実際は4件）。`DomUpdateDelay` のみ使用中のため残す。

## 見送った指摘

- **ConPTY入力の20ms待機**: #140 で「最後のチャンクの後の無駄な待ち」だけ除去済み。チャンク分割と間隔そのものは残す。`6f39f28`「Wait時間を増やすことにした」で Delay を 10→50 に**増やす**必要があった履歴が、受け手（conhost の入力バッファ / CLI）の取りこぼしを示しており、書き込みロックが防ぐ「複数経路の同時書き込みの混線」とは別問題のため。一括Write は長文欠けの再発リスクが高い
- **送信前の200ms待機**: CLI 側の貼り付け検知に依存する観測ベースの補正。レビューの「すぐ削除せず検証対象に」という判断に同意
- **Dispose 後の100ms待機**: 完了条件のない待機で怪しいが、ConPTY 破棄競合は過去に何度も踏んでいる領域（#117 / #129 / #133）なので別途切り分ける

## 確認状況

- `dotnet build`: 成功（0 エラー）
- `dotnet test TerminalHub.Terminal.Tests`: 72件すべて合格

**要実機確認**:
- シェルパネルを開いたときに初期プロンプトが欠けずに出ること、サイズが最初から正しいこと
- セッション切替でターミナル表示が崩れないこと（showTerminal の縮小）

🤖 Generated with [Claude Code](https://claude.com/claude-code)