### PR TITLE
fix: ConPTY読みループを専用スレッドへ移しThreadPool枯渇を解消する

### DIFF
--- a/TerminalHub/Services/ConPtyReadProbe.cs
+++ b/TerminalHub/Services/ConPtyReadProbe.cs
@@ -9,18 +9,22 @@ namespace TerminalHub.Services
     /// <see cref="OperationProbe"/> の in-flight ダンプが詰まりの最中でもほぼ空
     /// （＝計測点の外で誰かがスレッドを握っている）という強い陰性所見が出た。
     ///
-    /// 有力容疑者が ConPTY の読みループ。<c>ConPtySession</c> のパイプは
+    /// 犯人は ConPTY の読みループだった。<c>ConPtySession</c> のパイプは
     /// <c>new FileStream(pipeOut, FileAccess.Read)</c> と <c>isAsync</c> 未指定（＝同期モード）で
     /// 作られており、同期モードの FileStream の <c>ReadAsync</c> は overlapped I/O を使わず
     /// **ブロッキング読みを ThreadPool スレッドへ投げる**実装になる。つまり
-    /// 起動済みセッション1本につきプールスレッド1本が <c>ReadFile</c> で張り付き続ける。
+    /// 起動済みセッション1本につきプールスレッド1本が <c>ReadFile</c> で張り付き続けていた。
+    /// 実測でも <c>使用中ワーカー ≒ ConPTY読み + 1</c> が全域で成立し、min worker(16)到達で発症した。
     ///
-    /// この仮説を白黒つけるための2つのカウンタ:
+    /// 対策として読みループは専用スレッド上の同期 <c>Read()</c> へ移した（<c>ConPtyService</c> 参照）。
+    /// **したがって今のカウンタは ThreadPool 占有ではなく「専用スレッドが読み待ちしている本数」を数える。**
+    /// このクラスは対策の回帰監視として残している:
     /// - <see cref="ActiveLoops"/>: 走っている読みループの本数（＝起動済み ConPTY 数の実測）
-    /// - <see cref="BlockedInRead"/>: そのうち今まさに <c>ReadAsync</c> 待ちで張り付いている本数（本命）
+    /// - <see cref="BlockedInRead"/>: そのうち今まさに読み待ちで張り付いている本数
     ///
-    /// 判定: ストール時に <c>BlockedInRead</c> が <c>使用中ワーカー</c> の大半を占めていれば仮説は確定。
-    /// 逆にほぼ 0 なら（＝待ちが overlapped で処理されている）容疑は晴れ、別の犯人を探す。
+    /// 判定: **正常なら <c>ConPTY読み</c> が何本に増えても <c>使用中ワーカー</c> は連動しない**。
+    /// 連動していたら読みループが ThreadPool へ戻った（対策が外れた）サインなので、
+    /// <c>ConPtyService</c> の読みループが専用スレッドで同期 <c>Read()</c> を呼んでいるか確認すること。
     ///
     /// <see cref="OperationProbe"/> を再利用しない理由: あちらは閾値(1秒)超で完了した処理を必ず
     /// WARN に出す。読み待ちは「出力が来るまで分単位でブロックする」のが正常なので、そのまま使うと
@@ -47,7 +51,7 @@ namespace TerminalHub.Services
         /// <summary>走っている読みループの本数。</summary>
         public static int ActiveLoops => Volatile.Read(ref Counters[ActiveLoopsIndex].Value);
 
-        /// <summary>今まさに ReadAsync 待ちで張り付いている本数（同期 FileStream ならプールスレッドを握っている）。</summary>
+        /// <summary>今まさに読み待ちで張り付いている本数（専用スレッド化後は ThreadPool のワーカーではない）。</summary>
         public static int BlockedInRead => Volatile.Read(ref Counters[BlockedInReadIndex].Value);
 
         /// <summary>読みループの生存期間を数える。<c>using</c> で囲んで使う。</summary>
@@ -57,7 +61,7 @@ namespace TerminalHub.Services
             return new LoopScope(armed: true);
         }
 
