### PR TITLE
feat: Git変更ファイル一覧のファイル名クリックで既定アプリで開けるように

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -94,6 +94,7 @@
                      GitChangesOnBadgeClick=@gitChangesOnBadgeClick
                      OnShowInfoToast="(string msg) => toast?.ShowInfo(msg)"
                      OnShowErrorToast="(string msg) => toast?.ShowError(msg)"
+                     OnShowSuccessToast="(string msg) => toast?.ShowSuccess(msg)"
                      IsMobileOpen=@isMobileSidebarOpen
                      Scale=@sessionListScale
                      WidthPercent=@sidebarWidthPercent

--- a/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
@@ -60,7 +60,16 @@
                                     {
                                         <span class="text-muted">@file.OldFilePath →</span>
                                     }
-                                    @file.FilePath
+                                    @if (EffectiveStatus(file) == 'D')
+                                    {
+                                        @* 削除済みファイルは実体が無いため開けない *@
+                                        @file.FilePath
+                                    }
+                                    else
+                                    {
+                                        <a href="" class="text-decoration-none" title="@L["GitChanges.OpenFileTooltip"]"
+                                           @onclick="() => OpenFileAsync(file)" @onclick:preventDefault>@file.FilePath</a>
+                                    }
                                     @if (file.IsStaged && !file.IsUntracked)
                                     {
                                         <i class="bi bi-check2 text-success ms-1" title="@L["GitChanges.Staged"]"></i>
@@ -69,6 +78,12 @@
                             </div>
                         }
                     </div>
+                    @if (openError != null)
+                    {
+                        <div class="alert alert-warning py-1 px-2 mt-2 mb-0 small">
+                            <i class="bi bi-exclamation-triangle me-1"></i>@openError
+                        </div>
+                    }
                 }
             </div>
             <div class="modal-footer">
@@ -110,6 +125,8 @@
             // ダイアログが開かれた時（または対象が変わった時）のみ取得する
             _loadedPath = FolderPath;
             pathsCopied = false; // 前回対象の「コピーしました」表示を持ち越さない
+            openError = null;
+            _repoRoot = null; // 対象が変わったのでルートキャッシュを破棄
             if (InitialFiles != null)
             {
                 // 親がクリック時に取得済みなら再取得しない
@@ -137,6 +154,7 @@
         var requestPath = FolderPath;
         isLoading = true;
         loadFailed = false;
+        openError = null;
         StateHasChanged();
         try
         {
@@ -197,6 +215,40 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "[GitChangesDialog] パスのコピーに失敗");
+        }
+    }
+
+    // ファイル名クリックで開けなかったときの表示（次のクリック/再読込でクリア）
+    private string? openError;
+    // git status のパスはリポジトリルート基準のため、ルートを1回だけ解決してキャッシュする
+    private string? _repoRoot;
+
+    private async Task OpenFileAsync(GitChangedFile file)
+    {
+        if (string.IsNullOrEmpty(FolderPath)) return;
+        openError = null;
+        try
+        {
+            // サブフォルダをセッションにしている場合でも正しく解決できるようルート基準にする
+            _repoRoot ??= await GitService.GetRepositoryRootAsync(FolderPath) ?? FolderPath;
+            var fullPath = System.IO.Path.GetFullPath(System.IO.Path.Combine(_repoRoot, file.FilePath));
+            if (!File.Exists(fullPath))
+            {
+                openError = string.Format(L["GitChanges.FileNotFoundFormat"], fullPath);
+                return;
+            }
+
+            // ターミナル内パスクリックと同じく既定のアプリで開く
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = fullPath,
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "[GitChangesDialog] ファイルを開けませんでした: {Path}", file.FilePath);
+            openError = string.Format(L["GitChanges.OpenErrorFormat"], file.FilePath);
         }
     }
 

--- a/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
@@ -112,6 +112,8 @@
     [Parameter] public EventCallback<bool> OnChangesLoaded { get; set; }
     /// <summary>親がクリック時に取得済みの変更一覧。指定があれば開いた直後の再取得を省略する（更新ボタンでは取り直す）</summary>
     [Parameter] public List<GitChangedFile>? InitialFiles { get; set; }
+    /// <summary>ファイルを開けたときの成功トースト表示（既定アプリの起動が遅く無反応に見えるのを防ぐ）</summary>
+    [Parameter] public EventCallback<string> OnShowSuccessToast { get; set; }
 
     private List<GitChangedFile> changedFiles = new();
     private bool isLoading = false;
