### PR TITLE
fix: ブランチ名検証を実際に接続し、デッドコードを削除

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1716,16 +1716,6 @@
     }
 
 
-    private async Task UpdateSessionMemo(Guid sessionId, string memo)
-    {
-        var session = sessions.FirstOrDefault(s => s.SessionId == sessionId);
-        if (session != null)
-        {
-            session.Memo = memo;
-            // ローカルストレージを更新
-            await SaveSessionToStorageAsync(session);
-        }
-    }
 
     private async Task RemoveSession(Guid sessionId)
     {

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -1,4 +1,4 @@
-@using TerminalHub.Models
+﻿@using TerminalHub.Models
 @using TerminalHub.Services
 @using Microsoft.Extensions.Configuration
 @using Microsoft.Extensions.Localization
@@ -793,16 +793,6 @@
         };
     }
 
-    private string GetGeminiApprovalModeHelp()
-    {
-        return GeminiOptions.ApprovalMode switch
-        {
-            "default" => L["SessionOptions.Gemini.ApprovalMode.HelpDefault"],
-            "auto_edit" => L["SessionOptions.Gemini.ApprovalMode.HelpAutoEdit"],
-            "yolo" => L["SessionOptions.Gemini.ApprovalMode.HelpYolo"],
-            _ => ""
-        };
-    }
 
     private string GetApprovalPolicyHelp()
     {

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -104,6 +104,12 @@
                                     <small class="form-text text-muted">
                                         @L["SubSession.NewBranch.Help"]
                                     </small>
+                                    @if (!string.IsNullOrWhiteSpace(branchName) && !IsValidBranchName(branchName))
+                                    {
+                                        <div class="text-danger small mt-1">
+                                            <i class="bi bi-exclamation-circle me-1"></i>@L["SubSession.NewBranch.Invalid"]
+                                        </div>
+                                    }
                                 </div>
                             }
                             else if (branchSelectionMode == BranchSelectionMode.Detached)
@@ -436,7 +442,9 @@
             {
                 TabType.Create => IsGitRepository && branchSelectionMode switch
                 {
-                    BranchSelectionMode.NewBranch => !string.IsNullOrWhiteSpace(branchName),
+                    // 空でないことに加えて Git のブランチ名規則も満たすこと。
+                    // 満たさないまま進めると worktree 作成が git のエラーで落ちて理由が分かりにくい
+                    BranchSelectionMode.NewBranch => IsValidBranchName(branchName),
                     BranchSelectionMode.ExistingBranch => !string.IsNullOrWhiteSpace(selectedExistingBranch) && branchWorktreeInfo == null,
                     BranchSelectionMode.Detached => true,
                     _ => false
@@ -850,12 +858,6 @@
     private Task OnTerminalTypeChanged(TerminalType newType)
     {
         selectedTerminalType = newType;
-        return Task.CompletedTask;
-    }
-
-    private Task OnStartupCommandChanged(string newCommand)
-    {
-        startupCommand = newCommand;
         return Task.CompletedTask;
     }
 

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -1,4 +1,4 @@
-namespace TerminalHub.Models;
+﻿namespace TerminalHub.Models;
 
 /// <summary>
 /// アプリケーション全体の設定（ファイルベースで永続化）
@@ -229,15 +229,7 @@ public class CustomCliOptionsSettings
     public List<UserCliOption> Antigravity { get; set; } = new();
     public List<UserCliOption> Grok { get; set; } = new();
 
-    public List<UserCliOption> ForType(TerminalType type) => type switch
-    {
-        TerminalType.ClaudeCode => ClaudeCode,
-        TerminalType.GeminiCLI => GeminiCLI,
-        TerminalType.CodexCLI => CodexCLI,
-        TerminalType.Antigravity => Antigravity,
-        TerminalType.Grok => Grok,
-        _ => new List<UserCliOption>()
-    };
+
 }
 
 /// <summary>

--- a/TerminalHub/Models/SessionInfo.cs
+++ b/TerminalHub/Models/SessionInfo.cs
@@ -283,14 +283,6 @@ namespace TerminalHub.Models
             }
         }
 
-        public void ClearStatusChangeHistory()
-        {
-            lock (_statusHistoryLock)
-            {
-                _statusChangeHistory.Clear();
-            }
-        }
-
         // 通知ベル（通知マーク）変更履歴（診断用）。
         // ベル自体は Root(Circuit=ブラウザ接続) ごとに独立管理のため「別ブラウザでは残っている」ことがある。
         // どのインスタンスが・何経由で 付けた/消した/抑止した かを記録し、意図しない再点灯の調査に使う。