-        /// <summary>1回の ReadAsync 待ちを数える。<c>using</c> ブロックで await を囲んで使う。</summary>
+        /// <summary>1回の読み待ちを数える。<c>using</c> ブロックで <c>Read()</c> を囲んで使う。</summary>
         public static ReadScope EnterRead()
         {
             Interlocked.Increment(ref Counters[BlockedInReadIndex].Value);

--- a/TerminalHub/Services/ConPtyReadProbe.cs
+++ b/TerminalHub/Services/ConPtyReadProbe.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+using System.Runtime.InteropServices;
 
 namespace TerminalHub.Services
 {
@@ -22,41 +22,78 @@ namespace TerminalHub.Services
     /// 判定: ストール時に <c>BlockedInRead</c> が <c>使用中ワーカー</c> の大半を占めていれば仮説は確定。
     /// 逆にほぼ 0 なら（＝待ちが overlapped で処理されている）容疑は晴れ、別の犯人を探す。
     ///
-    /// 設計方針: 平常時のコストは Interlocked の増減のみ。
+    /// <see cref="OperationProbe"/> を再利用しない理由: あちらは閾値(1秒)超で完了した処理を必ず
+    /// WARN に出す。読み待ちは「出力が来るまで分単位でブロックする」のが正常なので、そのまま使うと
+    /// ログが洪水になる。ここは件数を数えるだけの軽量カウンタに留める（統合しないこと）。
+    ///
+    /// 設計方針: 平常時のコストは Interlocked の増減のみ。2つのカウンタは別々のキャッシュラインに
+    /// 置く（多セッション同時出力時の false sharing で、計測が測定対象の性能を乱さないようにするため）。
     /// </summary>
     public static class ConPtyReadProbe
     {
-        private static int _activeLoops;
-        private static int _blockedInRead;
+        // 1要素で1キャッシュライン（64B）を占有する箱。配列要素は連続配置されるので、
+        // Size=64 にしておけば 2つのカウンタが同じラインに乗ることはない。
+        [StructLayout(LayoutKind.Explicit, Size = 64)]
+        private struct PaddedCounter
+        {
+            [FieldOffset(0)] public int Value;
+        }
+
+        private const int ActiveLoopsIndex = 0;
+        private const int BlockedInReadIndex = 1;
+
+        private static readonly PaddedCounter[] Counters = new PaddedCounter[2];
 
         /// <summary>走っている読みループの本数。</summary>
-        public static int ActiveLoops => Volatile.Read(ref _activeLoops);
+        public static int ActiveLoops => Volatile.Read(ref Counters[ActiveLoopsIndex].Value);
 
         /// <summary>今まさに ReadAsync 待ちで張り付いている本数（同期 FileStream ならプールスレッドを握っている）。</summary>
-        public static int BlockedInRead => Volatile.Read(ref _blockedInRead);
+        public static int BlockedInRead => Volatile.Read(ref Counters[BlockedInReadIndex].Value);
 
         /// <summary>読みループの生存期間を数える。<c>using</c> で囲んで使う。</summary>
         public static LoopScope EnterLoop()
         {
-            Interlocked.Increment(ref _activeLoops);
-            return default;
+            Interlocked.Increment(ref Counters[ActiveLoopsIndex].Value);
+            return new LoopScope(armed: true);
         }
 
         /// <summary>1回の ReadAsync 待ちを数える。<c>using</c> ブロックで await を囲んで使う。</summary>
         public static ReadScope EnterRead()
         {
-            Interlocked.Increment(ref _blockedInRead);
-            return default;
+            Interlocked.Increment(ref Counters[BlockedInReadIndex].Value);
+            return new ReadScope(armed: true);
         }
 
+        /// <summary>
+        /// <see cref="EnterLoop"/> が返すスコープ。struct は既定値を作れてしまうので、
+        /// factory を通ったものだけ減算する（default を Dispose してもカウンタを壊さない）。
+        /// </summary>
         public readonly struct LoopScope : IDisposable
         {
-            public void Dispose() => Interlocked.Decrement(ref _activeLoops);
+            private readonly bool _armed;
+
+            internal LoopScope(bool armed) => _armed = armed;
+
+            public void Dispose()
+            {
+                if (_armed) Interlocked.Decrement(ref Counters[ActiveLoopsIndex].Value);
+            }
         }
 
+        /// <summary>
+        /// <see cref="EnterRead"/> が返すスコープ。既定値を Dispose してもカウンタを壊さない
+        /// （理由は <see cref="LoopScope"/> と同じ）。
+        /// </summary>
         public readonly struct ReadScope : IDisposable
         {
-            public void Dispose() => Interlocked.Decrement(ref _blockedInRead);
+            private readonly bool _armed;
+
+            internal ReadScope(bool armed) => _armed = armed;
+
+            public void Dispose()
+            {
+                if (_armed) Interlocked.Decrement(ref Counters[BlockedInReadIndex].Value);
+            }
         }
     }
 }

--- a/TerminalHub/Services/ConPtyReadProbe.cs
+++ b/TerminalHub/Services/ConPtyReadProbe.cs
@@ -1,0 +1,62 @@
+using System.Threading;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// ConPTY 読みループが ThreadPool スレッドを何本占有しているかの計測（実験コード）。
+    ///
+    /// 背景（2026-07-23 の調査）: ThreadPool starvation は再現・確認できたが、
+    /// <see cref="OperationProbe"/> の in-flight ダンプが詰まりの最中でもほぼ空
+    /// （＝計測点の外で誰かがスレッドを握っている）という強い陰性所見が出た。
+    ///
+    /// 有力容疑者が ConPTY の読みループ。<c>ConPtySession</c> のパイプは
+    /// <c>new FileStream(pipeOut, FileAccess.Read)</c> と <c>isAsync</c> 未指定（＝同期モード）で
+    /// 作られており、同期モードの FileStream の <c>ReadAsync</c> は overlapped I/O を使わず
+    /// **ブロッキング読みを ThreadPool スレッドへ投げる**実装になる。つまり
+    /// 起動済みセッション1本につきプールスレッド1本が <c>ReadFile</c> で張り付き続ける。
+    ///
+    /// この仮説を白黒つけるための2つのカウンタ:
+    /// - <see cref="ActiveLoops"/>: 走っている読みループの本数（＝起動済み ConPTY 数の実測）
+    /// - <see cref="BlockedInRead"/>: そのうち今まさに <c>ReadAsync</c> 待ちで張り付いている本数（本命）
+    ///
+    /// 判定: ストール時に <c>BlockedInRead</c> が <c>使用中ワーカー</c> の大半を占めていれば仮説は確定。
+    /// 逆にほぼ 0 なら（＝待ちが overlapped で処理されている）容疑は晴れ、別の犯人を探す。
+    ///
+    /// 設計方針: 平常時のコストは Interlocked の増減のみ。
+    /// </summary>
+    public static class ConPtyReadProbe
+    {
+        private static int _activeLoops;
+        private static int _blockedInRead;
+
+        /// <summary>走っている読みループの本数。</summary>
+        public static int ActiveLoops => Volatile.Read(ref _activeLoops);
+
+        /// <summary>今まさに ReadAsync 待ちで張り付いている本数（同期 FileStream ならプールスレッドを握っている）。</summary>
+        public static int BlockedInRead => Volatile.Read(ref _blockedInRead);
+
+        /// <summary>読みループの生存期間を数える。<c>using</c> で囲んで使う。</summary>
+        public static LoopScope EnterLoop()
+        {
+            Interlocked.Increment(ref _activeLoops);
+            return default;
+        }
+
+        /// <summary>1回の ReadAsync 待ちを数える。<c>using</c> ブロックで await を囲んで使う。</summary>
+        public static ReadScope EnterRead()
+        {
+            Interlocked.Increment(ref _blockedInRead);
+            return default;
+        }
+
+        public readonly struct LoopScope : IDisposable
+        {
+            public void Dispose() => Interlocked.Decrement(ref _activeLoops);
+        }
+
+        public readonly struct ReadScope : IDisposable
+        {
+            public void Dispose() => Interlocked.Decrement(ref _blockedInRead);
+        }
+    }
+}

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -567,8 +567,12 @@ namespace TerminalHub.Services
             var byteBuffer = new byte[65536]; // 64KB
             var charBuffer = new char[65536]; // 64KB
 