@@ -223,9 +225,13 @@
     // git status のパスはリポジトリルート基準のため、ルートを1回だけ解決してキャッシュする
     private string? _repoRoot;
 
+    // 反応が遅いときに二重クリックで2つ開くのを防ぐ
+    private bool isOpening;
+
     private async Task OpenFileAsync(GitChangedFile file)
     {
-        if (string.IsNullOrEmpty(FolderPath)) return;
+        if (string.IsNullOrEmpty(FolderPath) || isOpening) return;
+        isOpening = true;
         openError = null;
         try
         {
@@ -244,17 +250,23 @@
                 return;
             }
 
-            // ターミナル内パスクリックと同じく既定のアプリで開く
+            // ターミナル内パスクリックと同じく既定のアプリで開く。
+            // アプリの起動が遅い・前面に来ない等で無反応に見えるため、成功もトーストで知らせる
             System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
             {
                 FileName = fullPath,
                 UseShellExecute = true,
             });
+            await OnShowSuccessToast.InvokeAsync(string.Format(L["Root.Toast.FileOpenedFormat"], fullPath));
         }
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "[GitChangesDialog] ファイルを開けませんでした: {Path}", file.FilePath);
             openError = string.Format(L["GitChanges.OpenErrorFormat"], file.FilePath);
+        }
+        finally
+        {
+            isOpening = false;
         }
     }
 

