### PR TITLE
fix: シェルパネル破棄時のConPTY残留を修正（JS切断と独立させる）

### DIFF
--- a/TerminalHub/Components/Shared/BottomPanels/ShellPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/ShellPanel.razor
@@ -209,19 +209,37 @@
 
     public async ValueTask DisposeAsync()
     {
+        // イベントハンドラーを先に解除（Dispose中のデータ受信を防止）
+        if (shellSession != null)
+        {
+            shellSession.DataReceived -= OnDataReceived;
+            shellSession.ProcessExited -= OnProcessExited;
+        }
+
+        // JS 側とサーバー側の破棄は独立させる。
+        // Circuit 切断（ブラウザのリロード・タブを閉じる等）では JS 相互運用が
+        // JSDisconnectedException で失敗するが、両者を1つの try に入れていると
+        // そこで抜けて ConPTY の破棄に到達せず、cmd.exe/powershell が残ってしまう。
         try
         {
-            // イベントハンドラーを先に解除（Dispose中のデータ受信を防止）
-            if (shellSession != null)
-            {
-                shellSession.DataReceived -= OnDataReceived;
-                shellSession.ProcessExited -= OnProcessExited;
-            }
-
-            // XTermの破棄
             await DisposeTerminalAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+            // ブラウザ側は既に消えており、JS のリソースもページごと解放済み
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "シェルパネルのxterm破棄エラー: {PanelId}", PanelId);
+        }
+        finally
+        {
+            terminal = null;
+        }
 
-            // ConPTYセッションの破棄
+        // ConPTY はサーバー側のリソースなので、JS の破棄が失敗しても必ず落とす
+        try
+        {
             if (shellSession != null)
             {
                 shellSession.Dispose();
@@ -230,7 +248,7 @@
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "シェルパネルの破棄エラー: {PanelId}", PanelId);
+            Logger.LogError(ex, "シェルパネルのConPTY破棄エラー: {PanelId}", PanelId);
         }
     }
 

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -332,10 +332,10 @@ namespace TerminalHub.Services
                 _pipeOutStream = new FileStream(pipeOut, FileAccess.Read);
                 
                 // StreamWriterを作成（XTerm向けにUTF-8、改行コードLF）
-                // バッファサイズを65KBに増やして長い文字列の問題を解決
+                // AutoFlush は使わない。書き込みは WriteAsync の1経路だけで、そこがチャンクごとに
+                // 明示的に FlushAsync している（送出のタイミングはそちらで管理する）。
                 _writer = new StreamWriter(_pipeInStream, new UTF8Encoding(false), bufferSize: 65536)
                 {
-                    AutoFlush = true,
                     NewLine = "\n"  // LF改行（Unix形式）
                 };
                 

--- a/TerminalHub/Services/ConPtyWriteChunker.cs
+++ b/TerminalHub/Services/ConPtyWriteChunker.cs
@@ -20,9 +20,11 @@
         /// （例: ASCII 255文字 + 😀 → F0 9F 98 80 ではなく EF BF BD が2つ）。
         /// 末尾が高位サロゲートになる場合は1文字手前で区切り、ペアを次のチャンクへ送る。
         /// </summary>
-        public static int NextChunkLength(string input, int offset, int chunkSize = ChunkSize)
+        public static int NextChunkLength(string input, int offset)
         {
-            var length = System.Math.Min(chunkSize, input.Length - offset);
+            // chunkSize は引数にしない。1 を渡されると高位サロゲート先頭の入力で length が 0 になり、
+            // 呼び出し側の offset が進まず無限ループになる。可変にする理由も無いので固定にしておく。
+            var length = System.Math.Min(ChunkSize, input.Length - offset);
 
             // 後続がある場合のみ調整すればよい（末尾の孤立サロゲートは分割とは無関係）
             if (offset + length < input.Length && char.IsHighSurrogate(input[offset + length - 1]))

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -950,14 +950,6 @@ window.terminalFunctions = {
     
     // ターミナルクリーンアップ関数
     cleanupTerminal: function(sessionId) {
-        console.log(`[JS] cleanupTerminal: ★★★ 開始 sessionId=${sessionId}`);
-        console.trace(`[JS] cleanupTerminal: 呼び出し元`);
-
-        // 削除前の状態を記録
-        if (window.multiSessionTerminals) {
-            console.log(`[JS] cleanupTerminal: 削除前のターミナル数=${Object.keys(window.multiSessionTerminals).length}`);
-            console.log(`[JS] cleanupTerminal: 削除前のセッションID一覧: ${Object.keys(window.multiSessionTerminals).join(', ')}`);
-        }
 
         // フロー制御のクリーンアップ
         window.flowControlManager.remove(sessionId);


### PR DESCRIPTION
外部レビュー（Codex）の追加指摘に対応。**1件目は実害のあるリソースリーク**で、指摘どおりだった。

## 1. ShellPanel破棄時、JS切断でConPTYプロセスが残る（重要度85）

`DisposeAsync` が「イベント解除 → xterm破棄（JS相互運用）→ ConPTY破棄」を**1つの try に入れていた**:

```csharp
try
{
    // イベント解除
    await DisposeTerminalAsync();      // ← JS 相互運用
    if (shellSession != null) { shellSession.Dispose(); }   // ← ここに到達しない
}
catch (Exception ex) { Logger.LogError(...); }
```

Circuit 切断（**ブラウザのリロード・タブを閉じる**）では `DisposeTerminalAsync` が `JSDisconnectedException` を投げるのが正常系。そこで外側の catch へ飛ぶため **`shellSession.Dispose()` に到達せず、cmd.exe / powershell が残る**。

JS 側とサーバー側の破棄を独立させ、**ConPTY は JS の破棄が失敗しても必ず落とす**ようにした。`JSDisconnectedException` は「ブラウザが消えているだけ」なので個別に握り潰し、それ以外の例外はログに残す（JS 側のリソースはページごと解放される）。

なお PR #141 でこの周辺（初期化順序）を触った際、破棄側の順序までは見ていなかった。

## 2. chunkSize=1 で無限ループになりうる（重要度55）

`ConPtyWriteChunker.NextChunkLength` が任意の `chunkSize` を受け取れたため、高位サロゲートで始まる入力に `1` を渡すと `length--` で 0 になり、呼び出し側の `offset` が進まず無限ループになる。**引数を削除して 256 固定**にした（可変にする理由もなく、これで失敗モード自体が消える）。本番は既定値しか使っておらず、テストも既定値のみだったので影響なし。

## 3. AutoFlush と明示的 FlushAsync の二重（重要度45）

`StreamWriter` を `AutoFlush = true` で作りつつ、各チャンク後にも `FlushAsync()` していた。`_writer` を使うのは `WriteAsync` の**1経路だけ**で、そこが必ず明示 Flush するため `AutoFlush` は完全に冗長。送出タイミングは `WriteAsync` 側で管理する設計なので、**`AutoFlush` を削除**した。

## 4. 常時 console.trace が残っている（重要度40）

`cleanupTerminal` がセッション切替のたびに `console.trace()`（スタックトレース）を出し、さらに全セッションIDを `join` する診断ログを吐いていた。診断残骸整理の流れに合わせて削除。

## 確認状況

- `dotnet build`: 成功（0 エラー）
- `dotnet test`: 86件すべて合格

**要実機確認**: ブラウザをリロード／タブを閉じたあとに、シェルパネルの cmd.exe / powershell がタスクマネージャーに残らないこと（従来は残っていたはず）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)