@@ -450,14 +442,6 @@ namespace TerminalHub.Models
         public int HookEventLogCount
         {
             get { lock (_hookEventLogLock) { return _hookEventLog.Count; } }
-        }
-
-        public void ClearHookEventLog()
-        {
-            lock (_hookEventLogLock)
-            {
-                _hookEventLog.Clear();
-            }
         }
 
         public string GetDisplayName()

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     i18n shared resources (English - canonical)
@@ -502,6 +502,7 @@
   <data name="SubSession.SessionName.Placeholder" xml:space="preserve"><value>Auto-named from the folder if left empty</value></data>
   <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>New branch name</value></data>
   <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>A new worktree will be created for this branch</value></data>
+  <data name="SubSession.NewBranch.Invalid" xml:space="preserve"><value>Not a valid Git branch name (space ~ ^ : ? * [ \ and ".." are not allowed; cannot start with "." "-" or end with "." "/"; reserved names like HEAD are not allowed)</value></data>
   <data name="SubSession.ExistingBranch.Label" xml:space="preserve"><value>Select an existing branch</value></data>
   <data name="SubSession.ExistingBranch.Loading" xml:space="preserve"><value>Loading branch list...</value></data>
   <data name="SubSession.ExistingBranch.Empty" xml:space="preserve"><value>No branches available</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     i18n 共有リソース (日本語)
@@ -502,6 +502,7 @@
   <data name="SubSession.SessionName.Placeholder" xml:space="preserve"><value>未入力ならフォルダ名から自動命名</value></data>
   <data name="SubSession.NewBranch.Label" xml:space="preserve"><value>新しいブランチ名</value></data>
   <data name="SubSession.NewBranch.Help" xml:space="preserve"><value>このブランチ名で新しい Worktree が作成されます</value></data>
+  <data name="SubSession.NewBranch.Invalid" xml:space="preserve"><value>Git のブランチ名として使用できません（空白 ~ ^ : ? * [ \ や ".." は不可、先頭の "." "-" や末尾の "." "/" も不可。HEAD 等の予約名も不可）</value></data>
   <data name="SubSession.ExistingBranch.Label" xml:space="preserve"><value>既存のブランチを選択</value></data>
   <data name="SubSession.ExistingBranch.Loading" xml:space="preserve"><value>ブランチ一覧を読み込み中…</value></data>
   <data name="SubSession.ExistingBranch.Empty" xml:space="preserve"><value>利用可能なブランチがありません</value></data>

--- a/TerminalHub/Services/GitService.cs
+++ b/TerminalHub/Services/GitService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 using System.Text;
 
@@ -151,37 +151,6 @@ namespace TerminalHub.Services
             }
         }
 
