### PR TITLE
feat: 選択テキストの右クリックメニューを追加（日本語混じりのパスを開けるように）

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -827,6 +827,61 @@
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// 選択テキストをセッションのフォルダ基準で解決し、実在すれば絶対パスを返す（JavaScript から呼び出される）。
+    /// 右クリックメニューの「フルパスをコピー」用。実在しなければ null を返し、呼び出し側はメニューを出さない。
+    /// </summary>
+    [JSInvokable]
+    public Task<string?> ResolveTerminalPath(string sessionId, string path)
+    {
+        try
+        {
+            if (!Guid.TryParse(sessionId, out var guid))
+                return Task.FromResult<string?>(null);
+
+            var session = sessions.FirstOrDefault(s => s.SessionId == guid);
+            var basePath = session?.FolderPath;
+            if (string.IsNullOrEmpty(basePath) || string.IsNullOrWhiteSpace(path))
+                return Task.FromResult<string?>(null);
+
+            // OnTerminalPathClick と同じ規則で解決する（行番号付き表記のフォールバックも同様）
+            string? Resolve(string candidate)
+            {
+                string fullPath;
+                try
+                {
+                    fullPath = System.IO.Path.IsPathRooted(candidate)
+                        ? System.IO.Path.GetFullPath(candidate)
+                        : System.IO.Path.GetFullPath(System.IO.Path.Combine(basePath, candidate));
+                }
+                catch
+                {
+                    return null;
+                }
+
+                return Directory.Exists(fullPath) || File.Exists(fullPath) ? fullPath : null;
+            }
+
+            var trimmed = path.Trim();
+            var resolved = Resolve(trimmed);
+            if (resolved == null)
+            {
+                var withoutLineNumber = System.Text.RegularExpressions.Regex.Replace(trimmed, @"(?::\d+)+$", "");
+                if (withoutLineNumber != trimmed)
+                {
+                    resolved = Resolve(withoutLineNumber);
+                }
+            }
+
+            return Task.FromResult(resolved);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "[ResolveTerminalPath] パスを解決できませんでした: {Path}", path);
+            return Task.FromResult<string?>(null);
+        }
+    }
+
     // コミット情報ダイアログ（ターミナル内のコミットハッシュクリックで開く）
     private bool showCommitInfoDialog = false;
     private string? commitInfoFolderPath;

--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -822,3 +822,35 @@ h1:focus {
     border-top: 2px solid var(--th-accent);
     background-color: rgba(127, 127, 127, 0.08);
 }
+
+/* ターミナルの選択テキスト右クリックメニュー（terminal.js の showTerminalContextMenu）。
+   パスっぽい選択のときだけ出す。それ以外はネイティブメニューに素通しするので、
+   通常の文章での DeepL・スペルチェック等は従来どおり使える。 */
+.terminal-context-menu {
+    position: fixed;
+    z-index: 2000;
+    min-width: 12rem;
+    padding: 0.25rem;
+    background-color: var(--th-surface);
+    border: 1px solid var(--th-border);
+    border-radius: var(--th-radius-sm);
+    box-shadow: var(--th-shadow-lg);
+}
+
+.terminal-context-menu-item {
+    display: block;
+    width: 100%;
+    padding: 0.4rem 0.75rem;
+    border: 0;
+    border-radius: var(--th-radius-sm);
+    background: transparent;
+    color: var(--th-text-primary);
+    font-size: 0.875rem;
+    text-align: left;
+    white-space: nowrap;
+}
+
+.terminal-context-menu-item:hover,
+.terminal-context-menu-item:focus-visible {
+    background-color: var(--th-sidebar-hover);
+}

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -622,6 +622,123 @@ function setupUrlDetectionFallback(term) {
     }
 }
 
