### PR TITLE
fix: スクロールバック上限の不一致を解消し、握り潰しcatchを可視化（フェーズ3）

### DIFF
--- a/TerminalHub.Terminal/TerminalGrid.cs
+++ b/TerminalHub.Terminal/TerminalGrid.cs
@@ -15,7 +15,13 @@ public sealed class TerminalGrid
     /// <summary>スクロールバック（古い行が先頭）。alt-screen 中は追記しない。</summary>
     private readonly List<Cell[]> _scrollback = new();
 
-    /// <summary>スクロールバック保持行数の上限。</summary>
+    /// <summary>
+    /// スクロールバック保持行数の上限。
+    /// クライアント側 xterm の scrollback（wwwroot/js/terminal.js）と必ず揃えること。
+    /// セッション切替時の表示はここからのリプレイで作り直されるため、xterm 側だけ大きくしても
+    /// 切替の瞬間にこの上限まで減る。1行は Cols 個の Cell（＋セルごとの文字列）を保持するので、
+    /// 増やすとセッション数に比例してメモリを消費する点に注意。
+    /// </summary>
     public int MaxScrollback { get; set; } = 5000;
 
     // カーソル（0-based）

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -565,9 +565,12 @@
                 // 埋め込み済みのため、ここでは JS での再適用は行わない（フラッシュ防止）。
                 // テーマのみ全デバイス共通 (app-settings) のまま。
             }
-            catch
+            catch (Exception ex)
             {
-                // エラー時はデフォルト値を使用
+                // 起動を止めないために握り潰すが、無言だと「設定が効かない」が不可視になるため記録する。
+                // 注意: この try は JS 初期化〜設定読み込みまでを広く囲っているので、途中で落ちると
+                // そこまでに適用した設定は生きたまま、以降はフィールド初期値のまま、という混在になる。
+                Logger.LogError(ex, "[起動] 初期化・設定読み込みに失敗（以降の設定は既定値のまま）");
             }
 
             // ストレージサービスを初期化（SQLite強制）
@@ -654,9 +657,12 @@
 
                         sessionsToPopulateGitInfo.Add(newSession.SessionId);
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
-                        // Failed to restore session
+                        // 1件の失敗で残りの復元まで止めないよう握り潰すが、無言だと
+                        // 「起動したらセッションが1個消えている」が不可視になるため記録する。
+                        Logger.LogError(ex, "[起動] セッションの復元に失敗: SessionId={SessionId}, Name={Name}",
+                            sessionInfo.SessionId, sessionInfo.DisplayName);
                     }
                 }
             }
@@ -1592,9 +1598,11 @@
                 }
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // ProcessReceivedData error
+            // ここは ConPTY 出力のホットパス。1セッションの失敗で受信ループ全体を止めないよう
+            // 握り潰すが、無言だと文字化け・出力欠落の調査時に原因が見えないため記録する。
+            Logger.LogError(ex, "[ProcessReceivedData] 出力処理に失敗: SessionId={SessionId}", sessionId);
         }
     }
 

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -442,6 +442,11 @@ static async Task<int> RunCodexBridgeAsync(string[] args)
 
         var path = $"/api/hook/codex/{sessionId}";
         // まず HTTP、ダメなら HTTPS（Claude ブリッジと同じフォールバック）。