-            // 実験: この読みループが ThreadPool スレッドを何本占有しているかの計測（ConPtyReadProbe 参照）
+            // 実験: この読みループが ThreadPool スレッドを何本占有しているかの計測（ConPtyReadProbe 参照）。
+            // 開始/終了を残すのは、ゲージの ConPTY読み が下がらないときに「セッションが生きている」のか
+            // 「破棄済みなのにループが抜けられていない」のかを後からログだけで切り分けるため。
             using var _loopScope = ConPtyReadProbe.EnterLoop();
+            _logger.LogDebug("[ConPtyRead] 読みループ開始: SessionId={SessionId}, ActiveLoops={ActiveLoops}",
+                _sessionId, ConPtyReadProbe.ActiveLoops);
 
             while (!cancellationToken.IsCancellationRequested && !IsDisposed)
             {
@@ -636,6 +640,10 @@ namespace TerminalHub.Services
                 }
             }
             
+            // ここに来た時点でループは抜けている（＝プールスレッドの占有は解けた）。
+            // ActiveLoops は _loopScope の破棄でこの直後に減る。
+            _logger.LogDebug("[ConPtyRead] 読みループ終了: SessionId={SessionId}", _sessionId);
+
             // バッファリングタイマーを即座に停止
             if (_flushTimer != null)
             {
@@ -755,6 +763,16 @@ namespace TerminalHub.Services
                 // パイプ読み取りを先に解除し、待機がタイムアウトしにくいようにする。
                 _pipeOutStream?.Dispose();
                 _readTask?.Wait(1000); // 1秒待機
+
+                // 1秒で終わらなかった場合、読みループは走ったまま＝プールスレッドを握り続けている。
+                // このときゲージの ConPTY読み は実セッション数より多く出る。単調増加を「占有の蓄積」と
+                // 読み違えないよう、過大計上の可能性をここで明示的に残す（ConPtyReadProbe 参照）。
+                if (_readTask is { IsCompleted: false })
+                {
+                    _logger.LogWarning(
+                        "[ConPtyRead] 読みループが1秒以内に終了せず: SessionId={SessionId}, ActiveLoops={ActiveLoops}（以降 ConPTY読み が過大計上される可能性）",
+                        _sessionId, ConPtyReadProbe.ActiveLoops);
+                }
             }
             catch (Exception ex)
             {

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -67,7 +67,13 @@ namespace TerminalHub.Services
         private bool IsDisposed => Volatile.Read(ref _disposeState) != 0;
         private readonly object _pseudoConsoleLock = new();
         private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder();
-        private Task? _readTask;
+        // 読みループは ThreadPool ではなく専用スレッドで回す。
+        // ConPTY のパイプは CreatePipe 製で overlapped 非対応のため FileStream は同期モードでしか作れず、
+        // 同期モードの FileStream.ReadAsync は「ブロッキング読みを ThreadPool へ投げる」実装になる。
+        // つまり誰が呼んでも起動済みセッション1本につきプールスレッド1本が張り付き、
+        // セッション数が min worker 数に達した時点でプール全体が枯渇する（2026-07-23 に実測で確定）。
+        // 専用スレッド上で同期 Read() を直接呼べば、ブロックするのは自前のスレッドだけになる。
+        private Thread? _readThread;
         private CancellationTokenSource? _readCancellationTokenSource;
         private bool _started = false;
 
@@ -156,7 +162,15 @@ namespace TerminalHub.Services
             _flushTimer?.Start();
 
             _readCancellationTokenSource = new CancellationTokenSource();
-            _readTask = Task.Run(() => ReadPipeAsync(_readCancellationTokenSource.Token));
+
+            // ThreadPool には載せない（理由は _readThread の宣言箇所を参照）
+            var readToken = _readCancellationTokenSource.Token;
+            _readThread = new Thread(() => ReadPipeLoop(readToken))
+            {
+                IsBackground = true,
+                Name = $"ConPtyRead-{_sessionId?.ToString("N")[..8] ?? "unknown"}",
+            };
+            _readThread.Start();
         }
 
         private IntPtr CreateEnvironmentBlock()
