### PR TITLE
feat: スラッシュ補完でMCPツール由来コマンドを既定で隠す

### DIFF
--- a/TerminalHub.Terminal.Tests/SlashCommandFilterTests.cs
+++ b/TerminalHub.Terminal.Tests/SlashCommandFilterTests.cs
@@ -1,0 +1,102 @@
+using TerminalHub.Services;
+using Xunit;
+
+namespace TerminalHub.Terminal.Tests;
+
+/// <summary>
+/// <see cref="SlashCommandFilter"/> のテスト。
+/// 背景: MCP を接続していると slash_commands に MCP ツール由来の <c>mcp__server__tool</c> が
+/// 丸ごと載り、素の <c>/mcp</c> を打っただけで前方一致で混ざって組み込みコマンドを押し出す。
+/// 「検索語に <c>__</c> があるときだけ MCP ツールを出す」住み分けを検証する。
+/// </summary>
+public class SlashCommandFilterTests
+{
+    private static readonly SlashCommandItem[] Catalog =
+    {
+        new("/mcp", "Manage MCP server connections"),
+        new("/memory", "Edit memory files"),
+        new("/mcp__conoha-vps-mcp__create_server", null),
+        new("/mcp__conoha-vps-mcp__delete_server", null),
+        new("/clear", "Start a new conversation"),
+    };
+
+    [Fact]
+    public void 素のmcp検索ではMCPツール由来が混ざらない()
+    {
+        var result = SlashCommandFilter.Filter(Catalog, "mcp");
+
+        Assert.Equal(new[] { "/mcp" }, result.Select(x => x.Name));
+    }
+
+    [Fact]
+    public void アンダースコア2つを打てばMCPツール由来が出る()
+    {
+        var result = SlashCommandFilter.Filter(Catalog, "mcp__");
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, x => Assert.StartsWith("/mcp__", x.Name));
+    }
+
+    [Fact]
+    public void サーバー名側からでもアンダースコア2つがあれば掘れる()
+    {
+        var result = SlashCommandFilter.Filter(Catalog, "conoha-vps-mcp__");
+
+        Assert.Equal(2, result.Count); // 中間一致
+    }
+
+    [Fact]
+    public void 検索語が空でもMCPツール由来は出ない()
+    {
+        var result = SlashCommandFilter.Filter(Catalog, "");
+
+        Assert.DoesNotContain(result, x => SlashCommandFilter.IsMcpToolCommand(x.Name));
+        Assert.Equal(3, result.Count); // mcp, memory, clear
+    }
+
+    [Fact]
+    public void MCPツール名の一部に一致してもアンダースコア無しなら出ない()
+    {
+        // "create" は /mcp__conoha-vps-mcp__create_server にしか一致しない
+        var result = SlashCommandFilter.Filter(Catalog, "create");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void 前方一致が中間一致より先に並ぶ()
+    {
+        var catalog = new[]
+        {
+            new SlashCommandItem("/ide", null),      // 中間一致（"de" が途中）
+            new SlashCommandItem("/debug", null),    // 前方一致
+        };
+
+        var result = SlashCommandFilter.Filter(catalog, "de");
+
+        Assert.Equal(new[] { "/debug", "/ide" }, result.Select(x => x.Name));
+    }
+
+    [Fact]
+    public void 上限件数で打ち切られる()
+    {
+        var catalog = Enumerable.Range(0, 20)
+            .Select(i => new SlashCommandItem($"/cmd{i:D2}", null))
+            .ToArray();
+
+        var result = SlashCommandFilter.Filter(catalog, "cmd");
+
+        Assert.Equal(SlashCommandFilter.MaxSuggestions, result.Count);
+    }
+
+    [Theory]
+    [InlineData("/mcp", false)]
+    [InlineData("/mcp__a__b", true)]
+    [InlineData("mcp__a__b", true)]   // "/" 無しでも判定できる
+    [InlineData("/MCP__A__B", true)]  // 大文字小文字を無視する
+    [InlineData("/memory", false)]
+    public void MCPツール判定(string name, bool expected)
+    {
+        Assert.Equal(expected, SlashCommandFilter.IsMcpToolCommand(name));
+    }
+}