+        // http → https の順で試す。hook に書き込むブリッジ起動コマンド (CodexHookService.BuildBridgeCommand)
+        // は --port しか渡さず、スキームを伝えていない。TerminalHub 本体は既定では HTTP のみで listen する
+        // が、SessionManager.GetServerBaseUrl は「HTTPS しかなければ HTTPS を使う」構成も想定しているため、
+        // HTTPS-only で起動された場合はこのフォールバックが唯一の到達手段になる。
+        // 「本体は HTTP しか listen していないから https 分岐は死んでいる」と判断して消さないこと。
         foreach (var scheme in new[] { "http", "https" })
         {
             try

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -654,7 +654,11 @@ window.terminalFunctions = {
             // 囲み数字（①②③ 等）の範囲だけ等幅日本語フォントへ差し替えて読みやすくする。
             // 末尾はフォント未解決時の保険（Consolas → monospace）。
             fontFamily: "TermMix, 'Cascadia Mono', Consolas, monospace",
-            scrollback: 10000,
+            // サーバー側エミュレータの TerminalGrid.MaxScrollback と必ず揃えること。
+            // PR #91 以降、画面の真実はエミュレータ側にあり、xterm はセッション切替のたびに
+            // そこからのリプレイで作り直される。ここだけ大きくしても、切り替えた瞬間に
+            // エミュレータの上限まで減るため「履歴が急に半分になった」ように見えるだけ。
+            scrollback: 5000,
             scrollOnInput: true,
             // scrollOnOutput は false にする。true だと出力のたびに最下部へ強制スクロールされ、
             // Claude Code のように毎秒複数回再描画する CLI では、履歴を遡って読むことができなくなる


### PR DESCRIPTION
再スキャンで残っていた「判断が要る3件」。**うち1件は調査の結果、削除ではなく残すのが正解**だった。

## 1. スクロールバック上限の不一致（バグ）

xterm 側 `scrollback: 10000` に対し、サーバー側エミュレータの `TerminalGrid.MaxScrollback` は **5000** と2倍ずれていた。

PR #91 以降、**画面の真実はエミュレータ側**にあり、セッション切替のたびにそこからのリプレイで xterm を作り直す。よって実効的な履歴は常に 5000 に落ちる。xterm の 10000 が効くのは「切り替えるまでの現在のセッション」だけで、**切り替えた瞬間に履歴が半分になったように見える**状態だった。

**xterm 側を 5000 に下げて統一**した。実効値はもともと 5000 なので、実質の損失は「切り替えるまでのライブ表示だけ 10000 見えていた」部分のみ。

逆にサーバーを 10000 へ上げる案は採らなかった。1行が `Cols` 個の `Cell`（＋セルごとの文字列）を保持するため、**セッションあたり約20〜30MB → 40〜60MB** とメモリが倍増するため。`MaxScrollback = 5000` は無言だったが、メモリを意識した妥当な値だったと考えられる。

両方に「対であり必ず揃えること」をコメントで明記した。

## 2. 握り潰し catch の可視化

例外を握り潰す判断自体は妥当（起動を止めない／受信ループを止めない）なので、**catch の範囲は変えず `Logger.LogError` を追加**した。

| 場所 | 従来 | 問題 |
|---|---|---|
| 起動時の初期化・設定読み込み | `catch { // エラー時はデフォルト値を使用 }` | **コメントが実態と違う**。この try は JS 初期化〜設定読み込みまで広く囲っているので、途中で落ちると「そこまでの設定は適用済み・以降はフィールド初期値」という中途半端な混在になる。「デフォルト値を使用」ではない |
| セッション復元の失敗 | `catch (Exception) { // Failed to restore session }` | 「起動したらセッションが1個消えている」が完全に不可視 |
| `ProcessReceivedData` | `catch (Exception) { // ProcessReceivedData error }` | **ConPTY 出力のホットパス**。文字化け・出力欠落を追うとき、ここが黙っていると原因が絶対に見えない |

`Root` は `Logger` を注入済みで他の catch では `LogError` しているのに、これらだけ無言だった。

## 3. HTTPS フォールバックは残す（削除を撤回）

CLI ブリッジの `foreach (var scheme in new[] { "http", "https" })` を「本体は HTTP でしか listen していない（`UseHttpsRedirection` はコメントアウト、bat も launchSettings も http のみ）ので死んでいる」として削除しかけたが、**誤りだったため残した**。

根拠:

- hook に書き込むブリッジ起動コマンド（`CodexHookService.BuildBridgeCommand`）は **`--port` しか渡しておらず、スキームを伝えていない**
- `SessionManager.GetServerBaseUrl` は「HTTP を優先して選ぶ。**HTTPS しかなければ HTTPS を使う**」と、HTTPS-only 構成を明示的に想定している

つまり HTTPS-only で起動された場合、**この http→https フォールバックが唯一の到達手段**になる。同じ誤判断を繰り返さないよう、理由をコメントに残した。

`--event` CLI 経路（`/api/hook`）も同様に、旧形式 hook（`type:"command"` + `--notify --session`）が残っている環境を黙って壊す可能性があるため、今回は触っていない。

## 確認状況

- `dotnet build`: 成功（0 エラー）
- `dotnet test TerminalHub.Terminal.Tests`: 72件すべて合格

**要実機確認**: スクロールバックが 5000 行まで遡れること、セッションを切り替えても履歴が減らなくなったこと（従来は 10000→5000 に減っていた）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)