-        public async Task<bool> RemoveWorktreeAsync(string worktreePath)
-        {
-            try
-            {
-                if (!await IsWorktreeAsync(worktreePath))
-                {
-                    _logger.LogWarning("Worktree削除: 指定されたパスはWorktreeではありません: {Path}", worktreePath);
-                    return false;
-                }
-
-                var command = $"worktree remove \"{worktreePath}\"";
-                var result = await ExecuteGitCommandAsync(worktreePath, command);
-
-                if (result.Success)
-                {
-                    _logger.LogInformation("Worktree削除成功: {Path}", worktreePath);
-                    return true;
-                }
-                else
-                {
-                    _logger.LogWarning("Worktree削除失敗: {Error}", result.Error);
-                    return false;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Worktree削除でエラーが発生しました: {Path}", worktreePath);
-                return false;
-            }
-        }
-
         public async Task<bool> IsWorktreeAsync(string path)
         {
             try
@@ -278,73 +247,6 @@ namespace TerminalHub.Services
             {
                 _logger.LogError(ex, "Worktree一覧取得でエラーが発生しました: {Path}", path);
                 return worktrees;
-            }
-        }
-
-        public async Task<WorktreeInfo?> ValidateWorktreeAsync(string worktreePath)
-        {
-            try
-            {
-                if (!Directory.Exists(worktreePath))
-                    return null;
-
-                // Worktreeかどうかチェック
-                if (!await IsWorktreeAsync(worktreePath))
-                    return null;
-
-                // git worktree listでこのWorktreeの情報を取得
-                var result = await ExecuteGitCommandAsync(worktreePath, "worktree list --porcelain");
-                if (!result.Success || string.IsNullOrEmpty(result.Output))
-                    return null;
-
-                var lines = result.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-                WorktreeInfo? targetWorktree = null;
-                WorktreeInfo? currentWorktree = null;
-
-                foreach (var line in lines)
-                {
-                    if (line.StartsWith("worktree "))
-                    {
-                        var path = line.Substring("worktree ".Length).Trim();
-                        currentWorktree = new WorktreeInfo { Path = path };
-
-                        // パスが一致する場合、これが対象のWorktree
-                        if (Path.GetFullPath(path).Equals(Path.GetFullPath(worktreePath), StringComparison.OrdinalIgnoreCase))
-                        {
-                            targetWorktree = currentWorktree;
-                        }
-                    }
-                    else if (currentWorktree != null && currentWorktree == targetWorktree)
-                    {
-                        if (line.StartsWith("HEAD "))
-                        {
-                            currentWorktree.CommitHash = line.Substring("HEAD ".Length).Trim();
-                        }
-                        else if (line.StartsWith("branch "))
-                        {
-                            currentWorktree.BranchName = line.Substring("branch ".Length).Trim();
-                        }
-                        else if (line == "detached")
-                        {
-                            currentWorktree.BranchName = "(detached HEAD)";
-                        }
-                        else if (line == "locked")
-                        {
-                            currentWorktree.IsLocked = true;
-                        }
-                        else if (line == "prunable")
-                        {
-                            currentWorktree.IsPrunable = true;
-                        }
-                    }
-                }
-
-                return targetWorktree;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Worktree検証でエラーが発生しました: {Path}", worktreePath);
-                return null;
             }
         }
 

--- a/TerminalHub/Services/IGitService.cs
+++ b/TerminalHub/Services/IGitService.cs
@@ -1,4 +1,4 @@
-using TerminalHub.Models;
+﻿using TerminalHub.Models;
 
 namespace TerminalHub.Services
 {
@@ -36,13 +36,6 @@ namespace TerminalHub.Services
         Task<bool> CreateWorktreeAsync(string sourcePath, string branchName, string worktreePath, bool detach = false);
 
         /// <summary>
-        /// Worktreeを削除
-        /// </summary>
-        /// <param name="worktreePath">削除するWorktreeのパス</param>
-        /// <returns>成功した場合true</returns>
-        Task<bool> RemoveWorktreeAsync(string worktreePath);
-
-        /// <summary>
         /// 指定されたパスがWorktreeかどうかを判定
         /// </summary>
         /// <param name="path">チェックするパス</param>
@@ -55,13 +48,6 @@ namespace TerminalHub.Services
         /// <param name="path">リポジトリのパス</param>
         /// <returns>Worktree情報のリスト</returns>
         Task<List<WorktreeInfo>> GetWorktreeListAsync(string path);
-
-        /// <summary>
-        /// 既存のWorktreeを検証
-        /// </summary>
-        /// <param name="worktreePath">検証するWorktreeのパス</param>
-        /// <returns>Worktree情報、無効な場合はnull</returns>
-        Task<WorktreeInfo?> ValidateWorktreeAsync(string worktreePath);
 
         /// <summary>
         /// 未コミットの変更ファイル一覧を取得（git status --porcelain）

--- a/TerminalHub/Services/ISessionRepository.cs
+++ b/TerminalHub/Services/ISessionRepository.cs
@@ -1,4 +1,4 @@
-using TerminalHub.Models;
+﻿using TerminalHub.Models;
 
 namespace TerminalHub.Services
 {
@@ -29,7 +29,6 @@ namespace TerminalHub.Services
         // 入力履歴
         Task<List<string>> GetInputHistoryAsync(int limit = 100);
         Task AddInputHistoryAsync(string text);
-        Task ClearInputHistoryAsync();
 
         // データベース状態
         bool DatabaseExists();

--- a/TerminalHub/Services/McpConfigService.cs
+++ b/TerminalHub/Services/McpConfigService.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
@@ -8,8 +8,11 @@ namespace TerminalHub.Services;
 
 /// <summary>
 /// 試験機能: 対応CLI(Claude Code / Codex)のフォルダへ TerminalHub のローカル MCP サーバー
-/// (terminalhub) を自動登録/撤去するサービス。CodexHookService と同じく per-folder に書き、
+/// (terminalhub) を自動登録するサービス。CodexHookService と同じく per-folder に書き、
 /// 既存設定はマージ・TerminalHub は「terminalhub」エントリのみ所有する。
+///
+/// 撤去はしない（書き込むところまでが責務）。自動登録を無効に戻しても、既に書いた
+/// terminalhub エントリはそのまま残るので、不要なら利用者が設定ファイルから消す。
 ///
 /// - Claude Code → <c>&lt;folder&gt;/.mcp.json</c> の <c>mcpServers.terminalhub</c>（type:"http"）
 /// - Codex       → <c>&lt;folder&gt;/.codex/config.toml</c> の <c>[mcp_servers.terminalhub]</c>
@@ -20,8 +23,6 @@ public interface IMcpConfigService
     /// <summary>terminalhub MCP サーバーを CLI 設定へ追記（既存があれば最新値へ更新）。</summary>
     Task SetupAsync(string folderPath, TerminalType terminalType, string baseUrl);
 
-    /// <summary>TerminalHub 由来（terminalhub）エントリだけを CLI 設定から除去。</summary>
-    Task RemoveAsync(string folderPath, TerminalType terminalType);
 }
 
 public class McpConfigService : IMcpConfigService
@@ -55,19 +56,6 @@ public class McpConfigService : IMcpConfigService
                 break;
             default:
                 // Claude Code / Codex のみサポート。それ以外は何もしない。
-                break;
-        }
-    }
-
-    public async Task RemoveAsync(string folderPath, TerminalType terminalType)
-    {
-        switch (terminalType)
-        {
-            case TerminalType.ClaudeCode:
-                await RemoveClaudeAsync(folderPath);
-                break;
-            case TerminalType.CodexCLI:
-                await RemoveCodexAsync(folderPath);
                 break;
         }
     }
