### PR TITLE
diag: ThreadPool詰まりの犯人特定用にOperationProbeを追加しFreezeProbeを強化

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1303,6 +1303,9 @@
 
     private async Task SelectSession(Guid sessionId, bool forceReinit = false)
     {
+        // 実験: セッション切替（_switchLock 直列化・バッファ復元）が ThreadPool 詰まりに絡むかの計測（FreezeProbe と連動）
+        using var _op = OperationProbe.Track("SelectSession");
+
         // forceReinit=true の場合は同一セッションでも再初期化を通す。
         // これにより activeSessionId を一時的に null にする「null ダンス」を避け、
         // BottomPanel（および配下の ShellPanel タブ）が破棄されないようにする。
@@ -2714,6 +2717,9 @@
         HookNotification notification,
         bool permissionRequestRequiresUserInput)
     {
+        // 実験: Circuit 側の hook 処理（再描画/InvokeAsync）が ThreadPool 詰まりに絡むかの計測（FreezeProbe と連動）
+        using var _op = OperationProbe.Track($"OnHook:{notification.Event}");
+
         var eventType = notification.GetEventType();
         if (eventType == null) return;
 

--- a/TerminalHub/Services/ConPtyConnectionService.cs
+++ b/TerminalHub/Services/ConPtyConnectionService.cs
@@ -43,6 +43,8 @@ namespace TerminalHub.Services
         /// </summary>
         public void SubscribeToSession(Guid sessionId, ConPtySession conPtySession)
         {
+            // 実験: _subscriptionLock 待ちが ThreadPool 詰まりに絡むかの計測（FreezeProbe と連動）
+            using var _op = OperationProbe.Track("Subscribe");
             lock (_subscriptionLock)
             {
                 if (Volatile.Read(ref _disposeState) != 0)

--- a/TerminalHub/Services/FreezeProbeService.cs
+++ b/TerminalHub/Services/FreezeProbeService.cs
@@ -30,9 +30,12 @@ namespace TerminalHub.Services
         private Thread? _dedicatedThread;
         private Task? _threadPoolTask;
 
-        public FreezeProbeService(ILogger<FreezeProbeService> logger)
+        public FreezeProbeService(ILogger<FreezeProbeService> logger, ILoggerFactory loggerFactory)
         {
             _logger = logger;
+            // 「詰まっている間に何が実行中だったか」を撮る OperationProbe に、専用カテゴリの
+            // ロガーを渡す（[OpProbe] 行として grep しやすくする）。
+            OperationProbe.SetLogger(loggerFactory.CreateLogger("TerminalHub.Diagnostics.OperationProbe"));
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
@@ -77,13 +80,14 @@ namespace TerminalHub.Services
                 {
                     var gcDelta = gcPause - lastGcPause;
                     _logger.LogWarning(
-                        "[FreezeProbe] 専用スレッド停止検出: 停止={StallSec:F1}s (開始≒{StallStart:HH:mm:ss.fff}), GCポーズ差分={GcPauseSec:F1}s, Gen0/1/2={Gen0}/{Gen1}/{Gen2}, ThreadPool待機={Pending}, スレッド数={Threads}",
+                        "[FreezeProbe] 専用スレッド停止検出: 停止={StallSec:F1}s (開始≒{StallStart:HH:mm:ss.fff}), GCポーズ差分={GcPauseSec:F1}s, Gen0/1/2={Gen0}/{Gen1}/{Gen2}, ThreadPool待機={Pending}, スレッド数={Threads}, 実行中=[{InFlight}]",
                         elapsed.TotalSeconds,
                         DateTime.Now - elapsed,
                         gcDelta.TotalSeconds,
                         GC.CollectionCount(0), GC.CollectionCount(1), GC.CollectionCount(2),
                         ThreadPool.PendingWorkItemCount,
-                        ThreadPool.ThreadCount);
+                        ThreadPool.ThreadCount,
+                        OperationProbe.DumpInFlight());
                 }
 
                 lastGcPause = gcPause;
@@ -94,6 +98,7 @@ namespace TerminalHub.Services
         private async Task ProbeLoopThreadPoolAsync(CancellationToken token)
         {
             var sw = Stopwatch.StartNew();
+            var lastCompleted = ThreadPool.CompletedWorkItemCount;
 
             while (!token.IsCancellationRequested)
             {
@@ -109,14 +114,29 @@ namespace TerminalHub.Services
                 var elapsed = sw.Elapsed;
                 sw.Restart();
 
+                // 直近tickでの完了スループット（starvation中はほぼ0まで落ちる＝全ワーカーがブロック中の証拠）
+                var completed = ThreadPool.CompletedWorkItemCount;
+                var completedDelta = completed - lastCompleted;
+                lastCompleted = completed;
+
                 if (elapsed > StallThreshold)
                 {
+                    // ワーカースレッドの逼迫度: max - available = 使用中ワーカー
+                    ThreadPool.GetMaxThreads(out var maxWorkers, out _);
+                    ThreadPool.GetAvailableThreads(out var availWorkers, out _);
+                    ThreadPool.GetMinThreads(out var minWorkers, out _);
+
                     _logger.LogWarning(
-                        "[FreezeProbe] ThreadPool遅延検出: 遅延={StallSec:F1}s (開始≒{StallStart:HH:mm:ss.fff}), ThreadPool待機={Pending}, スレッド数={Threads}",
+                        "[FreezeProbe] ThreadPool遅延検出: 遅延={StallSec:F1}s (開始≒{StallStart:HH:mm:ss.fff}), ThreadPool待機={Pending}, 完了スループット={Throughput:F0}/s, 使用中ワーカー={BusyWorkers}/{MaxWorkers}(min={MinWorkers}), スレッド数={Threads}, 実行中=[{InFlight}]",
                         elapsed.TotalSeconds,
                         DateTime.Now - elapsed,
                         ThreadPool.PendingWorkItemCount,
-                        ThreadPool.ThreadCount);
+                        completedDelta / elapsed.TotalSeconds,
+                        maxWorkers - availWorkers,
+                        maxWorkers,
+                        minWorkers,
+                        ThreadPool.ThreadCount,
+                        OperationProbe.DumpInFlight());
                 }
             }
         }

--- a/TerminalHub/Services/FreezeProbeService.cs
+++ b/TerminalHub/Services/FreezeProbeService.cs
@@ -25,14 +25,25 @@ namespace TerminalHub.Services
         private static readonly TimeSpan Interval = TimeSpan.FromSeconds(1);
         private static readonly TimeSpan StallThreshold = TimeSpan.FromSeconds(2.5);
 
+        // 定期ゲージ（蓄積リーク検出用）の出力間隔。購読者数などが増え続けないか監視する。
+        private static readonly TimeSpan GaugeInterval = TimeSpan.FromSeconds(60);
+
         private readonly ILogger<FreezeProbeService> _logger;
+        private readonly IHookNotificationService _hookNotificationService;
+        private readonly ISessionManager _sessionManager;
         private readonly CancellationTokenSource _cts = new();
         private Thread? _dedicatedThread;
         private Task? _threadPoolTask;
 
-        public FreezeProbeService(ILogger<FreezeProbeService> logger, ILoggerFactory loggerFactory)
+        public FreezeProbeService(
+            ILogger<FreezeProbeService> logger,
+            ILoggerFactory loggerFactory,
+            IHookNotificationService hookNotificationService,
+            ISessionManager sessionManager)
         {
             _logger = logger;
+            _hookNotificationService = hookNotificationService;
+            _sessionManager = sessionManager;
             // 「詰まっている間に何が実行中だったか」を撮る OperationProbe に、専用カテゴリの
             // ロガーを渡す（[OpProbe] 行として grep しやすくする）。
             OperationProbe.SetLogger(loggerFactory.CreateLogger("TerminalHub.Diagnostics.OperationProbe"));
@@ -99,6 +110,7 @@ namespace TerminalHub.Services
         {
             var sw = Stopwatch.StartNew();
             var lastCompleted = ThreadPool.CompletedWorkItemCount;
+            var lastGauge = Stopwatch.StartNew();
 
             while (!token.IsCancellationRequested)
             {
@@ -113,6 +125,14 @@ namespace TerminalHub.Services
 
                 var elapsed = sw.Elapsed;
                 sw.Restart();
+
+                // 定期ゲージ: 増え続けたらリーク。特に hook/sessions の購読者数は Circuit 破棄で
+                // 減るはずなので、単調増加＝Circuit が破棄されず購読が漏れている証拠になる。
+                if (lastGauge.Elapsed >= GaugeInterval)
+                {
+                    lastGauge.Restart();
+                    LogGauge();
+                }
 
                 // 直近tickでの完了スループット（starvation中はほぼ0まで落ちる＝全ワーカーがブロック中の証拠）
                 var completed = ThreadPool.CompletedWorkItemCount;
@@ -139,6 +159,33 @@ namespace TerminalHub.Services
                         OperationProbe.DumpInFlight());
                 }
             }
+        }
+
+        /// <summary>
+        /// 蓄積リーク検出用の定期ゲージ。単調増加する値があればそれが犯人候補。
+        /// hook購読/sessions変更購読は Circuit 破棄で減るはずなので、増え続けたら購読漏れ。
+        /// </summary>
+        private void LogGauge()
+        {
+            int procThreads;
+            try
+            {
+                procThreads = Process.GetCurrentProcess().Threads.Count;
+            }
+            catch
+            {
+                procThreads = -1; // 取得失敗時も落とさない
+            }
+
+            _logger.LogInformation(
+                "[FreezeProbe] 定期ゲージ: hook購読={HookSubs}, sessions変更購読={SessSubs}, セッション数={Sessions}, in-flight={InFlight}, ThreadPool待機={Pending}, ThreadPoolスレッド={TpThreads}, プロセススレッド={ProcThreads}",
+                _hookNotificationService.SubscriberCount,
+                _sessionManager.SessionsChangedSubscriberCount,
+                _sessionManager.GetAllSessions().Count(),
+                OperationProbe.InFlightCount,
+                ThreadPool.PendingWorkItemCount,
+                ThreadPool.ThreadCount,
+                procThreads);
         }
 
         public Task StopAsync(CancellationToken cancellationToken)

--- a/TerminalHub/Services/FreezeProbeService.cs
+++ b/TerminalHub/Services/FreezeProbeService.cs
@@ -17,7 +17,7 @@ namespace TerminalHub.Services
     ///
     /// 遅延検知時に GC.GetTotalPauseDuration の差分を添えるので、
     /// 停止時間 ≒ GCポーズ差分 なら犯人はGC、そうでなければ別要因と判定できる。
-    /// 平常時は起動時の1行以外何も出力しない。
+    /// 平常時の出力は起動時の1行と、60秒毎の定期ゲージ（蓄積リーク監視）のみ。
     /// </summary>
     public class FreezeProbeService : IHostedService, IDisposable
     {
@@ -170,7 +170,9 @@ namespace TerminalHub.Services
             int procThreads;
             try
             {
-                procThreads = Process.GetCurrentProcess().Threads.Count;
+                // Process はハンドルを保持するので使い捨てにする（プローブ自身がハンドルを溜めないため）
+                using var proc = Process.GetCurrentProcess();
+                procThreads = proc.Threads.Count;
             }
             catch
             {

--- a/TerminalHub/Services/HookNotificationService.cs
+++ b/TerminalHub/Services/HookNotificationService.cs
@@ -65,6 +65,9 @@ public class HookNotificationService : IHookNotificationService
 
     public async Task HandleHookNotificationAsync(HookNotification notification)
     {
+        // 実験: 多セッション同時 hook 連打での ThreadPool 詰まり調査用の計測（FreezeProbe と連動）。
+        using var _op = OperationProbe.Track($"Hook:{notification.Event}");
+
         var eventType = notification.GetEventType();
         if (eventType == null)
         {

--- a/TerminalHub/Services/HookNotificationService.cs
+++ b/TerminalHub/Services/HookNotificationService.cs
@@ -17,6 +17,12 @@ public interface IHookNotificationService
     /// 通知イベントを登録する
     /// </summary>
     event EventHandler<HookNotificationEventArgs>? OnHookNotification;
+
+    /// <summary>
+    /// 診断用: OnHookNotification の購読者数。Root(Circuit)が破棄で解除するはずなので、
+    /// これが時間とともに増え続ける＝Circuit が破棄されず購読が漏れている（リーク）証拠。
+    /// </summary>
+    int SubscriberCount { get; }
 }
 
 /// <summary>
@@ -48,6 +54,9 @@ public class HookNotificationService : IHookNotificationService
     private readonly ISessionRepository _sessionRepository;
 
     public event EventHandler<HookNotificationEventArgs>? OnHookNotification;
+
+    // 診断用: 購読者数（GetInvocationList は宣言クラス内でのみ呼べるためここで公開する）
+    public int SubscriberCount => OnHookNotification?.GetInvocationList()?.Length ?? 0;
 
     public HookNotificationService(
         ILogger<HookNotificationService> logger,

--- a/TerminalHub/Services/OperationProbe.cs
+++ b/TerminalHub/Services/OperationProbe.cs
@@ -26,6 +26,9 @@ namespace TerminalHub.Services
         // 単発の処理がこの時間を超えて完了したら、その場で遅い処理として記録する
         private static readonly TimeSpan SlowOpThreshold = TimeSpan.FromSeconds(1.0);
 
+        /// <summary>現在実行中(in-flight)の追跡数。定期ゲージでの監視用。</summary>
+        public static int InFlightCount => InFlight.Count;
+
         /// <summary>FreezeProbe 起動時に一度だけ設定する。未設定でも Track 自体は動く。</summary>
         public static void SetLogger(ILogger logger) => _logger = logger;
 

--- a/TerminalHub/Services/OperationProbe.cs
+++ b/TerminalHub/Services/OperationProbe.cs
@@ -1,0 +1,79 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// 「反応が重い / 詰まる」調査用の軽量オペレーショントラッカー（実験コード）。
+    ///
+    /// 背景: FreezeProbe は「ThreadPool が遅れた事実・待機数・GC差分」までは出せるが、
+    /// 「その間どの処理が実行中でスレッドを握っていたか」が分からない。starvation の犯人を
+    /// 特定するには、ホットパスを <see cref="Track"/> で囲み、
+    /// (1) 単発で閾値超に遅い処理はその場で WARN、
+    /// (2) FreezeProbe がストール検知した瞬間に実行中(in-flight)の一覧をダンプする、の2つで攻める。
+    ///
+    /// 設計方針: 平常時はほぼゼロコスト（ConcurrentDictionary への add/remove と Dispose 時の経過判定のみ）。
+    /// ロガー未設定でも安全に動く（SetLogger 前は WARN を出さないだけ）。
+    /// </summary>
+    public static class OperationProbe
+    {
+        private sealed record Entry(string Name, long StartTimestamp, int ThreadId);
+
+        private static readonly ConcurrentDictionary<long, Entry> InFlight = new();
+        private static long _seq;
+        private static ILogger? _logger;
+
+        // 単発の処理がこの時間を超えて完了したら、その場で遅い処理として記録する
+        private static readonly TimeSpan SlowOpThreshold = TimeSpan.FromSeconds(1.0);
+
+        /// <summary>FreezeProbe 起動時に一度だけ設定する。未設定でも Track 自体は動く。</summary>
+        public static void SetLogger(ILogger logger) => _logger = logger;
+
+        /// <summary>
+        /// 処理を計測開始する。戻り値を using で受けると、スコープを抜けた時点で完了扱いになる。
+        /// 例: <c>using var _ = OperationProbe.Track("HookNotification:Stop");</c>
+        /// </summary>
+        public static Scope Track(string name)
+        {
+            var id = Interlocked.Increment(ref _seq);
+            InFlight[id] = new Entry(name, Stopwatch.GetTimestamp(), Environment.CurrentManagedThreadId);
+            return new Scope(id);
+        }
+
+        private static void Complete(long id)
+        {
+            if (!InFlight.TryRemove(id, out var e)) return;
+            var elapsed = Stopwatch.GetElapsedTime(e.StartTimestamp);
+            if (elapsed >= SlowOpThreshold)
+            {
+                _logger?.LogWarning(
+                    "[OpProbe] 遅い処理: {Name} = {Ms}ms (thread={ThreadId})",
+                    e.Name, (long)elapsed.TotalMilliseconds, e.ThreadId);
+            }
+        }
+
+        /// <summary>
+        /// 現在実行中の処理を経過時間の長い順に最大 <paramref name="max"/> 件、1行文字列で返す。
+        /// FreezeProbe がストール検知時に添えて出す用。追跡対象が無ければその旨を返す。
+        /// </summary>
+        public static string DumpInFlight(int max = 8)
+        {
+            var snapshot = InFlight.Values
+                .Select(e => (e.Name, Ms: (long)Stopwatch.GetElapsedTime(e.StartTimestamp).TotalMilliseconds, e.ThreadId))
+                .OrderByDescending(x => x.Ms)
+                .Take(max)
+                .ToList();
+
+            if (snapshot.Count == 0) return "(実行中の追跡対象なし)";
+            return string.Join(", ", snapshot.Select(x => $"{x.Name}:{x.Ms}ms(t{x.ThreadId})"));
+        }
+
+        /// <summary>Track の戻り値。Dispose で完了扱いにする。</summary>
+        public readonly struct Scope : IDisposable
+        {
+            private readonly long _id;
+            internal Scope(long id) => _id = id;
+            public void Dispose() => Complete(_id);
+        }
+    }
+}

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -16,6 +16,12 @@ namespace TerminalHub.Services
         /// </summary>
         event EventHandler? OnSessionsChanged;
 
+        /// <summary>
+        /// 診断用: OnSessionsChanged の購読者数。Circuit 破棄で解除されるはずで、
+        /// 増え続ける＝購読漏れ（Circuit リーク）の証拠。
+        /// </summary>
+        int SessionsChangedSubscriberCount { get; }
+
         Task<SessionInfo> CreateSessionAsync(string folderPath, string sessionName, TerminalType terminalType, Dictionary<string, string> options);
         Task<SessionInfo> CreateSessionAsync(Guid sessionGuid, string folderPath, string sessionName, TerminalType terminalType, Dictionary<string, string> options, bool skipGitInfo = false);
 
@@ -105,6 +111,9 @@ namespace TerminalHub.Services
         /// セッションが変更されたときに発火するイベント
         /// </summary>
         public event EventHandler? OnSessionsChanged;
+
+        // 診断用: 購読者数（GetInvocationList は宣言クラス内でのみ呼べるためここで公開する）
+        public int SessionsChangedSubscriberCount => OnSessionsChanged?.GetInvocationList()?.Length ?? 0;
 
         public SessionManager(IConPtyService conPtyService, ILogger<SessionManager> logger, IConfiguration configuration, IGitService gitService, IClaudeHookService? claudeHookService = null, IAppSettingsService? appSettingsService = null, IServer? server = null, ICodexHookService? codexHookService = null, IRawStreamCaptureService? rawStreamCapture = null, IMcpConfigService? mcpConfigService = null)
         {

--- a/TerminalHub/Services/SqliteStorageService.cs
+++ b/TerminalHub/Services/SqliteStorageService.cs
@@ -34,6 +34,8 @@ namespace TerminalHub.Services
 
         public async Task SaveSessionAsync(SessionInfo session)
         {
+            // 実験: DB 書き込みが ThreadPool 詰まりに絡むかの計測（FreezeProbe と連動）
+            using var _op = OperationProbe.Track("SaveSession");
             await _repository.SaveSessionAsync(session);
         }
 


### PR DESCRIPTION
## 背景

2026-07-21 06:09 頃の「反応が重い」を本番ログで調査した結果:

- 06:06〜06:12 に **ThreadPool 遅延プローブが連続発火**（最悪 06:09:06 起点で **9.6s**、待機キュー 48〜57）。
- **専用スレッド停止プローブは0件** → GC 等の stop-the-world / 全体フリーズではなく **ThreadPool starvation（飽和）**。
- 06:09:07 の3行 → **8.7秒完全無音** → 復帰後に `SelectSession` バッファ書き込み＋`Subscribe` が5セッション分フラッシュ。
- 当時 **Claude 5セッションが同時に hook 連打**（計56 POST/8分）＋各 Webhook ファンアウト。

従来の FreezeProbe は「遅延の事実・待機数・GC差分」までは出せるが、**「詰まっている間どの処理がスレッドを握っていたか」が撮れず犯人が分からない**。そこを強化する。

## 変更

### 新規 `OperationProbe`（`Services/OperationProbe.cs`）
実行中(in-flight)処理の軽量トラッカー。`using var _ = OperationProbe.Track("名前")` で囲むと:
- 単発で1秒超の処理はその場で `[OpProbe] 遅い処理: <名前> = <ms>ms` を WARN
- FreezeProbe がストール検知した瞬間に**実行中一覧をダンプ**

平常時は `ConcurrentDictionary` の add/remove と Dispose 時の経過判定のみ（ほぼゼロコスト）。ロガー未設定でも安全。

### `FreezeProbeService` 強化
ストール検知ログに追加:
- `完了スループット=/s`（starvation 中は全ワーカーがブロックで ≒0 に落ちる）
- `使用中ワーカー=busy/max(min=)`（プールが天井か）
- `実行中=[...]`（in-flight ダンプ、専用スレッド側にも追加）

### 計測を仕込んだチョークポイント（06:09 の主役）
- `HookNotificationService.HandleHookNotificationAsync` → `Hook:<Event>`
- `Root.OnHookNotification`（Circuit 側の再描画） → `OnHook:<Event>`
- `Root.SelectSession`（`_switchLock` 直列化） → `SelectSession`
- `ConPtyConnectionService.SubscribeToSession`（`_subscriptionLock`） → `Subscribe`
- `SqliteStorageService.SaveSessionAsync`（DB 書き込み） → `SaveSession`

## 位置づけ

実験的な診断コード（#161 の FreezeProbe と同系統）。静的調査では致命的な `.Result`/`GetResult()` は無く、実測でしか犯人を撮れないための計装。実データはプレビュー版を常用して収集する。

## テスト

ビルド 0 警告 / 0 エラー（別出力先ビルドで確認）。挙動を変えない計装のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)