### PR TITLE
fix: ConPTY入力のサロゲート分断とシェルパネルのJSリソース残留を修正

### DIFF
--- a/TerminalHub.Terminal.Tests/ConPtyWriteChunkerTests.cs
+++ b/TerminalHub.Terminal.Tests/ConPtyWriteChunkerTests.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using TerminalHub.Services;
+using Xunit;
+
+namespace TerminalHub.Terminal.Tests;
+
+/// <summary>
+/// ConPTY 入力の分割境界の検証。
+/// チャンクごとに FlushAsync でエンコーダ状態を強制フラッシュするため、
+/// 境界でサロゲートペアを割ると U+FFFD に潰れて絵文字が文字化けする。
+/// </summary>
+public sealed class ConPtyWriteChunkerTests
+{
+    private const string Emoji = "\U0001F600"; // 😀 = サロゲートペア
+
+    /// <summary>ConPtySession.WriteAsync と同じ手順で送信バイト列を組み立てる。</summary>
+    private static byte[] WriteThroughChunks(string input)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new StreamWriter(stream, new UTF8Encoding(false), bufferSize: 65536) { AutoFlush = true };
+
+        var offset = 0;
+        while (offset < input.Length)
+        {
+            var length = ConPtyWriteChunker.NextChunkLength(input, offset);
+            writer.Write(input.Substring(offset, length));
+            writer.Flush(); // ここでエンコーダ状態ごとフラッシュされる（本番と同じ）
+            offset += length;
+        }
+
+        return stream.ToArray();
+    }
+
+    // 境界（256）の前後で、サロゲートペアがちょうど跨ぐケースを含めて総当たりする
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(253)]
+    [InlineData(254)]
+    [InlineData(255)] // 修正前はここだけ文字化けしていた（ASCII255 + 絵文字 = ペアが境界を跨ぐ）
+    [InlineData(256)]
+    [InlineData(257)]
+    [InlineData(511)]
+    [InlineData(512)]
+    public void 絵文字が境界を跨いでも文字化けしない(int asciiPrefixLength)
+    {
+        var input = new string('a', asciiPrefixLength) + Emoji;
+
+        var actual = WriteThroughChunks(input);
+
+        Assert.Equal(Encoding.UTF8.GetBytes(input), actual);
+    }
+
+    [Fact]
+    public void 絵文字が連続していても文字化けしない()
+    {
+        var input = new string('a', 250) + string.Concat(Enumerable.Repeat(Emoji, 50));
+
+        var actual = WriteThroughChunks(input);
+
+        Assert.Equal(Encoding.UTF8.GetBytes(input), actual);
+    }
+
+    [Fact]
+    public void 高位サロゲートで終わる境界は1文字手前で区切る()
+    {
+        // 255文字 + 絵文字 → 256文字目が高位サロゲートになるので 255 で切る
+        var input = new string('a', 255) + Emoji;
+
+        Assert.Equal(255, ConPtyWriteChunker.NextChunkLength(input, 0));
+    }
+
+    [Fact]
+    public void 分断の必要がなければチャンクサイズをそのまま使う()
+    {
+        var input = new string('a', 1000);
+
+        Assert.Equal(ConPtyWriteChunker.ChunkSize, ConPtyWriteChunker.NextChunkLength(input, 0));
+    }
+
+    [Fact]
+    public void 残りがチャンクサイズ未満なら残り全部を返す()
+    {
+        var input = new string('a', 300);
+
+        Assert.Equal(44, ConPtyWriteChunker.NextChunkLength(input, 256));
+    }
+
+    [Fact]
+    public void 末尾の孤立した高位サロゲートは調整しない()
+    {
+        // 後続が無いので縮める意味がない（縮めると長さ0で無限ループになる）
+        var input = new string('a', 255) + '\uD83D';
+
+        Assert.Equal(256, ConPtyWriteChunker.NextChunkLength(input, 0));
+    }
+}

--- a/TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj
+++ b/TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\TerminalHub.Terminal\TerminalHub.Terminal.csproj" />
     <Compile Include="..\TerminalHub\Constants\TerminalConstants.cs" Link="TerminalConstants.cs" />
     <Compile Include="..\TerminalHub\Models\CodexProcessOptionsSnapshot.cs" Link="CodexProcessOptionsSnapshot.cs" />
