### PR TITLE
feat: 専用コマンドを親セッションからサブセッションへ伝搬できるようにする

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -2346,7 +2346,10 @@
 
     /// <summary>
     /// 親セッションの専用コマンドのうち、伝搬 ON のものを返す。
-    /// 親セッションそのもの、または親が見つからない（アーカイブ/削除済み）場合は空。
+    /// 親セッションそのもの、または親が完全削除されている場合は空。
+    /// 親がアーカイブ済みでも伝搬は続ける（ArchiveSession は IsArchived を立てるだけで
+    /// SessionManager からは消えないため、GetSessionInfo は引き続き返す）。親を片付けても
+    /// 子の worktree で作業を続けるケースがあり、そこでコマンドが消えるほうが不便なので意図的にそうしている。
     /// </summary>
     private List<CustomCommand> GetInheritedCommands(SessionInfo session)
     {

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -2331,11 +2331,33 @@
             ? new List<CustomCommand>(commands)
             : new List<CustomCommand>();
 
-        // セッション専用コマンドはグローバル分の後ろに連結する。
+        // 親セッションから伝搬されたコマンドを、自分の専用コマンドより前に連結する。
+        // サブセッションは並列作業場なので、親で生やした共通コマンドが子にも自動で生えるようにする。
+        // 階層は親子の2段固定（子からサブセッションは作れない）ため、親を1段だけ辿れば十分で、
+        // 再帰も循環ガードも不要。重複排除もしない（同名を並べたい場合があるため）。
+        result.AddRange(GetInheritedCommands(session));
+
+        // セッション専用コマンドはその後ろに連結する。
         if (session.SessionCommands.Count > 0)
             result.AddRange(session.SessionCommands);
 
         return result;
+    }
+
+    /// <summary>
+    /// 親セッションの専用コマンドのうち、伝搬 ON のものを返す。
+    /// 親セッションそのもの、または親が見つからない（アーカイブ/削除済み）場合は空。
+    /// </summary>
+    private List<CustomCommand> GetInheritedCommands(SessionInfo session)
+    {
+        if (!session.ParentSessionId.HasValue)
+            return new List<CustomCommand>();
+
+        var parent = SessionManager.GetSessionInfo(session.ParentSessionId.Value);
+        if (parent == null)
+            return new List<CustomCommand>();
+
+        return parent.SessionCommands.Where(c => c.PropagateToChildren).ToList();
     }
 
     private string claudeModeSwitchKey = "altM";

--- a/TerminalHub/Components/Shared/Dialogs/CommandEditDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/CommandEditDialog.razor
@@ -84,6 +84,21 @@
                                           placeholder="@L["Settings.Commands.CommandBodyPlaceholder"]"></textarea>
                             </div>
                         }
+                        @if (ShowPropagateOption)
+                        {
+                            <div class="col-12">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox"
+                                           id="@($"propagate-{_instanceId}")"
+                                           checked="@editPropagate"
+                                           @onchange="e => editPropagate = (bool?)e.Value ?? false" />
+                                    <label class="form-check-label" for="@($"propagate-{_instanceId}")">
+                                        <i class="bi bi-arrow-down-square me-1"></i>@L["Settings.Commands.Propagate"]
+                                    </label>
+                                </div>
+                                <small class="form-text text-muted">@L["Settings.Commands.Propagate.Help"]</small>
+                            </div>
+                        }
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -109,6 +124,12 @@
     /// <summary>編集対象のコマンド。null なら新規作成。Save 時はこの参照を直接書き換えず、新インスタンスを返す。</summary>
     [Parameter] public CustomCommand? Command { get; set; }
     [Parameter] public EventCallback<CustomCommand> OnSave { get; set; }
