### PR TITLE
fix: xterm 5 時代のIME細工を撤去（リスナー積み重なりの解消＋変換候補がカーソル位置へ）

### DIFF
--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -822,3 +822,15 @@ h1:focus {
     border-top: 2px solid var(--th-accent);
     background-color: rgba(127, 127, 127, 0.08);
 }
+
+/* IME 変換候補の表示位置対策。
+   xterm.css は入力補助用の hidden textarea を left:-9999em へ飛ばしている（カーソルを
+   見せないため）が、そのままだと IME の変換候補ウィンドウが画面外の左端に出てしまう。
+   left:0 へ引き戻してターミナル左端に出るようにする。
+   xterm.css 側の left は !important ではないので、読み込み順に関わらずこちらが勝つ。 */
+.xterm-helper-textarea {
+    left: 0 !important;
+}
+.xterm .composition-view {
+    left: 0 !important;
+}

--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -822,15 +822,3 @@ h1:focus {
     border-top: 2px solid var(--th-accent);
     background-color: rgba(127, 127, 127, 0.08);
 }
-
-/* IME 変換候補の表示位置対策。
-   xterm.css は入力補助用の hidden textarea を left:-9999em へ飛ばしている（カーソルを
-   見せないため）が、そのままだと IME の変換候補ウィンドウが画面外の左端に出てしまう。
-   left:0 へ引き戻してターミナル左端に出るようにする。
-   xterm.css 側の left は !important ではないので、読み込み順に関わらずこちらが勝つ。 */
-.xterm-helper-textarea {
-    left: 0 !important;
-}
-.xterm .composition-view {
-    left: 0 !important;
-}

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -622,63 +622,6 @@ function setupUrlDetectionFallback(term) {
     }
 }
 
