### PR TITLE
chore: Gemini廃止残骸の除去と無言catchの意図明示

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -3149,7 +3149,7 @@
         // ShellPanelの破棄（BottomPanelコンポーネント経由）
         if (bottomPanel != null)
         {
-            try { await bottomPanel.DisposeAllShellPanels(); } catch { }
+            try { await bottomPanel.DisposeAllShellPanels(); } catch { /* Dispose 経路。JSDisconnectedException 等は無視 */ }
         }
 
         // activeTerminalのDisposeを安全に処理

--- a/TerminalHub/Components/Shared/BottomPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanel.razor
@@ -189,7 +189,7 @@
         if (_focusEditingInput)
         {
             _focusEditingInput = false;
-            try { await editingInputRef.FocusAsync(); } catch { }
+            try { await editingInputRef.FocusAsync(); } catch { /* フォーカス失敗は無害（要素未描画/回線切断時） */ }
         }
     }
 
@@ -485,7 +485,7 @@
     {
         foreach (var panel in ShellPanelRefs.Values)
         {
-            try { await panel.DisposeAsync(); } catch { }
+            try { await panel.DisposeAsync(); } catch { /* Dispose 経路。JSDisconnectedException 等は無視 */ }
         }
         ShellPanelRefs.Clear();
     }

--- a/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
@@ -438,7 +438,7 @@
         AcceptSlashSuggestion();
         StateHasChanged();
         // クリック後はテキストエリアにフォーカスを戻す（自前ヘルパで id 指定・確実に戻す）。
-        try { await JS.InvokeVoidAsync("slashAutocomplete.focusInput", $"inputText-{PanelId}"); } catch { }
+        try { await JS.InvokeVoidAsync("slashAutocomplete.focusInput", $"inputText-{PanelId}"); } catch { /* フォーカス復帰失敗は無害（回線切断時含む） */ }
     }
 
     private async Task TryRegisterSlashAutocomplete()
@@ -693,14 +693,14 @@
                 await JS.InvokeVoidAsync("voiceInputManager.bindMiddlePushToTalk",
                     $"inputText-{PanelId}", dotNetRef);
             }
-            catch { }
+            catch { /* バインド失敗時は該当 Push-to-Talk が無効になるだけ。回線切断時の例外含め無視 */ }
             // スペース長押し Push-to-Talk バインド
             try
             {
                 await JS.InvokeVoidAsync("voiceInputManager.bindSpaceHoldPushToTalk",
                     $"inputText-{PanelId}", dotNetRef);
             }
-            catch { }
+            catch { /* 同上（バインド失敗＝機能縮退のみ） */ }
         }
     }
 
@@ -826,12 +826,12 @@
             {
                 await JS.InvokeVoidAsync("voiceInputManager.unbindMiddlePushToTalk", $"inputText-{PanelId}");
             }
-            catch { }
+            catch { /* Dispose 経路。JSDisconnectedException 等は無視 */ }
             try
             {
                 await JS.InvokeVoidAsync("voiceInputManager.unbindSpaceHoldPushToTalk", $"inputText-{PanelId}");
             }
-            catch { }
+            catch { /* 同上 */ }
             try
             {
                 await JS.InvokeVoidAsync("voiceInputManager.dispose");

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -1015,7 +1015,7 @@
                                         <i class="bi bi-info-circle me-1"></i>
                                         入力欄の内容が <code>/</code> で始まるときだけ候補ポップアップを表示し、名前の部分一致で絞り込みます
                                         （<kbd>↑↓</kbd> 選択 / <kbd>Tab</kbd>・<kbd>Enter</kbd> 確定 / <kbd>Esc</kbd> 閉じる）。
-                                        対応: <strong>Claude Code</strong> / <strong>Codex</strong>（Gemini は辞書を用意でき次第）。
+                                        対応: <strong>Claude Code</strong> / <strong>Codex</strong>。
                                     </p>
                                     <p class="text-muted small mt-1 mb-0">
                                         Claude Code はインストール済みバージョンの実コマンド一覧を自動取得（自作コマンド・プラグインも含む）。

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -2158,7 +2158,7 @@
         {
             await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
         }
-        catch { }
+        catch { /* クリップボード API 不許可/回線切断時は失敗するが致命的でないため無視 */ }
     }
 
     private async Task BrowseFavoriteFolder()

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -96,8 +96,6 @@
             return string.Join(" ", args);
         }
 