+    /// <summary>
+    /// 「子セッションにも表示する」チェックボックスを出すか。
+    /// 伝搬先が存在する親セッションの専用コマンドを編集するときだけ true にする。
+    /// （グローバル設定・子セッションの編集では意味を持たないので出さない）
+    /// </summary>
+    [Parameter] public bool ShowPropagateOption { get; set; }
 
     // ラジオボタンの DOM id/name が他のダイアログ/設定タブと衝突しないようインスタンス毎にユニーク化する。
     private readonly string _instanceId = Guid.NewGuid().ToString("N").Substring(0, 8);
@@ -119,6 +140,7 @@
     private string editCommandText = "";
     private string editKeyName = KeySequencePresets.DefaultKey;
     private CustomCommandSendMode editSendMode = CustomCommandSendMode.DirectSend;
+    private bool editPropagate = false;
 
     // Command 参照が変わったタイミング (= ダイアログを別アイテムで開き直したタイミング) でのみフォームを初期化する。
     private CustomCommand? _lastLoaded;
@@ -148,6 +170,7 @@
             editCommandText = "";
             editKeyName = KeySequencePresets.DefaultKey;
             editSendMode = CustomCommandSendMode.DirectSend;
+            editPropagate = false; // 既定は伝搬しない
         }
         else
         {
@@ -157,6 +180,7 @@
             editCommandText = Command.CommandText ?? "";
             editKeyName = string.IsNullOrEmpty(Command.KeyName) ? KeySequencePresets.DefaultKey : Command.KeyName;
             editSendMode = Command.SendMode;
+            editPropagate = Command.PropagateToChildren;
         }
     }
 
@@ -186,7 +210,9 @@
                 KeyName = editKeyName,
                 CommandText = "",
                 GroupName = groupName,
-                SendMode = editSendMode
+                SendMode = editSendMode,
+                // チェックボックス非表示時は編集前の値をそのまま持ち越す（LoadFromCommand で復元済み）
+                PropagateToChildren = editPropagate
             };
         }
         else
@@ -201,7 +227,8 @@
                 Title = title,
                 CommandText = commandText,
                 GroupName = groupName,
-                SendMode = editSendMode
+                SendMode = editSendMode,
+                PropagateToChildren = editPropagate
             };
         }
 

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -188,6 +188,47 @@
                     </button>
                 </div>
 
