### PR TITLE
feat: ダブルクォートで囲まれたフォルダパスでもセッション作成を受理する

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -415,6 +415,11 @@
         // 再試行時は前回のエラー表示をクリア
         folderErrorMessage = null;
 
+        // 貼り付け由来の前後クォート（"C:\path\x"）を剥がす。剥がさないと Directory.Exists が
+        // false になり、相対パス扱いでベースディレクトリに連結され不正パスで失敗する。
+        // 書き戻して UI 表示・確認ダイアログ・作成・結果すべてをクリーンな値で揃える。
+        folderPath = PathInputHelper.NormalizeFolderInput(folderPath);
+
         // フォルダが存在するかチェック
         if (!Directory.Exists(folderPath))
         {

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -558,8 +558,9 @@
                         _ => ""
                     }
                     : availableWorktrees?.FirstOrDefault(w => w.Path == selectedWorktreePath)?.BranchName ?? "",
+                // NewFolder は手入力なので貼り付け由来の前後クォートを剥がす（Existing はドロップダウン選択なので不要）
                 WorktreePath = activeTab == TabType.Existing ? selectedWorktreePath :
-                               activeTab == TabType.NewFolder ? newFolderPath : null,
+                               activeTab == TabType.NewFolder ? PathInputHelper.NormalizeFolderInput(newFolderPath) : null,
                 TerminalType = selectedTerminalType,
                 Options = activeTab switch
                 {

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -535,6 +535,13 @@
         if (!CanProcess)
             return;
 
+        // NewFolder は手入力なので、貼り付け由来の前後クォートを剥がしてフィールドへ書き戻す。
+        // これで以降の表示・結果すべてがクリーンな値で揃う（SessionCreateDialog と同じ方式）。
+        if (activeTab == TabType.NewFolder)
+        {
+            newFolderPath = PathInputHelper.NormalizeFolderInput(newFolderPath);
+        }
+
         isProcessing = true;
         errorMessage = "";
 
@@ -558,9 +565,9 @@
                         _ => ""
                     }
                     : availableWorktrees?.FirstOrDefault(w => w.Path == selectedWorktreePath)?.BranchName ?? "",
-                // NewFolder は手入力なので貼り付け由来の前後クォートを剥がす（Existing はドロップダウン選択なので不要）
+                // NewFolder の newFolderPath は ProcessOperation 冒頭で正規化済み（Existing はドロップダウン選択）
                 WorktreePath = activeTab == TabType.Existing ? selectedWorktreePath :
-                               activeTab == TabType.NewFolder ? PathInputHelper.NormalizeFolderInput(newFolderPath) : null,
+                               activeTab == TabType.NewFolder ? newFolderPath : null,
                 TerminalType = selectedTerminalType,
                 Options = activeTab switch
                 {

--- a/TerminalHub/Helpers/PathInputHelper.cs
+++ b/TerminalHub/Helpers/PathInputHelper.cs
@@ -1,0 +1,38 @@
+namespace TerminalHub.Helpers
+{
+    /// <summary>
+    /// フォルダパス入力欄の正規化。
+    ///
+    /// エクスプローラーの「パスのコピー」やターミナルからの貼り付けでは、パスが前後を
+    /// ダブルクォートで括られた形（"C:\path\x"）になることがある。これをそのまま扱うと
+    /// 先頭の <c>"</c> のせいで <see cref="System.IO.Directory.Exists(string)"/> が false になり、
+    /// さらに相対パス扱いでアプリのベースディレクトリに連結されて不正パスで失敗する
+    /// （例: ...\Programs\TerminalHub\"C:\Users\...\"）。入力段階でクォートを剥がして防ぐ。
+    /// </summary>
+    public static class PathInputHelper
+    {
+        /// <summary>
+        /// 前後の空白を除き、対で括るクォート（" または '）が付いていれば1組だけ剥がす。
+        /// 剥がした後も前後の空白を除く（" C:\x " のようなケース対応）。
+        /// null/空白のみは空文字を返す。
+        /// </summary>
+        public static string NormalizeFolderInput(string? input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return string.Empty;
+            }
+
+            var s = input.Trim();
+
+            // 前後が対で括られている場合のみ剥がす（片側だけのクォートは触らない）
+            if (s.Length >= 2 &&
+                ((s[0] == '"' && s[^1] == '"') || (s[0] == '\'' && s[^1] == '\'')))
+            {
+                s = s.Substring(1, s.Length - 2).Trim();
+            }
+
+            return s;
+        }
+    }
+}


### PR DESCRIPTION
## 概要

新規セッション/サブセッション作成のフォルダ入力欄に、**前後をダブルクォートで括ったパス**（`"C:\path\x"`）を貼り付けても受理できるようにする。

### 従来の問題
エクスプローラーの「パスのコピー」やターミナルからの貼り付けは `"C:\...\"` 形式になる。従来はそのまま扱っていたため:
- 先頭の `"` で `Directory.Exists` が false
- さらに相対パス扱いでアプリのベースディレクトリに連結され、不正パスで失敗

実際のエラー（#163 の無言リターン解消で可視化された）:
```
フォルダを作成できませんでした: ... : 'C:\Users\info\AppData\Local\Programs\TerminalHub\"C:\Users\info\source\repos\TerminalHub\"'
```

## 変更

- **`Helpers/PathInputHelper.NormalizeFolderInput`** を新設。前後が**対で括るクォート**（`"` または `'`）を1組だけ剥がし、前後空白も除く。片側だけ/中間のクォートや末尾区切りは触らないので、既存の正常パスには無影響。
- **`SessionCreateDialog.CreateSession`**: 冒頭で正規化して `folderPath` に**書き戻し**、UI表示・フォルダ作成確認ダイアログ・作成・結果すべてをクリーンな値で揃える。
- **`SubSessionDialog`（NewFolder タブ）**: `WorktreePath` 構築時に正規化（Existing タブはドロップダウン選択なので対象外）。

MCP/リモート起動等の programmatic 経路は引用符が付かないため対象外（手入力の入口のみ正規化）。

## テスト

- ビルド 0警告 / 0エラー。
- 実機確認済み: `"C:\Users\info\source\repos\TerminalHub"` を貼り付け → クォートが剥がれ既存フォルダとして認識され、そのままセッション作成できることを確認。

#163（無言リターン解消）と合わせ、貼り付けパスがそのまま通り、失敗時も理由が出る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)