@@ -107,23 +95,6 @@ public class McpConfigService : IMcpConfigService
         _logger.LogInformation("MCP設定を追記(Claude): {Path} url={Url}", path, url);
     }
 
-    private async Task RemoveClaudeAsync(string folderPath)
-    {
-        var path = Path.Combine(folderPath, ClaudeMcpFileName);
-        if (!File.Exists(path)) return;
-
-        var root = JsonNode.Parse(await File.ReadAllTextAsync(path))?.AsObject();
-        if (root?["mcpServers"] is not JsonObject servers) return;
-        if (!servers.ContainsKey(ServerName)) return;
-
-        servers.Remove(ServerName);
-        if (servers.Count == 0) root.Remove("mcpServers");
-
-        var options = new JsonSerializerOptions { WriteIndented = true };
-        await File.WriteAllTextAsync(path, root.ToJsonString(options));
-        _logger.LogInformation("MCP設定を除去(Claude): {Path}", path);
-    }
-
     // ---- Codex (.codex/config.toml / TOML) ----
     // TOML ライブラリを持たないため、TerminalHub が所有する [mcp_servers.terminalhub] テーブルの
     // ブロックだけを行スキャンで置換/除去する。他のTOMLには手を触れない。
@@ -152,20 +123,6 @@ public class McpConfigService : IMcpConfigService
 
         await File.WriteAllTextAsync(path, string.Join("\n", lines));
         _logger.LogInformation("MCP設定を追記(Codex): {Path} url={Url}", path, url);
-    }
-
-    private async Task RemoveCodexAsync(string folderPath)
-    {
-        var path = Path.Combine(folderPath, CodexConfigFileName);
-        if (!File.Exists(path)) return;
-
-        var lines = (await File.ReadAllTextAsync(path)).Replace("\r\n", "\n").Split('\n').ToList();
-        if (!RemoveTerminalHubTomlBlock(lines)) return;
-
-        TrimTrailingBlankLines(lines);
-        if (lines.Count > 0) lines.Add("");
-        await File.WriteAllTextAsync(path, string.Join("\n", lines));
-        _logger.LogInformation("MCP設定を除去(Codex): {Path}", path);
     }
 
     /// <summary>

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -1,4 +1,4 @@
-using TerminalHub.Models;
+﻿using TerminalHub.Models;
 using TerminalHub.Constants;
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
@@ -51,7 +51,6 @@ namespace TerminalHub.Services
         void MarkSessionConnected(Guid sessionId);
 
         Task<bool> SetActiveSessionAsync(Guid sessionId);
-        Guid? GetActiveSessionId();
         Task SaveSessionInfoAsync(SessionInfo sessionInfo);
         Task<SessionInfo?> CreateWorktreeSessionAsync(Guid parentSessionId, string branchName);
         Task<SessionInfo?> CreateWorktreeSessionAsync(Guid parentSessionId, string branchName, TerminalType terminalType, Dictionary<string, string>? options);
@@ -585,13 +584,6 @@ namespace TerminalHub.Services
             }
         }
 