--- a/TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj
+++ b/TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="..\TerminalHub\Services\CodexHookService.cs" Link="CodexHookService.cs" />
     <Compile Include="..\TerminalHub\Services\ConPtyWriteChunker.cs" Link="ConPtyWriteChunker.cs" />
     <Compile Include="..\TerminalHub\Services\SlashCommandMerge.cs" Link="SlashCommandMerge.cs" />
+    <Compile Include="..\TerminalHub\Services\SlashCommandFilter.cs" Link="SlashCommandFilter.cs" />
     <!-- CLI 出力解析器（UI 非依存の純ロジック）。テーブル駆動テスト用にリンク -->
     <Compile Include="..\TerminalHub\Helpers\AnsiHelper.cs" Link="AnsiHelper.cs" />
     <Compile Include="..\TerminalHub\Analyzers\IOutputAnalyzer.cs" Link="IOutputAnalyzer.cs" />

--- a/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
+++ b/TerminalHub/Components/Shared/BottomPanels/TextInputPanel.razor
@@ -340,7 +340,8 @@
     /// <summary>
     /// 現在の入力から補完候補を再計算する。
     /// 発火条件は「入力全体が "/" 始まりの単一トークン（空白・改行なし）」のときだけ。
-    /// マッチは名前（"/" を除く）に対する部分一致で、前方一致を優先してランク付けする。
+    /// 絞り込み・並べ替え（部分一致のランク付け、MCP ツール由来の除外、件数上限）は
+    /// 純粋ロジックの <see cref="SlashCommandFilter.Filter"/>（テスト対象）に委譲する。
     /// </summary>
     private void RecomputeSlashSuggestions()
     {
@@ -358,26 +359,7 @@
         var catalog = SlashCommandProvider.GetCommands(TerminalType);
         if (catalog.Count == 0) return;
 
-        var matches = new List<(SlashCommandItem Item, int Rank)>();
-        foreach (var item in catalog)
-        {
-            var nameNoSlash = item.Name.StartsWith("/") ? item.Name.Substring(1) : item.Name;
-            if (query.Length == 0)
-            {
-                matches.Add((item, 1));
-                continue;
-            }
-            var idx = nameNoSlash.IndexOf(query, StringComparison.OrdinalIgnoreCase);
-            if (idx < 0) continue;
-            matches.Add((item, idx == 0 ? 0 : 1)); // 前方一致=0, 中間一致=1
-        }
-
-        _slashSuggestions = matches
-            .OrderBy(m => m.Rank)
-            .ThenBy(m => m.Item.Name, StringComparer.OrdinalIgnoreCase)
-            .Select(m => m.Item)
-            .Take(8)
-            .ToList();
+        _slashSuggestions = SlashCommandFilter.Filter(catalog, query).ToList();
     }
 
     /// <summary>候補名のうち検索語に一致する部分を強調表示するため、前/一致/後に分割する。</summary>

