### PR TITLE
diag: プロセス全体フリーズの診断プローブを追加しSerilogシンクをAsync化（実験）

### DIFF
--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -22,17 +22,20 @@ var logsFolder = AppDataPaths.GetLogsFolder(
 var logPath = Path.Combine(logsFolder, "terminalhub-.log");
 builder.Host.UseSerilog((context, configuration) =>
 {
+    // シンクは Async でラップする（フリーズ調査の実験を兼ねた対策）。
+    // 同期シンクだと、コンソールの QuickEdit（画面上のテキスト選択）やディスク停滞で
+    // ログを書く全スレッドが巻き添えブロックし、プロセス全体フリーズの形になる。
     configuration
         .ReadFrom.Configuration(context.Configuration)
         .Enrich.FromLogContext()
-        .WriteTo.Console()
-        .WriteTo.File(
+        .WriteTo.Async(a => a.Console())
+        .WriteTo.Async(a => a.File(
             logPath,
             rollingInterval: RollingInterval.Day,
             retainedFileCountLimit: 7,
             fileSizeLimitBytes: 10 * 1024 * 1024, // 10MB
             rollOnFileSizeLimit: true,
-            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}");
+            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}"));
 });
 
 // Add services to the container.
@@ -97,6 +100,9 @@ builder.Services.AddScoped<IStorageServiceFactory, StorageServiceFactory>();
 // メモ編集履歴の自動スナップショットサービス (10分毎)
 builder.Services.AddSingleton<MemoSnapshotService>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<MemoSnapshotService>());
+
+// プロセス全体フリーズの診断プローブ（実験コード。原因特定後に撤去予定）
+builder.Services.AddHostedService<FreezeProbeService>();
 
 // NotificationServiceを登録
 builder.Services.AddScoped<INotificationService, NotificationService>();

--- a/TerminalHub/Services/FreezeProbeService.cs
+++ b/TerminalHub/Services/FreezeProbeService.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// プロセス全体フリーズの診断用プローブ（実験コード）。
+    ///
+    /// 背景: 2026-07-17 に「全ログ沈黙＋リクエスト受付停止」が数秒〜十数秒続く
+    /// フリーズを2回観測（17:54 に8.3秒、18:50 に11.9秒）。原因候補は
+    /// ①同期ログシンクの巻き添えブロック ②GC長時間ポーズ ③ThreadPool枯渇。
+    ///
+    /// 2種類のプローブで犯人を切り分ける:
+    /// - 専用スレッドプローブ: ThreadPool に依存しない Thread.Sleep ループ。
+    ///   ここが止まる = GC / OSサスペンド級のプロセス全体停止
+    /// - ThreadPoolプローブ: Task.Delay ループ。専用スレッドが無事なのに
+    ///   こちらだけ遅れる = ThreadPool 枯渇
+    ///
+    /// 遅延検知時に GC.GetTotalPauseDuration の差分を添えるので、
+    /// 停止時間 ≒ GCポーズ差分 なら犯人はGC、そうでなければ別要因と判定できる。
+    /// 平常時は起動時の1行以外何も出力しない。
+    /// </summary>
+    public class FreezeProbeService : IHostedService, IDisposable
+    {
+        // ティック間隔と、これを超えたら記録する閾値（体感できる遅さより十分小さく）
+        private static readonly TimeSpan Interval = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan StallThreshold = TimeSpan.FromSeconds(2.5);
+
+        private readonly ILogger<FreezeProbeService> _logger;
+        private readonly CancellationTokenSource _cts = new();
+        private Thread? _dedicatedThread;
+        private Task? _threadPoolTask;
+
+        public FreezeProbeService(ILogger<FreezeProbeService> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("[FreezeProbe] 起動: 間隔={IntervalSec}s, 閾値={ThresholdSec}s", Interval.TotalSeconds, StallThreshold.TotalSeconds);
+
+            _dedicatedThread = new Thread(() => ProbeLoopDedicated(_cts.Token))
+            {
+                IsBackground = true,
+                Name = "FreezeProbe-Dedicated",
+                // GC/OS停止の検出専用。優先度を上げてスケジューラ起因の誤検知を減らす
+                Priority = ThreadPriority.AboveNormal,
+            };
+            _dedicatedThread.Start();
+
+            _threadPoolTask = Task.Run(() => ProbeLoopThreadPoolAsync(_cts.Token), CancellationToken.None);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>専用スレッドプローブ: ここの停止はプロセス全体の停止（GC/OS）を意味する</summary>
+        private void ProbeLoopDedicated(CancellationToken token)
+        {
+            var sw = Stopwatch.StartNew();
+            var lastGcPause = GC.GetTotalPauseDuration();
+
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    Thread.Sleep(Interval);
+                }
+                catch (ThreadInterruptedException)
+                {
+                    return;
+                }
+
+                var elapsed = sw.Elapsed;
+                sw.Restart();
+                var gcPause = GC.GetTotalPauseDuration();
+
+                if (elapsed > StallThreshold)
+                {
+                    var gcDelta = gcPause - lastGcPause;
+                    _logger.LogWarning(
+                        "[FreezeProbe] 専用スレッド停止検出: 停止={StallSec:F1}s (開始≒{StallStart:HH:mm:ss.fff}), GCポーズ差分={GcPauseSec:F1}s, Gen0/1/2={Gen0}/{Gen1}/{Gen2}, ThreadPool待機={Pending}, スレッド数={Threads}",
+                        elapsed.TotalSeconds,
+                        DateTime.Now - elapsed,
+                        gcDelta.TotalSeconds,
+                        GC.CollectionCount(0), GC.CollectionCount(1), GC.CollectionCount(2),
+                        ThreadPool.PendingWorkItemCount,
+                        ThreadPool.ThreadCount);
+                }
+
+                lastGcPause = gcPause;
+            }
+        }
+
+        /// <summary>ThreadPoolプローブ: 専用スレッドが無事でここだけ遅れる = ThreadPool枯渇</summary>
+        private async Task ProbeLoopThreadPoolAsync(CancellationToken token)
+        {
+            var sw = Stopwatch.StartNew();
+
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(Interval, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                var elapsed = sw.Elapsed;
+                sw.Restart();
+
+                if (elapsed > StallThreshold)
+                {
+                    _logger.LogWarning(
+                        "[FreezeProbe] ThreadPool遅延検出: 遅延={StallSec:F1}s (開始≒{StallStart:HH:mm:ss.fff}), ThreadPool待機={Pending}, スレッド数={Threads}",
+                        elapsed.TotalSeconds,
+                        DateTime.Now - elapsed,
+                        ThreadPool.PendingWorkItemCount,
+                        ThreadPool.ThreadCount);
+                }
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _cts.Cancel();
+            _dedicatedThread?.Interrupt();
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            _cts.Dispose();
+        }
+    }
+}

