### PR TITLE
fix: フォルダ作成失敗を無言で握りつぶさずダイアログに表示する

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -70,6 +70,12 @@
                             </ul>
                         </div>
                     </div>
+                    @if (!string.IsNullOrEmpty(folderErrorMessage))
+                    {
+                        <div class="alert alert-danger mt-2 mb-0 py-2 px-3" role="alert">
+                            <i class="bi bi-exclamation-triangle-fill me-1"></i>@folderErrorMessage
+                        </div>
+                    }
                 </div>
 
 
@@ -145,6 +151,9 @@
     // 保存先は AppSettings.SessionDefaults。値の発生源は本ダイアログに一元化する。
     private bool showCreateFolderDialog = false;
     private bool pendingSessionCreation = false;
+    // フォルダ作成に失敗したときにメインダイアログへ出すインラインエラー。
+    // 失敗を無言で握りつぶすと「押しても何も起きずダイアログが戻る」ように見えるため、理由を表示する。
+    private string? folderErrorMessage;
 
     public class SessionCreateResult
     {
@@ -403,6 +412,9 @@
 
     private async Task CreateSession()
     {
+        // 再試行時は前回のエラー表示をクリア
+        folderErrorMessage = null;
+
         // フォルダが存在するかチェック
         if (!Directory.Exists(folderPath))
         {
@@ -457,7 +469,9 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, $"Failed to create folder: {folderPath}");
-            // エラーが発生した場合もダイアログを閉じる
+            // 失敗を無言で握りつぶさず、メインダイアログにエラー理由を表示して戻す。
+            // （例: ダブルクオートを含むパスは不正文字で ArgumentException になる）
+            folderErrorMessage = string.Format(L["SessionCreate.CreateFolder.ErrorFormat"], ex.Message);
             showCreateFolderDialog = false;
             pendingSessionCreation = false;
             StateHasChanged();
@@ -508,6 +522,7 @@
         await LoadLastUsedCliModes();
         showCreateFolderDialog = false;
         pendingSessionCreation = false;
+        folderErrorMessage = null;
     }
 
     private async Task OnTerminalTypeChanged(TerminalType newType)

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -322,6 +322,7 @@
   <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>Create Folder</value></data>
   <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>Create this folder?</value></data>
   <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>Create</value></data>
+  <data name="SessionCreate.CreateFolder.ErrorFormat" xml:space="preserve"><value>Failed to create the folder: {0}</value></data>
 
   <!-- SessionOptionsSelector: common -->
   <data name="SessionOptions.TerminalType.Label" xml:space="preserve"><value>Terminal type</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -322,6 +322,7 @@
   <data name="SessionCreate.CreateFolder.Title" xml:space="preserve"><value>フォルダの作成</value></data>
   <data name="SessionCreate.CreateFolder.Question" xml:space="preserve"><value>このフォルダを作成しますか？</value></data>
   <data name="SessionCreate.CreateFolder.Confirm" xml:space="preserve"><value>作成する</value></data>
+  <data name="SessionCreate.CreateFolder.ErrorFormat" xml:space="preserve"><value>フォルダを作成できませんでした: {0}</value></data>
 
   <!-- SessionOptionsSelector: common -->
   <data name="SessionOptions.TerminalType.Label" xml:space="preserve"><value>ターミナルタイプ</value></data>


### PR DESCRIPTION
## 概要

新規セッションダイアログ（`SessionCreateDialog`）で、存在しないフォルダを作成する確認後に **フォルダ作成が失敗すると、何のフィードバックも出さずにダイアログが閉じて戻る**（＝無言リターン）挙動を修正する。

再現しやすい例: フォルダ欄にダブルクオート付きパス `"C:\path\x"` を入れて作成すると、不正文字（`"`）で `Directory.CreateDirectory` が `ArgumentException` を投げ、`ConfirmFolderCreation` の catch がそれを握りつぶしていた。

## 変更

- `ConfirmFolderCreation` の catch で失敗理由をメインダイアログ上部に赤いアラートとして表示（`folderErrorMessage`）。
- 再試行（Create 再押下）時と `ResetForm`（成功・キャンセル時）でエラー表示をクリア。
- ローカライズキー `SessionCreate.CreateFolder.ErrorFormat` を ja/en に追加。

## 補足

引用符付きパス自体を受理する対応（`Trim('"')`）は別タスクとして分離。本 PR は「失敗を無言にしない」ことに絞っている（権限不足など引用符以外の失敗にも効く）。

## テスト

Razor/リソースのビルドは 0 警告 / 0 エラーで確認済み（別出力先ビルド）。UI 動作確認は ConPty/対話UI の都合で実機にて行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)