### PR TITLE
refactor: 設定画面の「CLI Hook 設定」節を削除（設定項目が無いため）

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -434,20 +434,6 @@
                         </div>
                     }
 
-                    <hr />
-
-                    <h6 class="mb-3">@L["Settings.Notifications.ClaudeHook.Header"]</h6>
-                    <p class="text-muted small mb-3">
-                        @((MarkupString)L["Settings.Notifications.ClaudeHook.HelpHtml"].Value)
-                    </p>
-
-                    <div class="mb-3">
-                        <small class="text-muted d-block">
-                            <i class="bi bi-info-circle me-1"></i>
-                            @L["Settings.Notifications.ClaudeHook.AlwaysOnNotice"]
-                        </small>
-                    </div>
-
                             </div>
                         }
                         else if (activeTab == "sessions")

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -135,9 +135,6 @@
   <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>Webhook</value></data>
   <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>Enable webhook notifications</value></data>
   <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>Webhook URL</value></data>
-  <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>CLI Hooks</value></data>
-  <data name="Settings.Notifications.ClaudeHook.HelpHtml" xml:space="preserve"><value>Use the hook feature of Claude Code / Codex to receive notifications more reliably. Hooks are passed automatically via launch options when a session starts, so no config files in your working folder are modified.</value></data>
-  <data name="Settings.Notifications.ClaudeHook.AlwaysOnNotice" xml:space="preserve"><value>Hooks are always enabled. They are applied automatically the next time each session is started/restarted (both Claude Code and Codex receive them via launch options without modifying any files).</value></data>
 
   <!-- Settings: Sessions Tab -->
   <data name="Settings.Sessions.SortOrder.Label" xml:space="preserve"><value>Session list sort order</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -135,9 +135,6 @@
   <data name="Settings.Notifications.Webhook.Header" xml:space="preserve"><value>Webhook 設定</value></data>
   <data name="Settings.Notifications.Webhook.Enable" xml:space="preserve"><value>Webhook 通知を有効にする</value></data>
   <data name="Settings.Notifications.Webhook.UrlLabel" xml:space="preserve"><value>Webhook URL</value></data>
-  <data name="Settings.Notifications.ClaudeHook.Header" xml:space="preserve"><value>CLI Hook 設定</value></data>
-  <data name="Settings.Notifications.ClaudeHook.HelpHtml" xml:space="preserve"><value>Claude Code / Codex の hook 機能を使用して、より確実に通知を受け取ることができます。セッション起動時に起動オプションで自動的に渡されるため、作業フォルダの設定ファイルは書き換えません。</value></data>
-  <data name="Settings.Notifications.ClaudeHook.AlwaysOnNotice" xml:space="preserve"><value>Hook は常に有効です。各セッションが次に起動／再起動されたタイミングで自動適用されます（Claude Code / Codex とも起動オプションで渡すため、ファイルは書き換えません）。</value></data>
 
   <!-- Settings: Sessions Tab -->
   <data name="Settings.Sessions.SortOrder.Label" xml:space="preserve"><value>セッション一覧の並び順</value></data>


### PR DESCRIPTION
Hook は常時有効・起動オプション注入となり（#152/#153）、この節にはトグルも入力も無く説明文2つだけが残っていた。内容も「起動オプションで渡す・ファイルは書き換えない」の繰り返しで、ユーザーに選択肢が無い挙動を設定画面で説明する必要はないため節ごと削除する。

- SettingsDialog.razor の該当節（hr含む）を削除
- 未使用になった resx キー3件 × ja/en を削除
- ビルド 0警告0エラー、残参照なし（grep確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)