+                @if (inheritedCommands.Any())
+                {
+                    <!-- 親から伝搬されてきたコマンド。ここでは編集できない（変更は親セッションの設定で行う） -->
+                    <div class="mb-3">
+                        <small class="text-muted d-block mb-1">
+                            <i class="bi bi-arrow-down-square me-1"></i>@string.Format(L["SessionSettings.Commands.InheritedFormat"], inheritedCommands.Count)
+                        </small>
+                        <ul class="list-group list-group-sm">
+                            @foreach (var inherited in inheritedCommands)
+                            {
+                                var inheritedIsKey = inherited.Type == CustomCommandType.KeySequence;
+                                var inheritedBody = inheritedIsKey
+                                    ? (KeySequencePresets.GetDisplayName(inherited.KeyName) ?? inherited.KeyName ?? "?")
+                                    : SummarizeCommandText(inherited.CommandText);
+                                <li class="list-group-item d-flex align-items-center py-1 px-2" style="background-color: var(--th-surface-raised);">
+                                    <small class="d-flex align-items-center text-muted" style="min-width: 0; flex: 1;">
+                                        @if (inheritedIsKey)
+                                        {
+                                            <i class="bi bi-keyboard me-1"></i>
+                                        }
+                                        @if (!string.IsNullOrEmpty(inherited.GroupName))
+                                        {
+                                            <span class="badge bg-secondary bg-opacity-25 text-muted me-2" style="font-weight: normal;">@inherited.GroupName</span>
+                                        }
+                                        @if (!string.IsNullOrEmpty(inherited.Title))
+                                        {
+                                            <strong>@inherited.Title</strong>
+                                            <span class="ms-2 text-truncate">@inheritedBody</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="text-truncate">@inheritedBody</span>
+                                        }
+                                    </small>
+                                </li>
+                            }
+                        </ul>
+                        <small class="form-text text-muted d-block">@L["SessionSettings.Commands.InheritedHelp"]</small>
+                    </div>
+                }
+
                 @if (editingSessionCommands.Any())
                 {
                     <ul class="list-group list-group-sm">
@@ -204,6 +245,10 @@
                                     @if (isKey)
                                     {
                                         <i class="bi bi-keyboard me-1 text-muted"></i>
+                                    }
+                                    @if (IsParentSession && cmd.PropagateToChildren)
+                                    {
+                                        <i class="bi bi-arrow-down-square me-1 text-primary" title="@L["Settings.Commands.Propagate"]"></i>
                                     }
                                     @if (!string.IsNullOrEmpty(cmd.GroupName))
                                     {
@@ -254,6 +299,7 @@
                    IsNew="commandEditDialogIsNew"
                    TerminalTypeLabel="@commandEditDialogTerminalLabel"
                    Command="commandEditDialogSource"
+                   ShowPropagateOption="IsParentSession"
                    OnSave="HandleSessionCommandSave" />
 
 @code {
@@ -277,6 +323,28 @@
     private int? commandEditDialogIndex = null;
     private CustomCommand? commandEditDialogSource = null;
     private string? commandEditDialogTerminalLabel = null;
+
+    // 親から伝搬されてきたコマンド（子セッションのみ。読み取り専用の表示用）
+    private List<CustomCommand> inheritedCommands = new();
+
+    // 親セッション（サブセッションを持ち得る側）かどうか。伝搬チェックはここでのみ意味を持つ。
+    private bool IsParentSession => sessionInfo != null && !sessionInfo.ParentSessionId.HasValue;
+
+    /// <summary>
+    /// 子セッションのとき、親セッションの専用コマンドのうち伝搬 ON のものを取得する。
+    /// 階層は親子の2段固定なので親を1段だけ辿れば十分。親が見つからなければ空。
+    /// </summary>
+    private List<CustomCommand> LoadInheritedCommands(SessionInfo session)
+    {
+        if (!session.ParentSessionId.HasValue)
+            return new List<CustomCommand>();
+
+        var parent = SessionManager.GetSessionInfo(session.ParentSessionId.Value);
+        if (parent == null)
+            return new List<CustomCommand>();
+
+        return parent.SessionCommands.Where(c => c.PropagateToChildren).ToList();
+    }
 
     private SessionOptionsSelector? optionsSelector;
     private SessionInfo? sessionInfo;
@@ -385,9 +453,13 @@
                     Type = c.Type,
                     KeyName = c.KeyName,
                     GroupName = c.GroupName,
-                    SendMode = c.SendMode
+                    SendMode = c.SendMode,
+                    PropagateToChildren = c.PropagateToChildren
                 })
                 .ToList();
+
+            // 子セッションなら、親から伝搬されてくるコマンドを読み取り専用で見せるために取得する
+            inheritedCommands = LoadInheritedCommands(sessionInfo);
 
             // オプションを解析
             var options = sessionInfo.Options;
@@ -670,7 +742,8 @@
                 Type = c.Type,
                 KeyName = c.KeyName,
                 GroupName = c.GroupName,
-                SendMode = c.SendMode
+                SendMode = c.SendMode,
+                PropagateToChildren = c.PropagateToChildren
             })
             .ToList();
 

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -332,7 +332,8 @@
 
     /// <summary>
     /// 子セッションのとき、親セッションの専用コマンドのうち伝搬 ON のものを取得する。