--- a/TerminalHub/Services/SlashCommandFilter.cs
+++ b/TerminalHub/Services/SlashCommandFilter.cs
@@ -1,0 +1,68 @@
+namespace TerminalHub.Services;
+
+/// <summary>
+/// スラッシュコマンド補完の絞り込み・並べ替え（純粋ロジック。UI 非依存でテスト可能）。
+///
+/// MCP を接続していると、Claude Code の slash_commands には MCP ツール由来の
+/// <c>mcp__&lt;サーバー名&gt;__&lt;ツール名&gt;</c> が丸ごと載る（ユーザースコープの MCP も含む）。
+/// これらは補完から呼び出す機会がほとんど無いのに、素の <c>/mcp</c> を打っただけで
+/// 前方一致で大量に混ざり、本来出したい組み込みコマンドを押し出してしまう
+/// （候補は上限 8 件で打ち切るため、サーバーが増えるほど実害が出る）。
+///
+/// そこで MCP ツール由来だけ特別扱いし、**検索語に <c>__</c> が含まれるとき＝
+/// 利用者が明示的に MCP ツールを掘りに行ったときだけ**候補に出す。
+/// 素の <c>/mcp</c> では組み込みの <c>/mcp</c> だけが出て、<c>/mcp__</c> まで打てば
+/// ツール一覧が出る、という住み分けになる（＝到達不能にはしない）。
+/// </summary>
+public static class SlashCommandFilter
+{
+    /// <summary>補完ポップアップに出す候補の上限。</summary>
+    public const int MaxSuggestions = 8;
+
+    /// <summary>
+    /// MCP ツール由来のコマンドか（<c>/mcp__server__tool</c> 形式）。
+    /// 組み込みの <c>/mcp</c> は該当しない。
+    /// </summary>
+    public static bool IsMcpToolCommand(string name)
+    {
+        var n = name.StartsWith("/") ? name.Substring(1) : name;
+        return n.StartsWith("mcp__", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// 検索語（"/" を除いた文字列）で候補を絞り込む。
+    /// - 名前（"/" を除く）への部分一致。前方一致を優先（rank 0）、中間一致は後（rank 1）
+    /// - 同ランク内は名前順
+    /// - MCP ツール由来は検索語に <c>__</c> が無い限り除外する
+    /// - 上限 <see cref="MaxSuggestions"/> 件で打ち切る
+    /// </summary>
+    public static IReadOnlyList<SlashCommandItem> Filter(
+        IReadOnlyList<SlashCommandItem> catalog, string query, int max = MaxSuggestions)
+    {
+        // 利用者が明示的に MCP ツールを指定しに来たかどうか。
+        var wantsMcpTools = query.Contains("__", StringComparison.Ordinal);
+
+        var matches = new List<(SlashCommandItem Item, int Rank)>();
+        foreach (var item in catalog)
+        {
+            if (!wantsMcpTools && IsMcpToolCommand(item.Name)) continue;
+
+            var nameNoSlash = item.Name.StartsWith("/") ? item.Name.Substring(1) : item.Name;
+            if (query.Length == 0)
+            {
+                matches.Add((item, 1));
+                continue;
+            }
+            var idx = nameNoSlash.IndexOf(query, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0) continue;
+            matches.Add((item, idx == 0 ? 0 : 1)); // 前方一致=0, 中間一致=1
+        }
+
+        return matches
+            .OrderBy(m => m.Rank)
+            .ThenBy(m => m.Item.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(m => m.Item)
+            .Take(max)
+            .ToList();
+    }
+}


### PR DESCRIPTION
## 問題

MCP を接続していると、Claude Code の headless init が返す `slash_commands` に **MCP ツール由来の `mcp__<サーバー>__<ツール>` が丸ごと載る**（ユーザースコープの MCP も含む）。素の `mcp` は前方一致するため組み込みの `/mcp` と同ランクで並び、補完候補に混ざる（`/mcp` と打つと `/mcp__conoha-vps-mcp__create_server` が並ぶ）。

候補は上限8件で打ち切るため、**MCP サーバーが増えるほど本来出したい組み込みコマンドを押し出す**。一方これらを補完から呼び出す機会はほとんど無い。

## 対応

MCP ツール由来だけ特別扱いし、**検索語に `__` が含まれるとき＝利用者が明示的に掘りに行ったときだけ**候補に出す。

| 入力 | 出るもの |
|---|---|
| `/mcp` | 組み込みの `/mcp` のみ |
| `/mcp__` | MCP ツール一覧 |
| `/conoha-vps-mcp__` | サーバー名側からでも掘れる（中間一致） |
| `/create` | 出ない（MCP ツールにしか無い語では引っかけない） |

到達不能にはしていない。

## 実装

`TextInputPanel.razor` に直書きだった絞り込み・並べ替え（部分一致のランク付け・件数上限）を `Services/SlashCommandFilter.cs` へ純ロジックとして切り出した（`SlashCommandMerge` と同じ流儀）。razor 側は1行の委譲になる。

## テスト

`SlashCommandFilterTests.cs`（8ケース）を追加。テスト用 csproj にリンク済み。

- `dotnet test --filter "FullyQualifiedName~SlashCommand"` → 19件全パス
- 本体ビルド 警告0 / エラー0

実機（ConPty 経由）の動作確認は未実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