@@ -562,14 +576,21 @@ namespace TerminalHub.Services
         }
 
         // バックグラウンドでパイプを読み取るメソッド
-        private async Task ReadPipeAsync(CancellationToken cancellationToken)
+        /// <summary>
+        /// パイプを読み続けるループ。**専用スレッドで同期に回す**（ThreadPool には載せない）。
+        /// 同期モードの FileStream では ReadAsync も内部でプールスレッドをブロックするため、
+        /// ここでは素の Read() を呼び、ブロックするのを自前のスレッドだけに閉じ込める。
+        /// キャンセルは Read() 自体には効かないが、Dispose がパイプを閉じることで解除される。
+        /// </summary>
+        private void ReadPipeLoop(CancellationToken cancellationToken)
         {
             var byteBuffer = new byte[65536]; // 64KB
             var charBuffer = new char[65536]; // 64KB
 
-            // 実験: この読みループが ThreadPool スレッドを何本占有しているかの計測（ConPtyReadProbe 参照）。
-            // 開始/終了を残すのは、ゲージの ConPTY読み が下がらないときに「セッションが生きている」のか
-            // 「破棄済みなのにループが抜けられていない」のかを後からログだけで切り分けるため。
+            // 計測（ConPtyReadProbe 参照）。専用スレッド化後は「ConPTY読みが増えても使用中ワーカーが
+            // 連動しない」ことが対策の効いている証拠になる。開始/終了を残すのは、ActiveLoops が
+            // 下がらないときに「セッションが生きている」のか「破棄済みなのに抜けられていない」のかを
+            // 後からログだけで切り分けるため。
             using var _loopScope = ConPtyReadProbe.EnterLoop();
             _logger.LogDebug("[ConPtyRead] 読みループ開始: SessionId={SessionId}, ActiveLoops={ActiveLoops}",
                 _sessionId, ConPtyReadProbe.ActiveLoops);
@@ -578,21 +599,14 @@ namespace TerminalHub.Services
             {
                 try
                 {
-                    // フロー制御: 一時停止中は再開を待つ
+                    // フロー制御: 一時停止中は再開を待つ（最大30秒）
                     if (_outputPaused)
                     {
                         var resumeTask = _resumeTcs?.Task;
                         if (resumeTask != null)
                         {
-                            // キャンセルトークンと組み合わせて待機
-                            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                            linkedCts.CancelAfter(TimeSpan.FromSeconds(30)); // 最大30秒待機
-
-                            try
-                            {
-                                await resumeTask.WaitAsync(linkedCts.Token);
-                            }
-                            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                            // 専用スレッドなので同期待ちでよい。キャンセル時は例外で下の catch へ抜ける。
+                            if (!resumeTask.Wait(TimeSpan.FromSeconds(30), cancellationToken))
                             {
                                 // タイムアウトの場合は強制的に再開
                                 _logger.LogWarning("Flow control timeout - forcing resume");
@@ -604,12 +618,11 @@ namespace TerminalHub.Services
                     if (_pipeOutStream == null)
                         break;
 
-                    // 同期モードの FileStream では、この await はプールスレッドを掴んだまま
-                    // ブロッキング読みになる。何本が同時に張り付いているかを計測する。
+                    // 同期 Read。ブロックするのはこの専用スレッドだけで、ThreadPool は消費しない。
                     int bytesRead;
                     using (ConPtyReadProbe.EnterRead())
                     {
-                        bytesRead = await _pipeOutStream.ReadAsync(byteBuffer, 0, byteBuffer.Length, cancellationToken);
+                        bytesRead = _pipeOutStream.Read(byteBuffer, 0, byteBuffer.Length);
                     }
 
                     if (bytesRead > 0)
@@ -760,14 +773,15 @@ namespace TerminalHub.Services
             try
             {
                 _readCancellationTokenSource?.Cancel();
-                // パイプ読み取りを先に解除し、待機がタイムアウトしにくいようにする。
+                // 同期 Read() はキャンセルで抜けないので、パイプを閉じて読みを解除するのが必須。
+                // これで Read() が例外/0 で戻り、ループが終了できる。
                 _pipeOutStream?.Dispose();
-                _readTask?.Wait(1000); // 1秒待機
+                _readThread?.Join(1000); // 1秒待機
 
-                // 1秒で終わらなかった場合、読みループは走ったまま＝プールスレッドを握り続けている。
+                // 1秒で終わらなかった場合、読みループは走ったまま＝専用スレッドが残っている。
                 // このときゲージの ConPTY読み は実セッション数より多く出る。単調増加を「占有の蓄積」と
                 // 読み違えないよう、過大計上の可能性をここで明示的に残す（ConPtyReadProbe 参照）。
-                if (_readTask is { IsCompleted: false })
+                if (_readThread is { IsAlive: true })
                 {
                     _logger.LogWarning(
                         "[ConPtyRead] 読みループが1秒以内に終了せず: SessionId={SessionId}, ActiveLoops={ActiveLoops}（以降 ConPTY読み が過大計上される可能性）",

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -567,6 +567,9 @@ namespace TerminalHub.Services
             var byteBuffer = new byte[65536]; // 64KB
             var charBuffer = new char[65536]; // 64KB
 
+            // 実験: この読みループが ThreadPool スレッドを何本占有しているかの計測（ConPtyReadProbe 参照）
+            using var _loopScope = ConPtyReadProbe.EnterLoop();
+
             while (!cancellationToken.IsCancellationRequested && !IsDisposed)
             {
                 try
@@ -597,7 +600,13 @@ namespace TerminalHub.Services
                     if (_pipeOutStream == null)
                         break;
 
-                    var bytesRead = await _pipeOutStream.ReadAsync(byteBuffer, 0, byteBuffer.Length, cancellationToken);
+                    // 同期モードの FileStream では、この await はプールスレッドを掴んだまま
+                    // ブロッキング読みになる。何本が同時に張り付いているかを計測する。
+                    int bytesRead;
+                    using (ConPtyReadProbe.EnterRead())
+                    {
+                        bytesRead = await _pipeOutStream.ReadAsync(byteBuffer, 0, byteBuffer.Length, cancellationToken);
+                    }
 
                     if (bytesRead > 0)
                     {

--- a/TerminalHub/Services/FreezeProbeService.cs
+++ b/TerminalHub/Services/FreezeProbeService.cs
@@ -37,6 +37,14 @@ namespace TerminalHub.Services
         private Thread? _dedicatedThread;
         private Task? _threadPoolTask;
 
+        // ストール中のピーク値。ThreadPool プローブは詰まっている間そもそも動けず、
+        // 遅延に気づくのは「明けた後」なので、そこで読む値は復帰後のスナップショットになってしまう。
+        // 詰まっている最中も回り続ける専用スレッド（starvation では無事なことを確認済み）で毎秒サンプルし、
+        // 最大値を持ち回ることで「詰まっていた瞬間の値」を遅延検出行に添える。
+        // 書き手は専用スレッドのみ、読み手は ThreadPool プローブのみ。
+        private int _peakBlockedInRead;
+        private int _peakBusyWorkers;
+
         public FreezeProbeService(
             ILogger<FreezeProbeService> logger,
             ILoggerFactory loggerFactory,
@@ -85,6 +93,9 @@ namespace TerminalHub.Services
                     return;
                 }
 
+                // ThreadPool が詰まっている間もここは回るので、ピーク採取はこのループが担う
+                SamplePeaks();
+
                 var elapsed = sw.Elapsed;
                 sw.Restart();
                 var gcPause = GC.GetTotalPauseDuration();
@@ -105,6 +116,23 @@ namespace TerminalHub.Services
 
                 lastGcPause = gcPause;
             }
+        }
+
+        /// <summary>
+        /// ストール中の値を取りこぼさないよう、専用スレッドから毎秒サンプルして最大値を更新する。
+        /// 単一書き手なので read-then-write で足りる（Interlocked は不要）。
+        /// </summary>
+        private void SamplePeaks()
+        {
+            var blocked = ConPtyReadProbe.BlockedInRead;
+            if (blocked > Volatile.Read(ref _peakBlockedInRead))
+                Volatile.Write(ref _peakBlockedInRead, blocked);
+
+            ThreadPool.GetMaxThreads(out var maxWorkers, out _);
+            ThreadPool.GetAvailableThreads(out var availWorkers, out _);
+            var busy = maxWorkers - availWorkers;
+            if (busy > Volatile.Read(ref _peakBusyWorkers))
+                Volatile.Write(ref _peakBusyWorkers, busy);
         }
 
         /// <summary>ThreadPoolプローブ: 専用スレッドが無事でここだけ遅れる = ThreadPool枯渇</summary>
@@ -148,9 +176,11 @@ namespace TerminalHub.Services
                     ThreadPool.GetAvailableThreads(out var availWorkers, out _);
                     ThreadPool.GetMinThreads(out var minWorkers, out _);
 
-                    // ConPTY読み占有: BusyWorkers の大半が ReadAsync待ちなら starvation の犯人が確定する
+                    // ConPTY読み占有: BusyWorkers の大半が ReadAsync待ちなら starvation の犯人が確定する。
+                    // 素の値はこの行を書いている「復帰後」のスナップショットなので、判定には
+                    // 専用スレッドが詰まっている最中に採ったピーク値のほうを見ること。
                     _logger.LogWarning(
-                        "[FreezeProbe] ThreadPool遅延検出: 遅延={StallSec:F1}s (開始≒{StallStart:HH:mm:ss.fff}), ThreadPool待機={Pending}, 完了スループット={Throughput:F0}/s, 使用中ワーカー={BusyWorkers}/{MaxWorkers}(min={MinWorkers}), スレッド数={Threads}, ConPTY読み={BlockedInRead}/{ReadLoops}, 実行中=[{InFlight}]",
+                        "[FreezeProbe] ThreadPool遅延検出: 遅延={StallSec:F1}s (開始≒{StallStart:HH:mm:ss.fff}), ThreadPool待機={Pending}, 完了スループット={Throughput:F0}/s, 使用中ワーカー={BusyWorkers}/{MaxWorkers}(min={MinWorkers}), スレッド数={Threads}, ConPTY読み={BlockedInRead}/{ReadLoops}, ストール中ピーク(ConPTY読み/使用中)={PeakBlockedInRead}/{PeakBusyWorkers}, 実行中=[{InFlight}]",
                         elapsed.TotalSeconds,
                         DateTime.Now - elapsed,
                         ThreadPool.PendingWorkItemCount,
@@ -161,8 +191,15 @@ namespace TerminalHub.Services
                         ThreadPool.ThreadCount,
                         ConPtyReadProbe.BlockedInRead,
                         ConPtyReadProbe.ActiveLoops,
+                        Volatile.Read(ref _peakBlockedInRead),
+                        Volatile.Read(ref _peakBusyWorkers),
                         OperationProbe.DumpInFlight());
                 }
+
+                // ピークは「前回このループが回ってから今まで」＝ストール区間を表すようにしたいので、
+                // 遅延の有無に関わらず毎ティックで畳む。
+                Volatile.Write(ref _peakBlockedInRead, 0);
+                Volatile.Write(ref _peakBusyWorkers, 0);
             }
         }
 

--- a/TerminalHub/Services/FreezeProbeService.cs
+++ b/TerminalHub/Services/FreezeProbeService.cs
@@ -17,9 +17,13 @@ namespace TerminalHub.Services
     ///
     /// 遅延検知時に GC.GetTotalPauseDuration の差分を添えるので、
     /// 停止時間 ≒ GCポーズ差分 なら犯人はGC、そうでなければ別要因と判定できる。
-    /// 平常時の出力は起動時の1行と、60秒毎の定期ゲージ（蓄積リーク監視＋ConPTY読み占有）のみ。
-    /// ConPTY読み占有（<see cref="ConPtyReadProbe"/>）は starvation の本命容疑者の計測で、
-    /// 「使用中ワーカーのうち何本が ConPTY の ReadAsync 待ちで張り付いているか」を出す。
+    /// 平常時の出力は起動時の1行と、60秒毎の定期ゲージ（蓄積リーク監視＋ConPTY読み）のみ。
+    ///
+    /// ConPTY読み（<see cref="ConPtyReadProbe"/>）は、かつて starvation の犯人だった
+    /// 「読みループによる ThreadPool 占有」の回帰監視。読みループは専用スレッドへ移したので、
+    /// **正常なら ConPTY読み が何本に増えても 使用中ワーカー は連動しない**。
+    /// 逆に 使用中ワーカー ≒ ConPTY読み + 1 のように連動していたら、読みループが
+    /// ThreadPool へ戻ってしまった（対策が外れた）サイン。
     /// </summary>
     public class FreezeProbeService : IHostedService, IDisposable
     {
@@ -41,7 +45,9 @@ namespace TerminalHub.Services
         // 遅延に気づくのは「明けた後」なので、そこで読む値は復帰後のスナップショットになってしまう。
         // 詰まっている最中も回り続ける専用スレッド（starvation では無事なことを確認済み）で毎秒サンプルし、
         // 最大値を持ち回ることで「詰まっていた瞬間の値」を遅延検出行に添える。
-        // 書き手は専用スレッドのみ、読み手は ThreadPool プローブのみ。
+        // 書き手は2つある（専用スレッドが最大値を更新し、ThreadPool プローブが毎ティックで 0 に畳む）ので、
+        // 更新は CAS、畳みは Interlocked.Exchange で行う。素の read-then-write だと畳みと更新が
+        // 競合してピークを取りこぼし、「詰まっていなかった」と誤読させうる。
         private int _peakBlockedInRead;
         private int _peakBusyWorkers;
 
@@ -120,19 +126,26 @@ namespace TerminalHub.Services
 
         /// <summary>
         /// ストール中の値を取りこぼさないよう、専用スレッドから毎秒サンプルして最大値を更新する。
-        /// 単一書き手なので read-then-write で足りる（Interlocked は不要）。
+        /// ThreadPool プローブ側が同じフィールドを 0 に畳むため、CAS で更新する。
         /// </summary>
         private void SamplePeaks()
         {
-            var blocked = ConPtyReadProbe.BlockedInRead;
-            if (blocked > Volatile.Read(ref _peakBlockedInRead))
-                Volatile.Write(ref _peakBlockedInRead, blocked);
+            UpdatePeak(ref _peakBlockedInRead, ConPtyReadProbe.BlockedInRead);
 
             ThreadPool.GetMaxThreads(out var maxWorkers, out _);
             ThreadPool.GetAvailableThreads(out var availWorkers, out _);
-            var busy = maxWorkers - availWorkers;
-            if (busy > Volatile.Read(ref _peakBusyWorkers))
-                Volatile.Write(ref _peakBusyWorkers, busy);
+            UpdatePeak(ref _peakBusyWorkers, maxWorkers - availWorkers);
+        }
+
+        /// <summary>現在値がピークを超えていれば CAS で更新する（畳み込みと競合しても取りこぼさない）。</summary>
+        private static void UpdatePeak(ref int peak, int value)
+        {
+            while (true)
+            {
+                var current = Volatile.Read(ref peak);
+                if (value <= current) return;
+                if (Interlocked.CompareExchange(ref peak, value, current) == current) return;
+            }
         }
 
         /// <summary>ThreadPoolプローブ: 専用スレッドが無事でここだけ遅れる = ThreadPool枯渇</summary>
@@ -176,7 +189,8 @@ namespace TerminalHub.Services
                     ThreadPool.GetAvailableThreads(out var availWorkers, out _);
                     ThreadPool.GetMinThreads(out var minWorkers, out _);
 
-                    // ConPTY読み占有: BusyWorkers の大半が ReadAsync待ちなら starvation の犯人が確定する。
+                    // ConPTY読みは回帰監視。専用スレッド化後は BusyWorkers に算入されないはずなので、
+                    // ピークの ConPTY読み が ピークの使用中 に迫っていたら対策が外れた疑い。
                     // 素の値はこの行を書いている「復帰後」のスナップショットなので、判定には
                     // 専用スレッドが詰まっている最中に採ったピーク値のほうを見ること。
                     _logger.LogWarning(
@@ -197,9 +211,10 @@ namespace TerminalHub.Services
                 }
 
                 // ピークは「前回このループが回ってから今まで」＝ストール区間を表すようにしたいので、
-                // 遅延の有無に関わらず毎ティックで畳む。
-                Volatile.Write(ref _peakBlockedInRead, 0);
-                Volatile.Write(ref _peakBusyWorkers, 0);
+                // 遅延の有無に関わらず毎ティックで畳む。専用スレッド側の CAS 更新と競合しても
+                // 落ちないよう Exchange で行う。
+                Interlocked.Exchange(ref _peakBlockedInRead, 0);
+                Interlocked.Exchange(ref _peakBusyWorkers, 0);
             }
         }
 

--- a/TerminalHub/Services/FreezeProbeService.cs
+++ b/TerminalHub/Services/FreezeProbeService.cs
@@ -17,7 +17,9 @@ namespace TerminalHub.Services
     ///
     /// 遅延検知時に GC.GetTotalPauseDuration の差分を添えるので、
     /// 停止時間 ≒ GCポーズ差分 なら犯人はGC、そうでなければ別要因と判定できる。
-    /// 平常時の出力は起動時の1行と、60秒毎の定期ゲージ（蓄積リーク監視）のみ。
+    /// 平常時の出力は起動時の1行と、60秒毎の定期ゲージ（蓄積リーク監視＋ConPTY読み占有）のみ。
+    /// ConPTY読み占有（<see cref="ConPtyReadProbe"/>）は starvation の本命容疑者の計測で、
+    /// 「使用中ワーカーのうち何本が ConPTY の ReadAsync 待ちで張り付いているか」を出す。
     /// </summary>
     public class FreezeProbeService : IHostedService, IDisposable
     {
@@ -146,8 +148,9 @@ namespace TerminalHub.Services
                     ThreadPool.GetAvailableThreads(out var availWorkers, out _);
                     ThreadPool.GetMinThreads(out var minWorkers, out _);
 
+                    // ConPTY読み占有: BusyWorkers の大半が ReadAsync待ちなら starvation の犯人が確定する
                     _logger.LogWarning(
-                        "[FreezeProbe] ThreadPool遅延検出: 遅延={StallSec:F1}s (開始≒{StallStart:HH:mm:ss.fff}), ThreadPool待機={Pending}, 完了スループット={Throughput:F0}/s, 使用中ワーカー={BusyWorkers}/{MaxWorkers}(min={MinWorkers}), スレッド数={Threads}, 実行中=[{InFlight}]",
+                        "[FreezeProbe] ThreadPool遅延検出: 遅延={StallSec:F1}s (開始≒{StallStart:HH:mm:ss.fff}), ThreadPool待機={Pending}, 完了スループット={Throughput:F0}/s, 使用中ワーカー={BusyWorkers}/{MaxWorkers}(min={MinWorkers}), スレッド数={Threads}, ConPTY読み={BlockedInRead}/{ReadLoops}, 実行中=[{InFlight}]",
                         elapsed.TotalSeconds,
                         DateTime.Now - elapsed,
                         ThreadPool.PendingWorkItemCount,
@@ -156,6 +159,8 @@ namespace TerminalHub.Services
                         maxWorkers,
                         minWorkers,
                         ThreadPool.ThreadCount,
+                        ConPtyReadProbe.BlockedInRead,
+                        ConPtyReadProbe.ActiveLoops,
                         OperationProbe.DumpInFlight());
                 }
             }
@@ -179,15 +184,22 @@ namespace TerminalHub.Services
                 procThreads = -1; // 取得失敗時も落とさない
             }
 
+            // 使用中ワーカーも平常時から採る（ConPTY読み占有との比を時系列で追うため）
+            ThreadPool.GetMaxThreads(out var maxWorkers, out _);
+            ThreadPool.GetAvailableThreads(out var availWorkers, out _);
+
             _logger.LogInformation(
-                "[FreezeProbe] 定期ゲージ: hook購読={HookSubs}, sessions変更購読={SessSubs}, セッション数={Sessions}, in-flight={InFlight}, ThreadPool待機={Pending}, ThreadPoolスレッド={TpThreads}, プロセススレッド={ProcThreads}",
+                "[FreezeProbe] 定期ゲージ: hook購読={HookSubs}, sessions変更購読={SessSubs}, セッション数={Sessions}, in-flight={InFlight}, ThreadPool待機={Pending}, ThreadPoolスレッド={TpThreads}, プロセススレッド={ProcThreads}, 使用中ワーカー={BusyWorkers}, ConPTY読み={BlockedInRead}/{ReadLoops}",
                 _hookNotificationService.SubscriberCount,
                 _sessionManager.SessionsChangedSubscriberCount,
                 _sessionManager.GetAllSessions().Count(),
                 OperationProbe.InFlightCount,
                 ThreadPool.PendingWorkItemCount,
                 ThreadPool.ThreadCount,
-                procThreads);
+                procThreads,
+                maxWorkers - availWorkers,
+                ConPtyReadProbe.BlockedInRead,
+                ConPtyReadProbe.ActiveLoops);
         }
 
         public Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
「偶に反応が重い」問題（2026-07-17 から追っていたもの）の**根本原因を特定し、修正**した。実機で11.8時間の効果確認済み。

## 原因

ConPTY のパイプは `CreatePipe` 製で overlapped 非対応のため `FileStream` は同期モードでしか作れない。**同期モードの `FileStream.ReadAsync` は overlapped I/O を使わず、ブロッキング読みを ThreadPool へ投げる**実装になる。

結果、**起動済みセッション1本につきプールスレッド1本が `ReadFile` で永久に張り付いていた**。

## 確定に至った計測データ（修正前）

`ConPtyReadProbe` を追加して計測したところ、以下がすべて成立した。

- `BlockedInRead == ActiveLoops` が常時成立（読みループは常に100%が待ち状態）
- **`使用中ワーカー ≒ ConPTY読み + 1`** が全域で成立（6本→9、10本→11、13本→14、16本→17）
- セッションを触るたび 7→16 と**単調増加し、一度も減らない**（遅延初期化なので触った数だけ積み上がる）
- **min worker = 16（論理CPU数）に達した瞬間に発症**。遅延検出131件すべて `ConPTY読み=16` のときで、**15本以下では3時間5分1件も出ていない**

これが「一度なると再起動まで直らない」「溜まっていく感じ」という体感の正体だった（イベント購読リークではなくスレッド占有）。

## 修正

`ReadAsync` は呼び出し元がどのスレッドでもプールへ投げるので、単に `Task.Run` をやめるだけでは解決しない。**読みループ自体を専用 `Thread` で回し、そこで同期 `Read()` を直接呼ぶ**ことで、ブロックを自前のスレッドに閉じ込める。

- `_readTask`(Task) → `_readThread`(Thread, IsBackground)
- `ReadPipeAsync` → 同期の `ReadPipeLoop`。フロー制御の待ちも同期 `Wait` に
- Dispose は `Join(1000)` へ。同期 `Read()` はキャンセルで抜けないため、**パイプを閉じてから待つ既存の順序が必須**（コメントで明示）

## 効果（実機、同一プロセスで11.8時間）

| | 修正前 (5.5h) | 修正後 (11.8h) |
|---|---|---|
| ThreadPool遅延検出 | **131件**（最悪15.2秒） | **0件** |
| 専用スレッド停止検出 | 0件 | 0件 |
| 1秒超の遅い処理 | 多発（SelectSession 4.0〜6.7秒） | 1件 |
| ThreadPoolスレッド | 20〜22 | **7〜10** |

同一 reader 本数での比較（「セッションが少ないから軽いだけ」の否定）:

| ConPTY読み | 修正前の使用中ワーカー | 修正後の使用中ワーカー |
|---|---|---|
| 13本 | 14 | **1** |
| 15本 | 16 | **1** |
| 16本 | 17（→ストール131件） | **1**（→ストール0件） |
| 17本 | 未到達 | **1** |

**修正前の発症閾値16を超えて17本まで到達しても、使用中ワーカーは1のまま**。ConPTY読みと使用中ワーカーの相関が完全に切れている。

なお `ConPTY読み=13` の時点で MCP の `list_sessions` を突き合わせ、`status=ready` がちょうど13本であることを確認済み（カウンタの独立検証）。

## 計測コードについて

`ConPtyReadProbe` と FreezeProbe のゲージ拡張は**意図的に残している**。「ConPTY読みが増えても使用中ワーカーが連動しない」ことが対策の効いている証拠になり、再発時の一次切り分けにも使えるため。平常時のコストは Interlocked の増減のみ（2カウンタは false sharing を避けて別キャッシュラインに配置）。

## テスト

- `dotnet test` 161件全パス
- ビルド 警告0 / エラー0
- 実機動作は上記のとおりユーザー環境で11.8時間確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