--- a/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/GitChangesDialog.razor
@@ -229,9 +229,15 @@
         openError = null;
         try
         {
-            // サブフォルダをセッションにしている場合でも正しく解決できるようルート基準にする
-            _repoRoot ??= await GitService.GetRepositoryRootAsync(FolderPath) ?? FolderPath;
-            var fullPath = System.IO.Path.GetFullPath(System.IO.Path.Combine(_repoRoot, file.FilePath));
+            // サブフォルダをセッションにしている場合でも正しく解決できるようルート基準にする。
+            // ReloadAsync と同じく、await 中にダイアログが別セッションで開き直された場合は
+            // 古い応答を破棄する（キャッシュへ旧セッションのルートを混入させない）
+            var requestPath = FolderPath;
+            var repoRoot = _repoRoot ?? await GitService.GetRepositoryRootAsync(requestPath) ?? requestPath;
+            if (!IsVisible || requestPath != FolderPath)
+                return; // 古い応答: 破棄
+            _repoRoot = repoRoot;
+            var fullPath = System.IO.Path.GetFullPath(System.IO.Path.Combine(repoRoot, file.FilePath));
             if (!File.Exists(fullPath))
             {
                 openError = string.Format(L["GitChanges.FileNotFoundFormat"], fullPath);

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -230,7 +230,8 @@
                   BranchName="@gitChangesSession?.GitBranch"
                   InitialFiles="@gitChangesFiles"
                   OnClose="() => gitChangesSession = null"
-                  OnChangesLoaded="HandleGitChangesLoaded" />
+                  OnChangesLoaded="HandleGitChangesLoaded"
+                  OnShowSuccessToast="OnShowSuccessToast" />
 
 @code {
     [Parameter] public List<SessionInfo> Sessions { get; set; } = new();
@@ -247,6 +248,7 @@
     [Parameter] public bool GitChangesOnBadgeClick { get; set; }
     [Parameter] public EventCallback<string> OnShowInfoToast { get; set; }
     [Parameter] public EventCallback<string> OnShowErrorToast { get; set; }
+    [Parameter] public EventCallback<string> OnShowSuccessToast { get; set; }
 
     private string filterText = string.Empty;
 

--- a/TerminalHub/Components/Shared/Toast.razor
+++ b/TerminalHub/Components/Shared/Toast.razor
@@ -2,7 +2,9 @@
 
 @if (Messages.Any())
 {
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1050;">
+    @* z-index はモーダル(1055)より前面の 1090 (Bootstrap 推奨のトースト層)。
+       Git変更ダイアログ等、モーダルを開いたままのトースト表示を隠さないため *@
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1090;">
         @foreach (var message in Messages)
         {
             <div class="toast show @GetToastClass(message.Type)" role="alert">

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -544,6 +544,9 @@
   <data name="GitChanges.CopyPaths" xml:space="preserve"><value>Copy paths</value></data>
   <data name="GitChanges.Copied" xml:space="preserve"><value>Copied</value></data>
   <data name="GitChanges.Staged" xml:space="preserve"><value>Staged</value></data>
+  <data name="GitChanges.OpenFileTooltip" xml:space="preserve"><value>Open with default app</value></data>
+  <data name="GitChanges.FileNotFoundFormat" xml:space="preserve"><value>File not found: {0}</value></data>
+  <data name="GitChanges.OpenErrorFormat" xml:space="preserve"><value>Failed to open file: {0}</value></data>
   <data name="GitChanges.Status.Untracked" xml:space="preserve"><value>Untracked</value></data>
   <data name="GitChanges.Status.Modified" xml:space="preserve"><value>Modified</value></data>
   <data name="GitChanges.Status.Added" xml:space="preserve"><value>Added</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -544,6 +544,9 @@
   <data name="GitChanges.CopyPaths" xml:space="preserve"><value>パスをコピー</value></data>
   <data name="GitChanges.Copied" xml:space="preserve"><value>コピーしました</value></data>
   <data name="GitChanges.Staged" xml:space="preserve"><value>ステージ済み</value></data>
+  <data name="GitChanges.OpenFileTooltip" xml:space="preserve"><value>既定のアプリで開く</value></data>
+  <data name="GitChanges.FileNotFoundFormat" xml:space="preserve"><value>ファイルが見つかりません: {0}</value></data>
+  <data name="GitChanges.OpenErrorFormat" xml:space="preserve"><value>ファイルを開けませんでした: {0}</value></data>
   <data name="GitChanges.Status.Untracked" xml:space="preserve"><value>未追跡</value></data>
   <data name="GitChanges.Status.Modified" xml:space="preserve"><value>変更</value></data>
   <data name="GitChanges.Status.Added" xml:space="preserve"><value>追加</value></data>

--- a/TerminalHub/Services/GitService.cs
+++ b/TerminalHub/Services/GitService.cs
@@ -250,6 +250,22 @@ namespace TerminalHub.Services
             }
         }
 
+        public async Task<string?> GetRepositoryRootAsync(string path)
+        {
+            try
+            {
+                // --show-toplevel は / 区切りで返るため Windows 標準の \ 区切りへ正規化する
+                var result = await ExecuteGitCommandAsync(path, "rev-parse --show-toplevel");
+                var root = result.Success ? result.Output?.Trim() : null;
+                return string.IsNullOrEmpty(root) ? null : Path.GetFullPath(root);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "リポジトリルート取得でエラーが発生しました: {Path}", path);
+                return null;
+            }
+        }
+
         public async Task<List<GitChangedFile>?> GetChangedFilesAsync(string path)
         {
             try

--- a/TerminalHub/Services/IGitService.cs
+++ b/TerminalHub/Services/IGitService.cs
@@ -50,6 +50,14 @@ namespace TerminalHub.Services
         Task<List<WorktreeInfo>> GetWorktreeListAsync(string path);
 
         /// <summary>
+        /// リポジトリのルートパス（worktree の場合はその worktree のルート）を取得。
+        /// git status --porcelain の相対パスはルート基準のため、絶対パス化に使う
+        /// </summary>
+        /// <param name="path">リポジトリ内の任意のパス</param>
+        /// <returns>ルートの絶対パス。リポジトリでない・取得失敗時は null</returns>
+        Task<string?> GetRepositoryRootAsync(string path);
+
+        /// <summary>
         /// 未コミットの変更ファイル一覧を取得（git status --porcelain）
         /// </summary>
         /// <param name="path">リポジトリのパス</param>


### PR DESCRIPTION
## 概要
Gitバッジクリックで開く「Git 変更ファイル」ダイアログのファイル名をリンク化し、クリックで既定のアプリで開けるようにする。

## 変更内容
- **GitChangesDialog**: ファイル名をリンク化（ツールチップ「既定のアプリで開く」）。ターミナル内パスクリックと同じ流儀で `Process.Start`（UseShellExecute）により既定アプリで開く
- 削除済みファイル（実体なし）はリンクにしない。リネームは新パス側で開く
- 開けなかった場合（ファイル不在等）はダイアログ内に警告を表示
- **GitService/IGitService**: `GetRepositoryRootAsync`（`rev-parse --show-toplevel`）を追加。`git status --porcelain` の相対パスはリポジトリルート基準のため、サブフォルダをセッションにしている場合でも正しく絶対パス化できる（ダイアログ表示中はルートをキャッシュ）
- リソース文字列（ja/en）を3件追加

## 補足
一覧の内容が「サブフォルダセッションでもリポジトリ全体の変更を表示する」のは git status 自体の仕様で従来どおり。フィルタは加えない方針で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)