--- a/TerminalHub/TerminalHub.csproj
+++ b/TerminalHub/TerminalHub.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## 背景

2026-07-17 の本番ログで「全ログ沈黙＋リクエスト受付停止」が数秒〜十数秒続くプロセス全体フリーズを2回観測した。

| 時刻 | 長さ | 状況 |
|------|------|------|
| 17:54:16 | 8.3秒 | セッション切替中（バッファ書き込み開始→完了の間で全ログ沈黙） |
| 18:50:58 | 11.9秒 | 送信ボタン押下時。解凍15ms後に HandleTextInputSend が実行され、溜まった hook POST が3連発で流入（=Kestrelごと停止していた証拠）。ユーザーの体感遅延と完全一致 |

通常時のセッション切替は中央値9ms/最悪258ms（241回）で、特定処理の遅さではなくプロセス全体の停止。原因候補は ①同期ログシンクの巻き添えブロック ②GC長時間ポーズ ③ThreadPool枯渇。

## 変更内容（実験コード。原因特定後に撤去予定）

### FreezeProbeService（新規）
二重プローブで犯人を切り分ける:
- **専用スレッドプローブ**: ThreadPool 非依存の `Thread.Sleep` 1秒ループ。停止=GC/OSレベルの全体停止
- **ThreadPoolプローブ**: `Task.Delay` 1秒ループ。専用スレッド無事でこちらだけ遅延=ThreadPool枯渇

2.5秒超の遅延検知時のみ WARN で「停止時間・停止開始時刻・GCポーズ差分（`GC.GetTotalPauseDuration`）・Gen0/1/2回数・ThreadPool待機数」を記録。停止時間≒GCポーズ差分ならGC確定。平常時は起動時の1行以外無出力。

### Serilog シンクの Async 化
`WriteTo.Console()` / `WriteTo.File(...)` を `WriteTo.Async(...)` でラップ（`Serilog.Sinks.Async` 追加)。同期シンクはコンソールの QuickEdit（画面上のテキスト選択）やディスク停滞でログを書く全スレッドを巻き添えにし、観測されたフリーズの形と一致するため、検証を兼ねた対策。

## 判定表（次のフリーズ時に `[FreezeProbe]` を grep）
- プローブ無言のまま体感が遅い → サーバー無実、ブラウザ/JS側
- 専用スレッド停止 + GCポーズ差分≒停止時間 → GC
- 専用スレッド停止 + GCポーズ差分ほぼゼロ → OSサスペンド/ページング等
- ThreadPool遅延のみ → ThreadPool枯渇

## 検証
- Release ビルド成功（0警告0エラー）
- 本番反映はマージ後にローカルビルド→インストール（ConPTY 検証の制約によりツール経由での実機起動確認はしない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)