-    /// 階層は親子の2段固定なので親を1段だけ辿れば十分。親が見つからなければ空。
+    /// 階層は親子の2段固定なので親を1段だけ辿れば十分。親が完全削除されていれば空。
+    /// アーカイブ済みの親からも伝搬を続ける点は Root.razor の GetInheritedCommands と揃えている。
     /// </summary>
     private List<CustomCommand> LoadInheritedCommands(SessionInfo session)
     {

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -211,6 +211,12 @@ public class CustomCommand
     public string? GroupName { get; set; }
     /// <summary>Text 型のときの送信方法。KeySequence 型では無視する。</summary>
     public CustomCommandSendMode SendMode { get; set; } = CustomCommandSendMode.DirectSend;
+    /// <summary>
+    /// セッション専用コマンドを子セッション（サブセッション）にも表示するか。
+    /// 親セッション（ParentSessionId が null）のコマンドでのみ意味を持つ。
+    /// グローバルコマンドでは未使用。
+    /// </summary>
+    public bool PropagateToChildren { get; set; } = false;
 }
 
 /// <summary>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -178,6 +178,8 @@
   <data name="Settings.Commands.SendMode" xml:space="preserve"><value>Send mode</value></data>
   <data name="Settings.Commands.SendMode.Direct" xml:space="preserve"><value>Direct send</value></data>
   <data name="Settings.Commands.SendMode.Insert" xml:space="preserve"><value>Insert into input</value></data>
+  <data name="Settings.Commands.Propagate" xml:space="preserve"><value>Also show in sub-sessions</value></data>
+  <data name="Settings.Commands.Propagate.Help" xml:space="preserve"><value>Shows this command in the quick-send bar of sub-sessions created from this session, including sub-sessions with a different terminal type.</value></data>
   <data name="Settings.Commands.CommandBody" xml:space="preserve"><value>Command</value></data>
   <data name="Settings.Commands.CommandBodyPlaceholder" xml:space="preserve"><value>Multi-line OK. With Insert mode, this gets put into the textarea.</value></data>
   <data name="Settings.Commands.AddNew" xml:space="preserve"><value>Add new</value></data>
@@ -467,6 +469,8 @@
   <data name="SessionSettings.Commands.Help" xml:space="preserve"><value>These commands appear in the quick-send bar for this session only (after the global commands).</value></data>
   <data name="SessionSettings.Commands.ManageButton" xml:space="preserve"><value>Commands</value></data>
   <data name="SessionSettings.Commands.SaveHint" xml:space="preserve"><value>Additions, edits, and deletions are saved immediately.</value></data>
+  <data name="SessionSettings.Commands.InheritedFormat" xml:space="preserve"><value>Inherited from parent session ({0})</value></data>
+  <data name="SessionSettings.Commands.InheritedHelp" xml:space="preserve"><value>These commands have "Also show in sub-sessions" enabled on the parent session. Edit or remove them in the parent session's settings.</value></data>
   <data name="SessionSettings.Loading" xml:space="preserve"><value>Loading session info...</value></data>
   <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>Apply changes immediately (restart session)</value></data>
   <data name="SessionSettings.Save" xml:space="preserve"><value>Save</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -178,6 +178,8 @@
   <data name="Settings.Commands.SendMode" xml:space="preserve"><value>送信モード</value></data>
   <data name="Settings.Commands.SendMode.Direct" xml:space="preserve"><value>直接送信</value></data>
   <data name="Settings.Commands.SendMode.Insert" xml:space="preserve"><value>入力欄に挿入</value></data>
+  <data name="Settings.Commands.Propagate" xml:space="preserve"><value>子セッションにも表示する</value></data>
+  <data name="Settings.Commands.Propagate.Help" xml:space="preserve"><value>このセッションから作成したサブセッションのクイック送信バーにも、同じコマンドを表示します。ターミナル種別が違うサブセッションにも表示されます。</value></data>
   <data name="Settings.Commands.CommandBody" xml:space="preserve"><value>コマンド</value></data>
   <data name="Settings.Commands.CommandBodyPlaceholder" xml:space="preserve"><value>複数行 OK。挿入モードなら textarea に流し込まれます。</value></data>
   <data name="Settings.Commands.AddNew" xml:space="preserve"><value>新規追加</value></data>