+// ---- 選択テキストの右クリックメニュー ----
+//
+// リンクプロバイダはトークンの「境界」を推測する必要があり、日本語やスペースを含む
+// ファイル名では破綻するため対応を見送っている。選択は境界をユーザーが与えてくれるので、
+// 選択テキストならその制約がない（「パスっぽいか」の判定自体は容易）。
+//
+// パスっぽい選択があるときだけ自前メニューを出し、それ以外はネイティブメニューに素通しする。
+// こうすると通常の文章を選んでの DeepL・スペルチェック・絵文字は従来どおり使える。
+
+// 選択がパスらしいか。リンクプロバイダの pathRegex と違い境界の切り出しは不要で、
+// 「区切り文字を含むか / ドライブレターで始まるか / 拡張子で終わるか」だけ見る。
+function looksLikePath(text) {
+    if (!text || text.length > 4096 || /[\r\n]/.test(text)) return false;
+    return /[\\/]/.test(text) || /^[A-Za-z]:/.test(text) || /\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(text);
+}
+
+function closeTerminalContextMenu() {
+    const existing = document.getElementById('terminal-context-menu');
+    if (existing) existing.remove();
+}
+
+function showTerminalContextMenu(x, y, items) {
+    closeTerminalContextMenu();
+
+    const menu = document.createElement('div');
+    menu.id = 'terminal-context-menu';
+    menu.className = 'terminal-context-menu';
+    menu.setAttribute('role', 'menu');
+
+    for (const item of items) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'terminal-context-menu-item';
+        button.setAttribute('role', 'menuitem');
+        button.textContent = item.label;
+        button.addEventListener('click', () => {
+            closeTerminalContextMenu();
+            item.action();
+        });
+        menu.appendChild(button);
+    }
+
+    // 画面外にはみ出さないよう、いったん不可視で置いて実寸から補正する
+    menu.style.visibility = 'hidden';
+    document.body.appendChild(menu);
+    const rect = menu.getBoundingClientRect();
+    menu.style.left = `${Math.min(x, window.innerWidth - rect.width - 4)}px`;
+    menu.style.top = `${Math.min(y, window.innerHeight - rect.height - 4)}px`;
+    menu.style.visibility = '';
+
+    // 次のクリック・ESC・スクロールで閉じる（capture で確実に拾う）
+    const dismiss = (e) => {
+        if (e.type === 'keydown' && e.key !== 'Escape') return;
+        if (e.type === 'mousedown' && menu.contains(e.target)) return;
+        closeTerminalContextMenu();
+        document.removeEventListener('mousedown', dismiss, true);
+        document.removeEventListener('keydown', dismiss, true);
+        window.removeEventListener('blur', dismiss);
+    };
+    document.addEventListener('mousedown', dismiss, true);
+    document.addEventListener('keydown', dismiss, true);
+    window.addEventListener('blur', dismiss);
+}
+
+// element へ contextmenu を登録する。attachTouchScroll と同じく、コンテナ div は
+// セッションごとに永続する一方 createMultiSessionTerminal は毎回呼ばれるため、
+// 前回のリスナーを必ず外してから付け直す（外し忘れるとセッションを開くたび多重登録される）。
+function attachSelectionContextMenu(term, element, sessionId) {
+    if (typeof element._selectionMenuDetach === 'function') {
+        element._selectionMenuDetach();
+    }
+
+    const onContextMenu = (e) => {
+        let selection = '';
+        try {
+            selection = (term.getSelection() || '').trim();
+        } catch {
+            return; // 破棄済み等。ネイティブメニューに任せる
+        }
+
+        if (!selection) return;
+
+        const items = [
+            { label: 'コピー', action: () => copyLinkToClipboard(selection) },
+        ];
+
+        if (looksLikePath(selection)) {
+            // 「開く」はリンククリックと同じ経路（C# 側でセッションのフォルダ基準に解決し、
+            // フォルダ=Explorer / ファイル=既定アプリ。実在しなければ警告トースト）
+            items.push({ label: '開く', action: () => activateTerminalPath(sessionId, selection) });
+            items.push({
+                label: 'フルパスをコピー',
+                action: () => {
+                    if (!window.terminalHubDotNetRef) return;
+                    window.terminalHubDotNetRef.invokeMethodAsync('ResolveTerminalPath', sessionId, selection)
+                        .then(full => copyLinkToClipboard(full || selection))
+                        .catch(() => copyLinkToClipboard(selection));
+                }
+            });
+        }
+
+        // パスでなければ「コピー」しか無い＝ネイティブメニューの方が有用なので出さない
+        if (items.length === 1) return;
+
+        e.preventDefault();
+        showTerminalContextMenu(e.clientX, e.clientY, items);
+    };
+
+    element.addEventListener('contextmenu', onContextMenu);
+
+    element._selectionMenuDetach = () => {
+        closeTerminalContextMenu();
+        element.removeEventListener('contextmenu', onContextMenu);
+        element._selectionMenuDetach = null;
+    };
+}
+
 window.terminalFunctions = {
     // マルチセッション用のターミナル作成関数
     createMultiSessionTerminal: function(terminalId, sessionId, dotNetRef, fontSize) {
@@ -717,6 +834,9 @@ window.terminalFunctions = {
             // （v5 までは動作していた退行）。指の移動量を scrollLines に変換して自前で処理する。
             // 併せて app.css の .xterm { touch-action: none } でページ全体へのスクロール伝播を抑止。
             attachTouchScroll(term, element);
+
+            // 選択テキストの右クリックメニュー（パスっぽい選択のときだけ出す）
+            attachSelectionContextMenu(term, element, sessionId);
 
             // リサイズ診断用: 最後に通知したサイズと通知元を記録
             let lastNotifiedSize = { cols: 0, rows: 0, source: '', time: 0 };
@@ -984,9 +1104,12 @@ window.terminalFunctions = {
 
         // ターミナルdiv内をクリア - より安全なDOM操作を使用
         if (terminalDiv) {
-            // タッチスクロールのリスナーを外す（破棄済み term への参照を残さない）
+            // 登録したリスナーを外す（破棄済み term への参照を残さない）
             if (typeof terminalDiv._touchScrollDetach === 'function') {
                 terminalDiv._touchScrollDetach();
+            }
+            if (typeof terminalDiv._selectionMenuDetach === 'function') {
+                terminalDiv._selectionMenuDetach();
             }
             while (terminalDiv.firstChild) {
                 terminalDiv.removeChild(terminalDiv.firstChild);

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -271,6 +271,14 @@ window.setTerminalLinkCopyMode = function (enabled) {
     terminalLinkCopyMode = !!enabled;
 };
 
+// リンク活性化を左クリックだけに限定するガード。
+// xterm はリンクの activate を呼ぶ前にマウスボタンを見ないため、素通しにすると
+// 右クリック（コンテキストメニューを出したいだけ）や中クリックでもリンクが開いてしまう。
+// button: 0=左 / 1=中 / 2=右。event が無い経路（将来の API 変更等）では従来どおり通す。
+function isPrimaryClick(e) {
+    return !e || e.button === undefined || e.button === 0;
+}
+
 // リンクのアクティベート処理（WebLinksAddon / フォールバック共通）
 function activateTerminalLink(uri) {
     if (terminalLinkCopyMode) {
@@ -386,7 +394,7 @@ function setupFilePathDetection(term, sessionId) {
                         end: { x: match.index + text.length + 1, y: bufferLineNumber }
                     },
                     text: text,
-                    activate: (e, uri) => activateTerminalPath(sessionId, uri)
+                    activate: (e, uri) => { if (isPrimaryClick(e)) activateTerminalPath(sessionId, uri); }
                 });
             }
 
@@ -451,6 +459,7 @@ function setupCommitHashDetection(term, sessionId) {
                     },
                     text: text,
                     activate: (e, uri) => {
+                        if (!isPrimaryClick(e)) return;
                         if (window.terminalHubDotNetRef) {
                             window.terminalHubDotNetRef.invokeMethodAsync('OnTerminalCommitHashClick', sessionId, uri)
                                 .catch(err => console.error('[Hash Detection] open failed:', err));
@@ -506,7 +515,7 @@ function setupPrNumberDetection(term, sessionId) {
                         end: { x: match.index + text.length + 1, y: bufferLineNumber }
                     },
                     text: text,
-                    activate: (e, uri) => activateTerminalPrNumber(sessionId, uri)
+                    activate: (e, uri) => { if (isPrimaryClick(e)) activateTerminalPrNumber(sessionId, uri); }
                 });
             }
 
@@ -553,7 +562,9 @@ function setupUrlDetection(term) {
         try {
             // WebLinksAddonを作成（URLをクリック可能にする）
             // 既定ハンドラは直接 window.open するため、コピー動作モードを差し込めるようカスタムハンドラを渡す
-            const webLinksAddon = new WebLinksAddon.WebLinksAddon((event, uri) => activateTerminalLink(uri));
+            const webLinksAddon = new WebLinksAddon.WebLinksAddon((event, uri) => {
+                if (isPrimaryClick(event)) activateTerminalLink(uri);
+            });
             term.loadAddon(webLinksAddon);
             console.log('[URL Detection] WebLinksAddon loaded successfully');
         } catch (error) {
@@ -600,6 +611,7 @@ function setupUrlDetectionFallback(term) {
                         },
                         text: match[0],
                         activate: (e, uri) => {
+                            if (!isPrimaryClick(e)) return;
                             console.log('[URL Detection] Link activated:', uri);
                             activateTerminalLink(uri);
                         }

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -328,15 +328,31 @@ function showLinkCopyNotice(uri, success) {
 // バッファ行のテキストを取得（各リンクプロバイダー共通）
 // ワイド文字（全角等）の2セル目は getChars() が空を返すためスペースで埋め、
 // 文字列インデックスとターミナル列番号を揃える
+// 行のテキストと、各文字が始まるセル列(0始まり)の対応表を返す。
+//
+// 全角文字は2セルを占め、xterm は2セル目を「幅0・getChars()=''」のセルとして返す。
+// これを ' ' として拾うと（旧実装）パスの途中に空白が入り、空白を含まない前提の
+// pathRegex がそこで切れる（例: C:\Users\info\テスト用メモ.md が
+// "C:\Users\info\テ" までしかリンク化されない）。幅0のセルは飛ばす。
+//
+// また x はセル列なので、全角があると文字数（match.index）とズレる。columns で引き直す。
 function getBufferLineText(line) {
-    let lineText = '';
+    let text = '';
+    const columns = [];
     for (let i = 0; i < line.length; i++) {
         const cell = line.getCell(i);
-        if (cell) {
-            lineText += cell.getChars() || ' ';
+        if (!cell || cell.getWidth() === 0) {
+            continue; // 全角の後続セル（幅0）は本体側に含まれている
         }
+        const chars = cell.getChars() || ' ';
+        // サロゲートペアや結合文字で chars が複数コード単位になる場合も同じ列を指す
+        for (let k = 0; k < chars.length; k++) {
+            columns.push(i);
+        }
+        text += chars;
     }
-    return lineText;
+    columns.push(line.length); // 末尾（マッチ終端の変換用）
+    return { text, columns };
 }
 
 // ファイルパス検出の設定
@@ -366,7 +382,7 @@ function setupFilePathDetection(term, sessionId) {
                 return;
             }
 
-            const lineText = getBufferLineText(line);
+            const { text: lineText, columns } = getBufferLineText(line);
 
             const links = [];
             let match;
@@ -390,8 +406,8 @@ function setupFilePathDetection(term, sessionId) {
 
                 links.push({
                     range: {
-                        start: { x: match.index + 1, y: bufferLineNumber },
-                        end: { x: match.index + text.length + 1, y: bufferLineNumber }
+                        start: { x: columns[match.index] + 1, y: bufferLineNumber },
+                        end: { x: columns[match.index + text.length] + 1, y: bufferLineNumber }
                     },
                     text: text,
                     activate: (e, uri) => { if (isPrimaryClick(e)) activateTerminalPath(sessionId, uri); }
@@ -432,7 +448,7 @@ function setupCommitHashDetection(term, sessionId) {
                 return;
             }
 
-            const lineText = getBufferLineText(line);
+            const { text: lineText, columns } = getBufferLineText(line);
 
             const links = [];
             let match;
@@ -454,8 +470,8 @@ function setupCommitHashDetection(term, sessionId) {
 
                 links.push({
                     range: {
-                        start: { x: match.index + 1, y: bufferLineNumber },
-                        end: { x: match.index + text.length + 1, y: bufferLineNumber }
+                        start: { x: columns[match.index] + 1, y: bufferLineNumber },
+                        end: { x: columns[match.index + text.length] + 1, y: bufferLineNumber }
                     },
                     text: text,
                     activate: (e, uri) => {
@@ -498,7 +514,7 @@ function setupPrNumberDetection(term, sessionId) {
                 return;
             }
 
-            const lineText = getBufferLineText(line);
+            const { text: lineText, columns } = getBufferLineText(line);
 
             const links = [];
             let match;
@@ -511,8 +527,8 @@ function setupPrNumberDetection(term, sessionId) {
 
                 links.push({
                     range: {
-                        start: { x: match.index + 1, y: bufferLineNumber },
-                        end: { x: match.index + text.length + 1, y: bufferLineNumber }
+                        start: { x: columns[match.index] + 1, y: bufferLineNumber },
+                        end: { x: columns[match.index + text.length] + 1, y: bufferLineNumber }
                     },
                     text: text,
                     activate: (e, uri) => { if (isPrimaryClick(e)) activateTerminalPrNumber(sessionId, uri); }
@@ -596,7 +612,7 @@ function setupUrlDetectionFallback(term) {
                 }
                 
                 // 行のテキストを取得
-                const lineText = getBufferLineText(line);
+                const { text: lineText, columns } = getBufferLineText(line);
 
                 // URLを検出
                 const links = [];
@@ -606,8 +622,8 @@ function setupUrlDetectionFallback(term) {
                 while ((match = urlRegex.exec(lineText)) !== null) {
                     const link = {
                         range: {
-                            start: { x: match.index + 1, y: bufferLineNumber },
-                            end: { x: match.index + match[0].length + 1, y: bufferLineNumber }
+                            start: { x: columns[match.index] + 1, y: bufferLineNumber },
+                            end: { x: columns[match.index + match[0].length] + 1, y: bufferLineNumber }
                         },
                         text: match[0],
                         activate: (e, uri) => {


### PR DESCRIPTION
## 背景

ターミナル内のパスをクリックで開けるリンクプロバイダはあるが、**日本語やスペースを含むファイル名は対応を見送っていた**。理由は「どこからどこまでがパスか」という**境界の推測**が破綻するため。

選択なら、**境界はユーザーが与えてくれる**。検出の難しさの本体が消えるので、リンク化で諦めた形もそのまま開ける。「パスっぽいか」の判定自体は区切り文字の有無で足りる。

## 設計

**パスっぽい選択があるときだけ**自前メニューを出し、それ以外は `preventDefault` せず**ネイティブメニューへ素通し**する。

```js
const selection = term.getSelection().trim();
if (!selection) return;                    // ネイティブへ
...
if (items.length === 1) return;            // コピーしか無い＝ネイティブの方が有用
e.preventDefault();
showTerminalContextMenu(...);
```

これにより、通常の文章を選んでの **DeepL・スペルチェック・絵文字は従来どおり使える**（PR #143 でネイティブのフルメニューが出るようになったばかりなので、それを潰さない形にした）。

### メニュー項目

| 項目 | 動作 |
|---|---|
| コピー | 選択テキストをそのまま |
| 開く | **リンククリックと同じ経路**（`OnTerminalPathClick`）。セッションのフォルダ基準で解決し、フォルダ=Explorer / ファイル=既定アプリ。実在しなければ警告トースト |
| フルパスをコピー | 相対パスを絶対パスへ解決してコピー（`ResolveTerminalPath` を追加。解決できなければ選択テキストのままコピー） |

「開く」は既存の完成した入口をそのまま呼ぶだけなので、相対パス解決・実在チェック・成功トーストは既に入っている。

### パス判定の検証

```
OK  true  "docs/設計メモ 第2版.md"        日本語+スペース入りパス（本命）
OK  true  "C:\Users\info\デスクトップ\資料.xlsx"  Windows絶対パス+日本語
OK  true  "設計メモ.md"                 拡張子のみ
OK  true  "./src/Root.razor:123"        行番号付き
OK  true  "TerminalHub/Services"        フォルダ
OK  false "これは普通の日本語の文章です"     文章→ネイティブメニュー
OK  false "Hello world"                 英文→ネイティブメニュー
OK  false "エラーが発生しました。"          句点で終わる文
```

## リスナーの多重登録対策

`contextmenu` リスナーは `attachTouchScroll` と同じ作法で、**登録前に前回分を外し**、`cleanupTerminal` からも解除する（`_selectionMenuDetach`）。

コンテナ div はセッションごとに永続する一方 `createMultiSessionTerminal` は毎回呼ばれるため、外し忘れるとセッションを開くたびに積み重なる。**PR #143 で撤去した `setupContextMenuAndIME` がまさにこれを踏んでいた**ので、同じ轍は踏まない。

## 確認状況

- `dotnet build`: 成功（0 エラー）

**要実機確認**:
- 日本語やスペースを含むパスを選択して右クリック → 「開く」で開けること
- 普通の文章を選択して右クリック → **ネイティブメニュー（DeepL 等）がそのまま出る**こと
- セッションを何度か切り替えたあとでも、メニューが二重に出たりしないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記: リンクが右クリックでも開いていた（実機で発覚）

メニューを出したところ「メニューは出るが、同時にリンクのファイルも開く」状態だった。

原因は **xterm がリンクの `activate` を呼ぶ前にマウスボタンを見ていない**こと。従来から右クリックでリンクが開いていたが、右クリックで何も出なかったため気づきにくかっただけで、これは**この PR で作り込んだものではなく既存の挙動**。

`isPrimaryClick` ガードを追加し、**リンク活性化の5経路すべて**に適用した:

- パス（`activateTerminalPath`）
- コミットハッシュ（`OnTerminalCommitHashClick`）
- PR番号（`activateTerminalPrNumber`）
- WebLinksAddon（URL）
- フォールバックURL プロバイダ

中クリックも同様に無視される。「URL の上で右クリック → 意図せずブラウザが開く」も併せて直る。