-        // BuildGeminiArgs は廃止 (GeminiCLI 起動経路は撤去済み)
-
         public static string BuildCodexArgs(
             Dictionary<string, string> options,
             string? terminalHubMcpUrl = null,

--- a/TerminalHub/Services/GitService.cs
+++ b/TerminalHub/Services/GitService.cs
@@ -450,7 +450,7 @@ namespace TerminalHub.Services
                 }
                 catch (OperationCanceledException)
                 {
-                    try { process.Kill(); } catch { }
+                    try { process.Kill(); } catch { /* 既に終了済みなら Kill は失敗する。無視して良い */ }
                     _logger.LogWarning("Gitコマンドがタイムアウトしました: git {Arguments} in {WorkingDirectory}", arguments, workingDirectory);
                     return (false, null, "タイムアウト");
                 }

--- a/TerminalHub/Services/SlashCommandCatalog.cs
+++ b/TerminalHub/Services/SlashCommandCatalog.cs
@@ -190,8 +190,8 @@ public static class SlashCommandCatalog
         new("/exit", "Codex CLIを終了（/quit と同じ）"),
     };
 
-    // Gemini CLI の組み込みコマンドは、各CLIに自前で辞書を作らせてここへはめ込む予定。
-    // それまでは未対応（空＝補完オフ）とする。
+    // Gemini CLI は公式廃止（Antigravity へ移行済み）。enum 値はデシリアライズ互換のため
+    // 残置しているが、新規辞書は追加しない（＝補完オフ）。
 
     private static readonly SlashCommandItem[] Empty = System.Array.Empty<SlashCommandItem>();
 
@@ -200,7 +200,7 @@ public static class SlashCommandCatalog
     {
         TerminalType.ClaudeCode => ClaudeCommands,
         TerminalType.CodexCLI => CodexCommands,
-        // TODO: Gemini は各CLI提供の辞書を追加したら分岐を復活させる。
+        // Gemini は廃止済みのため分岐なし（default で空＝補完オフ）。
         _ => Empty,
     };
 }


### PR DESCRIPTION
## 概要
改善候補調査（A: すぐ効く小改善）の実施。低リスク・挙動不変のクリーンアップ。

## 変更内容

### Gemini 廃止残骸（本当に古い部分のみ）
- `TerminalConstants.cs` — 実体のない `BuildGeminiArgs` を指す墓標コメントを削除
- `SlashCommandCatalog.cs` — 「Gemini 辞書を後で追加」「分岐を復活させる」という復活前提のコメントを、公式廃止（Antigravity 移行済み）の実態に合わせて修正

### 無言 catch の意図明示（挙動は不変）
既存作法（`// JSDisconnectedException等は無視`）に揃え、空 catch を「意図的な握りつぶし」と分かるようコメント付与:
- 音声 Push-to-Talk バインド/アンバインド（`TextInputPanel.razor`）
- スラッシュ補完・編集入力のフォーカス復帰（`TextInputPanel` / `BottomPanel`）
- クリップボードコピー（`SettingsDialog`）
- Dispose 経路の JSDisconnectedException 吸収（`BottomPanel` / `Root`）
- Git の `process.Kill()` 失敗（`GitService`）

## あえて残した判断
- Gemini の**説明コメント**（未登録理由・default 分岐・UI 非表示理由）は、enum を互換で残す意図的設計の documentation なので残置
- `SlashCommandCatalog` の TODO(将来: 自作コマンド走査) は Gemini 無関係の正当な未実装機能なので残置

## 検証
Release ビルド 0警告 / 0エラー。7ファイル・+13/−15行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)