@@ -467,6 +469,8 @@
   <data name="SessionSettings.Commands.Help" xml:space="preserve"><value>このセッションでだけクイック送信バーに表示されるコマンドです（全体設定のコマンドの後ろに並びます）</value></data>
   <data name="SessionSettings.Commands.ManageButton" xml:space="preserve"><value>専用コマンド</value></data>
   <data name="SessionSettings.Commands.SaveHint" xml:space="preserve"><value>追加・編集・削除は即時保存されます。</value></data>
+  <data name="SessionSettings.Commands.InheritedFormat" xml:space="preserve"><value>親セッションから継承（{0}件）</value></data>
+  <data name="SessionSettings.Commands.InheritedHelp" xml:space="preserve"><value>親セッションで「子セッションにも表示する」を有効にしたコマンドです。変更・削除は親セッションの設定で行ってください。</value></data>
   <data name="SessionSettings.Loading" xml:space="preserve"><value>セッション情報を読み込み中…</value></data>
   <data name="SessionSettings.RestartOnSave" xml:space="preserve"><value>変更を即座に適用（セッションを再起動）</value></data>
   <data name="SessionSettings.Save" xml:space="preserve"><value>保存</value></data>


### PR DESCRIPTION
## 背景

サブセッションは並列作業場として使うため、親で生やした共通コマンドを worktree ごとに手で足し直すのが手間だった。一方で、性質の違うコマンド体系は伝搬させたくない。そこで **コマンド単位で伝搬の ON/OFF を選べる** ようにする。

## 変更内容

- `CustomCommand` に `PropagateToChildren` を追加（**既定 OFF**）。`SessionCommands` は JSON カラムなので **DB マイグレーション不要**で、既存データはフィールド欠落 → `false` として読まれる
- クイック送信バーの並びを **グローバル → 親からの継承 → 自分の専用** の3段に変更
- チェックボックスは**親側**に置く。伝搬先が存在しないグローバル設定・子セッションの編集画面には出さない
- 親の一覧では伝搬中のコマンドに ↓ アイコンを表示
- 子セッションの専用コマンド管理に「親セッションから継承（N件）」を**読み取り専用**で表示（変更は親側で行う旨の注記付き）
- ターミナル種別ではフィルタしない。共通で使えるコマンドが多いため、要否はコマンド単位のフラグで判断する

## 設計判断

**階層は親子の2段固定**なので、親を1段だけ辿れば十分で、**再帰も循環ガードも不要**。サブセッション作成の入口は `SessionSettingsDialog` の1箇所だけで `!ParentSessionId.HasValue` にガードされており（子の設定画面にはボタンが出ない）、`SessionList` の `OnCreateWorktree` は配線されているが呼び出し箇所が無い。よって孫は作れない。重複排除も行わない。

## 実装上の注意

`SessionSettingsDialog` のディープコピーは**2箇所**あり（編集バッファへの読み込み / 書き戻し）、どちらかで新フィールドを落とすと保存のたびにフラグが消える。両方に追加済み。

## 動作確認

`localhost:5081` のデバッグインスタンスで実機確認済み（すべて OK）:

1. 親の編集ダイアログにチェックボックスが出る（既定 OFF）
2. ON にすると一覧行に ↓ アイコンが出る
3. 既存の子のクイック送信バーに継承分が並ぶ
4. **ライブ反映**: 子を開いたまま親のチェックを外すと、その場でバーから消える／戻すと復活
5. 子の専用コマンド管理に「親セッションから継承」がグレーで並び、編集/削除ボタンが無い
6. 子には「サブセッションを作成」ボタンが出ない（孫が作れない前提の裏取り）
7. **DB 永続化**: `"PropagateToChildren":true` が書き込まれ、ダイアログを開き直すとチェック状態も復元
8. **新規サブセッション作成**（detached worktree）でも、作成直後から継承分が並ぶ
9. **ターミナル種別違い**（Claude 親 → Codex 子）でも継承される
10. **ボタンのインデックス整合性**: 継承分を並びの途中に挿しても、押したボタンと送信内容が一致する

ビルド 0 エラー / 0 警告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)