+    <Compile Include="..\TerminalHub\Services\ConPtyWriteChunker.cs" Link="ConPtyWriteChunker.cs" />
   </ItemGroup>
 
   <!-- Fixtures をテスト出力にコピー（実 TUI キャプチャの置き場） -->

--- a/TerminalHub/Components/Shared/BottomPanels/ShellPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/ShellPanel.razor
@@ -241,16 +241,11 @@
             return;
         }
 
-        await JSRuntime.InvokeVoidAsync("eval", $@"
-            (function() {{
-                const terminalId = '{TerminalId}';
-                const termObj = window.multiSessionTerminals && window.multiSessionTerminals[terminalId];
-                if (termObj) {{
-                    termObj.terminal.dispose();
-                    delete window.multiSessionTerminals[terminalId];
-                }}
-            }})()
-        ");
+        // 通常セッションと同じ cleanupTerminal に寄せる。手書きで terminal.dispose() と
+        // multiSessionTerminals からの削除だけを行うと、ResizeObserver・フロー制御の状態・
+        // コンテナへ登録したタッチスクロールのリスナー（と慣性スクロールの rAF）が
+        // 解除されず、シェルタブを開閉するたびに残り続ける。
+        await JSRuntime.InvokeVoidAsync("terminalFunctions.cleanupTerminal", TerminalId);
 
         await terminal.DisposeAsync();
         terminal = null;

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -409,18 +409,18 @@ namespace TerminalHub.Services
                 // 受け手に猶予を与える意味はなく、遅延にしかならない。onData 経由のキー入力は
                 // 1打鍵ごとに WriteAsync を呼ぶ（=常に1チャンク）ため、ここで待つと全打鍵が
                 // 20ms 遅れる。
-                const int CHUNK_SIZE = 256;
                 const int INTER_CHUNK_DELAY_MS = 20;
 
-                for (int i = 0; i < input.Length; i += CHUNK_SIZE)
+                var offset = 0;
+                while (offset < input.Length)
                 {
-                    var isLastChunk = i + CHUNK_SIZE >= input.Length;
-                    var chunk = isLastChunk
-                        ? input.Substring(i)
-                        : input.Substring(i, CHUNK_SIZE);
+                    // 境界はサロゲートペアを分断しないよう調整される（ConPtyWriteChunker 参照）
+                    var length = ConPtyWriteChunker.NextChunkLength(input, offset);
+                    var isLastChunk = offset + length >= input.Length;
 
-                    await _writer.WriteAsync(chunk);
+                    await _writer.WriteAsync(input.Substring(offset, length));
                     await _writer.FlushAsync();
+                    offset += length;
 
                     if (!isLastChunk)
                     {

--- a/TerminalHub/Services/ConPtyWriteChunker.cs
+++ b/TerminalHub/Services/ConPtyWriteChunker.cs
@@ -1,0 +1,36 @@
+﻿namespace TerminalHub.Services
+{
+    /// <summary>
+    /// ConPTY への入力を分割する際の境界を決める。
+    /// 長い文字列を一括で流し込むと受け手（conhost の入力バッファ / CLI）が取りこぼすため、
+    /// <see cref="ChunkSize"/> 文字ずつ間隔を空けて送る必要がある（ConPtySession.WriteAsync 参照）。
+    /// </summary>
+    internal static class ConPtyWriteChunker
+    {
+        /// <summary>1チャンクの最大文字数。実測で調整された値で理論的な裏付けはない。</summary>
+        public const int ChunkSize = 256;
+
+        /// <summary>
+        /// <paramref name="offset"/> から送るべきチャンクの長さを返す。
+        ///
+        /// UTF-16 サロゲートペア（絵文字等の非BMP文字）を境界で分断しない。
+        /// StreamWriter の Encoder はチャンクをまたいで高位サロゲートを保持できるが、
+        /// 呼び出し側はチャンクごとに FlushAsync でエンコーダ状態ごと強制フラッシュするため、
+        /// 宙に浮いた高位サロゲートはその場で U+FFFD に潰されてしまう
+        /// （例: ASCII 255文字 + 😀 → F0 9F 98 80 ではなく EF BF BD が2つ）。
+        /// 末尾が高位サロゲートになる場合は1文字手前で区切り、ペアを次のチャンクへ送る。
+        /// </summary>
+        public static int NextChunkLength(string input, int offset, int chunkSize = ChunkSize)
+        {
+            var length = System.Math.Min(chunkSize, input.Length - offset);
+
+            // 後続がある場合のみ調整すればよい（末尾の孤立サロゲートは分割とは無関係）
+            if (offset + length < input.Length && char.IsHighSurrogate(input[offset + length - 1]))
+            {
+                length--;
+            }
+
+            return length;
+        }
+    }
+}

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -843,7 +843,10 @@ window.terminalFunctions = {
             
             window.multiSessionTerminals[sessionId] = {
                 terminal: term,
-                fitAddon: fitAddon
+                fitAddon: fitAddon,
+                // コンテナ要素。cleanupTerminal がタッチリスナー解除と DOM クリアに使う。
+                // id から組み立てると命名規則（terminal-{guid}）に依存し、シェルパネルで外れる。
+                container: element
             };
 
             // フロー制御マネージャーにdotNetRefを設定
@@ -909,11 +912,9 @@ window.terminalFunctions = {
             },
             getSize: () => {
                 return { cols: term.cols, rows: term.rows };
-            },
-            dispose: () => {
-                window.resizeObserverManager.remove(sessionId);
-                term.dispose();
             }
+            // 破棄は terminalFunctions.cleanupTerminal に一本化する。ここに dispose を生やすと
+            // フロー制御・タッチリスナー・DOM クリアを取りこぼした不完全な破棄経路が増える。
         };
     },
 
@@ -960,11 +961,18 @@ window.terminalFunctions = {
         // ResizeObserverのクリーンアップ
         window.resizeObserverManager.remove(sessionId);
         
+        // コンテナは作成時に保持した参照を使う。id を `terminal-${sessionId}` と組み立てると
+        // 通常セッション（コンテナ terminal-{guid}）でしか当たらず、シェルパネル
+        // （コンテナ shell-panel-*、キー shell-term-*）ではタッチリスナー解除と
+        // DOM クリアが空振りする。旧データ用に getElementById もフォールバックとして残す。
+        const terminalInfo = window.multiSessionTerminals && window.multiSessionTerminals[sessionId];
+        const terminalDiv = terminalInfo?.container || document.getElementById(`terminal-${sessionId}`);
+
         // ターミナルインスタンスのクリーンアップ
-        if (window.multiSessionTerminals && window.multiSessionTerminals[sessionId]) {
-            if (window.multiSessionTerminals[sessionId].terminal) {
+        if (terminalInfo) {
+            if (terminalInfo.terminal) {
                 try {
-                    window.multiSessionTerminals[sessionId].terminal.dispose();
+                    terminalInfo.terminal.dispose();
                 } catch (e) {
                     // WebglAddonの内部レンダラーが不整合な状態（スリープ復帰後・コンテキスト喪失後等）でも安全に破棄
                     console.log(`[JS] cleanupTerminal: dispose()エラー（無視）: ${e.message}`);
@@ -977,9 +985,8 @@ window.terminalFunctions = {
         else {
             console.log(`[JS] cleanupTerminal: ★★★ 警告: 削除対象のターミナルが存在しない sessionId=${sessionId}`);
         }
-        
+
         // ターミナルdiv内をクリア - より安全なDOM操作を使用
-        const terminalDiv = document.getElementById(`terminal-${sessionId}`);
         if (terminalDiv) {
             // タッチスクロールのリスナーを外す（破棄済み term への参照を残さない）
             if (typeof terminalDiv._touchScrollDetach === 'function') {


### PR DESCRIPTION
外部レビュー（Codex）の指摘に対応。**どちらも実バグ**で、実測で再現と修正を確認した。

## 1. 256文字境界で絵文字が文字化けする（重要度85）

`ConPtySession.WriteAsync` の固定長分割が UTF-16 サロゲートペアを分断していた。

`StreamWriter` の Encoder はチャンクをまたいで高位サロゲートを保持できるが、**チャンクごとに `FlushAsync` でエンコーダ状態ごと強制フラッシュする**ため、宙に浮いた高位サロゲートがその場で U+FFFD に潰される。

**実測**（ASCII 255文字 + 😀 を送信したときの末尾バイト）:

```
修正前: 6161 EFBFBD EFBFBD   ← 置換文字2つ（文字化け）
修正後: 6161 F09F9880        ← 正しい😀
```

境界を総当たりで確認したところ、**`n=255` のときだけ**（＝ペアがちょうど256文字境界を跨ぐとき）化ける:

```
n=250  旧=OK      新=OK
n=254  旧=OK      新=OK
n=255  旧=文字化け  新=OK
n=256  旧=OK      新=OK
```

`WriteToTerminalChunkedAsync` には **PR #95 で同じ対策が入っていた**のに、ConPTY 入力側だけ抜けていた。私が PR #140 でこの関数を触りながら見落としていた箇所で、Codex の指摘が正確だった。

**テストを追加**した。境界判定を `ConPtyWriteChunker.NextChunkLength` に切り出し、テストプロジェクトへソースをリンク（`TerminalConstants.cs` と同じ流儀）して境界を総当たり検証する。実際に UTF-8 へエンコードして期待バイト列と比較しているので、`Flush` 由来の潰れも捕まえる。**対策を外すと該当テストが失敗することも確認済み**（86件中3件が失敗）。

## 2. シェルパネルを閉じてもJSリソースが残る（重要度78）

`ShellPanel.DisposeTerminalAsync` が手書きの `eval` で `terminal.dispose()` と `multiSessionTerminals` からの削除だけを行っており、以下が解除されていなかった:

- `resizeObserverManager`
- `flowControlManager`
- コンテナに登録したタッチスクロールのイベントリスナー
- 慣性スクロールの `requestAnimationFrame`

シェルタブを作成・削除するたびに残り続ける。

通常セッションと同じ **`terminalFunctions.cleanupTerminal` に寄せた**。

ただしそれだけでは不十分だった: `cleanupTerminal` はコンテナを **`terminal-${sessionId}` と組み立てて `getElementById`** しており、この命名規則が成り立つのは通常セッション（コンテナ `terminal-{guid}`／キー `{guid}`）だけ。シェルパネルはコンテナ `shell-panel-*`／キー `shell-term-*` なので**DOM 探索が空振りし、タッチリスナー解除と DOM クリアが効かない**。作成時にコンテナ参照を `container` として保持し、命名規則への依存自体をなくした（旧経路用に `getElementById` フォールバックは残置）。

**あわせて返却オブジェクトの `dispose()` を削除**した。`activeTerminal.DisposeAsync()` は .NET 側の参照解放であってこの JS メソッドは呼ばないため**呼び出し元ゼロの死にコード**であり、かつ中身が `cleanupTerminal` の部分集合（フロー制御・タッチリスナー・DOM クリアを取りこぼす）で、**不完全な破棄経路を増やす罠**になっていた。破棄は `cleanupTerminal` に一本化する。

## 確認状況

- `dotnet build`: 成功（0 エラー）
- `dotnet test`: **86件すべて合格**（72 → 86、サロゲート境界テスト14件を追加）

**要実機確認**: 絵文字を含む長文（256文字境界をまたぐもの）を貼り付けて文字化けしないこと。シェルタブの開閉を繰り返しても動作が重くならないこと。

## レビューで指摘され、今回対応しなかったもの

タイミング依存コードの残り（`SessionManager` の Dispose 後 100ms、新規セッション作成後の DOM 待機 50ms、シェルタブのフォーカス待機 50ms、送信後 Enter の 200ms×3経路、Remote Control の 1秒＋3秒）については、レビューの「本文とEnterの200ms、チャンク間の20msは実機での取りこぼし対策なので現時点では削除せず、共通化・計測対象にするのが安全」という判断に同意。別途扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)