-        public Guid? GetActiveSessionId()
-        {
-            lock (_lockObject)
-            {
-                return _activeSessionId;
-            }
-        }
 
         public Task SaveSessionInfoAsync(SessionInfo sessionInfo)
         {

--- a/TerminalHub/Services/SessionRepository.cs
+++ b/TerminalHub/Services/SessionRepository.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using TerminalHub.Models;
@@ -478,14 +478,6 @@ namespace TerminalHub.Services
                 DELETE FROM InputHistory WHERE Id NOT IN (
                     SELECT Id FROM InputHistory ORDER BY Id DESC LIMIT 100
                 )");
-        }
-
-        public async Task ClearInputHistoryAsync()
-        {
-            await using var connection = _dbContext.CreateConnection();
-            await connection.OpenAsync();
-
-            await connection.ExecuteNonQueryAsync("DELETE FROM InputHistory");
         }
 
         private async Task<Dictionary<string, string>> GetSessionOptionsAsync(SqliteConnection connection, Guid sessionId)


### PR DESCRIPTION
外部レビュー（Codex）のデッドコード指摘に対応。指摘はすべて事実だったが、**性質が3つに分かれる**ので分けて扱った。

## A. ブランチ名の検証が繋がっていなかった（機能欠落・要修正）

`SubSessionDialog.IsValidBranchName` は予約名（HEAD 等）・禁止文字（`~ ^ : ? * [ \` と空白）・`..`・先頭末尾の規則まで見る**しっかりした実装**なのに、**どこからも呼ばれていなかった**。

```csharp
BranchSelectionMode.NewBranch => !string.IsNullOrWhiteSpace(branchName),   // 空かどうかだけ
```

不正な名前がそのまま git まで流れ、worktree 作成が失敗して初めて分かる状態だった。

同じファイルの `IsValidFolderSuffix` が「不正なら赤字警告＋ボタン無効化」という**手本を持っていた**ので、それに揃えて接続した。繋ぐのを忘れただけに見える。

文言（`SubSession.NewBranch.Invalid`）は実装が実際に弾く条件に合わせて ja/en に追加。

## B. `McpConfigService.RemoveAsync` を撤去（方針決定）

interface のドキュメントは「自動登録/**撤去**するサービス」と謳っていたが、撤去は**呼び出し元ゼロで到達不能**だった。

MCP 設定ファイルへは**「書き込むところまでが責務」**という方針にしたため、`RemoveAsync` / `RemoveClaudeAsync` / `RemoveCodexAsync` を削除し、契約の記述も実態に合わせた（自動登録を無効に戻しても書いた設定は残る旨を明記）。

なお `RemoveTerminalHubTomlBlock` と `TrimTrailingBlankLines` は **`SetupCodexAsync` からも使われている**（既存エントリを消してから書き直すため）ので残している。

## C. 死んだメソッドを削除（すべて参照ゼロを確認）

| 対象 | 備考 |
|---|---|
| `GetGeminiApprovalModeHelp` | Gemini 廃止の残骸 |
| `OnStartupCommandChanged` | |
| `UpdateSessionMemo` | |
| `CustomCliOptionsSettings.ForType` | |
| `SessionInfo.ClearStatusChangeHistory` / `ClearHookEventLog` | |
| `ISessionRepository.ClearInputHistoryAsync` | |
| `SessionManager.GetActiveSessionId` | **同期版のみ**。リポジトリ側の `GetActiveSessionIdAsync` は `SqliteStorageService` から使われており現役なので別物 |

### worktree API も削除（追記）

`IGitService.RemoveWorktreeAsync` / `ValidateWorktreeAsync` も削除した。

- **RemoveWorktreeAsync**: worktree の実ディレクトリ削除は持たせない方針のため
- **ValidateWorktreeAsync**: 任意の1パスを検証する API だが、既存の worktree 関連の導線（`SubSessionDialog` の既存Worktreeタブ / `SessionManager` の重複チェック）は**いずれも親リポジトリの `GetWorktreeListAsync` で一覧を引く形で足りており**、出番がない（一覧の方が `IsPrunable` 等も含んでいて情報も多い）

**`IsWorktreeAsync` は残した**。Validate/Remove の内部からしか呼ばれていないように見えたが、実際は `GetGitInfoAsync` が `gitInfo.IsWorktree` の判定に使っている現役だった。

## 確認状況

- `dotnet build`: 成功（0 エラー・0 警告）
- `dotnet test`: 86件すべて合格

**要実機確認**: サブセッション作成で、不正なブランチ名（例: `feature branch`（空白入り）、`HEAD`、`..` を含む、`-` 始まり）を入れると赤字警告が出て作成ボタンが押せないこと。正常な名前（`feature/new-feature` 等）はこれまでどおり作成できること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