-// 右クリック検出とIMEスタイル制御
-function setupContextMenuAndIME(element, sessionId) {
-    let imeStyleSheet = null;
-    
-    // IME用のスタイルシートを作成
-    function createIMEStyle() {
-        if (!imeStyleSheet) {
-            imeStyleSheet = document.createElement('style');
-            imeStyleSheet.textContent = `
-                .xterm-helper-textarea {
-                    left: 0 !important;
-                }
-                .xterm .composition-view {
-                    left: 0 !important;
-                }
-            `;
-            imeStyleSheet.id = 'ime-positioning-style';
-        }
-    }
-    
-    // スタイルを適用
-    function enableIMEStyle() {
-        createIMEStyle();
-        if (!document.getElementById('ime-positioning-style')) {
-            document.head.appendChild(imeStyleSheet);
-        }
-    }
-    
-    // スタイルを削除
-    function disableIMEStyle() {
-        const style = document.getElementById('ime-positioning-style');
-        if (style) {
-            style.remove();
-        }
-    }
-    
-    // 初期状態でIMEスタイルを有効化
-    enableIMEStyle();
-    
-    // 右クリックイベントを検出
-    element.addEventListener('contextmenu', (e) => {
-        console.log(`[IME] 右クリック検出 - IMEスタイル無効化`);
-        disableIMEStyle();
-        
-        // 一定時間後に再度有効化
-        setTimeout(() => {
-            console.log(`[IME] IMEスタイル再有効化`);
-            enableIMEStyle();
-        }, 1000);
-    });
-    
-    // クリックでIMEスタイルを再有効化
-    element.addEventListener('click', () => {
-        enableIMEStyle();
-    });
-}
-
 window.terminalFunctions = {
     // マルチセッション用のターミナル作成関数
     createMultiSessionTerminal: function(terminalId, sessionId, dotNetRef, fontSize) {
@@ -823,9 +766,6 @@ window.terminalFunctions = {
                 return true; // その他のキーは通常通り処理
             });
             
-            // 右クリック検出とIMEスタイル制御
-            setupContextMenuAndIME(element, sessionId);
-
             // xterm.jsのリサイズイベントリスナーを追加
             term.onResize((size) => {
                 notifyResize(size.cols, size.rows, 'onResize', '');


### PR DESCRIPTION
`setupContextMenuAndIME`（terminal.js）は `3bf9c17`「hozon」(2025-07-23) 由来の **xterm 5 時代の IME 位置ずれ回避**。実機検証の結果、**役目を終えているどころか現在の xterm の正しい挙動を阻害していた**ことが分かったため、JS・CSS とも撤去した。

**最終差分は terminal.js から60行削除のみ**（CSS の追加なし）。

※ フェーズ1（#142）とは terminal.js の別領域なので独立。どちらから先にマージしてもよい。

## 実機検証の結果（改善）

当初は「スタイルの実体は `left: 0 !important` の2セレクタだけなので app.css へ移設」する方針だったが、**外してみたら両方とも良くなった**ため、まるごと削除に切り替えた（コミットを2本に分けてその経緯を残してある）。

| | 従来（left:0 で固定） | 撤去後 |
|---|---|---|
| 日本語の変換候補 | ターミナル左端に固定 | **カーソル位置に出る** |
| 右クリックのメニュー | 左上の textarea 上だけテキスト用、他は canvas の画像用（画像を保存/コピー）でちぐはぐ | **位置によらずテキスト用のフルメニュー**（貼り付け等）で統一 |

xterm 6 は helper textarea をカーソル位置へ追従させるようになっており、`left: 0` の固定はその追従を打ち消していた。ターミナルとしては、貼り付けのあるテキスト用メニューの方が画像メニューより有用。

## 撤去した細工の問題点

### 1. リスナーが積み重なる（実バグ）

`element` は**セッションごとに永続する div**（`Root.razor:143`）だが、`createMultiSessionTerminal` は**セッション選択のたびに**呼ばれる。`contextmenu` / `click` のリスナーには解除処理がなく、`cleanupTerminal` も div の子要素しか消さない。

結果、**セッションを N 回開くと右クリック1回で N 個の `setTimeout` が走る**。

同じファイルの `attachTouchScroll` には、まさにこの退行への対処と理由を明記したコメントがある:

> 再アタッチ対応: コンテナ div はセッション切替やターミナル再作成のたびに使い回されるが、createMultiSessionTerminal は毎回呼ばれる。前回のリスナーを外さずに追加するとリスナーが積み重なり…

`setupContextMenuAndIME` は**まったく同じ `element` を受け取りながら、この作法だけが抜けていた**。

### 2. 1000ms タイマーに根拠がない

```js
element.addEventListener('contextmenu', (e) => {
    disableIMEStyle();
    setTimeout(() => { enableIMEStyle(); }, 1000);   // 根拠なし
});
element.addEventListener('click', () => { enableIMEStyle(); });
```

メニューが1秒以上開いていればスタイルが戻り、1秒未満で閉じても次のクリックまではズレたまま。**どちらの方向にも保証がない**。click ハンドラと役割も重複しており、`setTimeout` がカバーするのは「クリックせず放置した場合」＝実害がない場合だけ。

なお検証により、この 1000ms の**意図はほぼ特定できた**: 右クリック時だけ textarea を画面外へ逃がし、canvas の画像メニューに揃えたかったものと思われる。コミットには記録がなく、消してみて初めて見えた。そして今回、揃える先はむしろテキスト用メニューの方が望ましいと判明した。

### 3. style 要素の id がセッション間で衝突

固定 id `'ime-positioning-style'` を `getElementById` で探すため所有権が壊れており、セッションAの右クリックがセッションBの style を消してAのものを付け直す状態だった。

### 4. 引数 `sessionId` が完全に未使用

## 確認状況

- `dotnet build`: 成功（0 エラー）
- **実機確認済み**: 日本語入力の変換候補がカーソル位置に出ること、右クリックのメニューが位置によらず揃うことをユーザーが確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)