### PR TITLE
fix: npm版Claude Codeが起動できない回帰を修正（cmd.exeの引用符処理）

### DIFF
--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -267,20 +267,24 @@ namespace TerminalHub.Services
                     var claudeArgs = TerminalConstants.BuildClaudeCodeArgs(options, ResolveClaudeMcpConfigPath(), ResolveClaudeHookConfigPath(sessionId));
                     var claudeCmdPath = GetClaudeCmdPath();
 
-                    // ネイティブ版(.exe)は直接実行、npm版(.cmd)はcmd.exe経由
-                    if (claudeCmdPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // ネイティブ版: 直接実行
-                        return (claudeCmdPath, claudeArgs);
-                    }
-                    else
-                    {
-                        // npm版: cmd.exe経由で実行
-                        var args = string.IsNullOrWhiteSpace(claudeArgs)
-                            ? $"/c \"{claudeCmdPath}\""
-                            : $"/c \"{claudeCmdPath}\" {claudeArgs}";
-                        return ("cmd.exe", args);
-                    }
+                    // ネイティブ版(.exe)・npm版(.cmd)とも cmd.exe 経由で同じ形に組み立てる。
+                    //
+                    // cmd.exe /c は「引用符がちょうど2個」の条件を外れると、先頭の引用符と末尾の引用符
+                    // だけを削る旧挙動になる（cmd /? 参照）。この形だと実行対象が "…\claude.cmd\"" のように
+                    // パスの途中へ引用符が残り、「見つからない」ではなく ERROR_INVALID_NAME
+                    // （ファイル名、ディレクトリ名、またはボリューム ラベルの構文が間違っています）で落ちる。
+                    // v1.0.71 で --settings が常時付くようになり引用符が2個→4個になったことで、
+                    // npm版の Claude Code セッションが起動できなくなっていた。
+                    //
+                    // 対策は「実行ファイルパスを引用符で囲んだうえで、全体をもう一組の引用符で囲む」。
+                    // これなら引用符付きの引数がいくつ増えても壊れない（実測確認済み）。
+                    // ネイティブ版も同じ形にするのは、パスにスペースを含むユーザー名で同種の破綻を
+                    // 起こさないため（TerminalConstants.BuildClaudeCodeArgs の引用符と同じ理由）。
+                    var quotedClaudePath = $"\"{claudeCmdPath}\"";
+                    var claudeCmdArgs = string.IsNullOrWhiteSpace(claudeArgs)
+                        ? $"/c {quotedClaudePath}"
+                        : $"/c \"{quotedClaudePath} {claudeArgs}\"";
+                    return ("cmd.exe", claudeCmdArgs);
 
                 // GeminiCLI は廃止: 既存セッションは default 分岐で通常ターミナルとして起動する
 


### PR DESCRIPTION
## 症状

v1.0.71 で **npm版 Claude Code のセッションが一切起動できない**。ターミナルに以下だけが出る。

```
ファイル名、ディレクトリ名、またはボリューム ラベルの構文が間違っています。
```

利用者からの報告で発覚（「最新にしたらトラブルになった」）。**ネイティブ版(.exe)では再現しない**ため、開発環境では気づけなかった。

## 原因

`cmd.exe /c` は「引用符がちょうど2個」の条件を外れると、**先頭の引用符と末尾の引用符だけを削る**旧挙動になる（`cmd /?` の /C の項）。

npm版は `BuildTerminalCommand` が `("cmd.exe", "/c \"<path>\" <args>")` を返し、さらに `ConPtyService` が `cmd.exe /c` を前置するため cmd が二重になる。内側の cmd が受け取る文字列は:

| バージョン | 内側 cmd が受け取る文字列 | 引用符 | 結果 |
|---|---|---|---|
| v1.0.70 以前 | `"…\claude.cmd"` | 2個 | 正常 |
| v1.0.71 | `"…\claude.cmd" --settings "…\hooks.json"` | 4個 | **破綻** |

旧挙動で先頭と末尾だけ削られると、実行対象が `…\claude.cmd"` と**パスの途中に引用符が残った文字列**になる。これは「見つからない」ではなく**パスとして不正**なので ERROR_INVALID_NAME になり、あのメッセージが出る。

`--settings`（hook）と `--mcp-config` はどちらも v1.0.71 で追加され（871a7b8 / 757f3b5、`git tag --contains` で v1.0.71 のみ）、**`--settings` は常時有効**。つまり v1.0.71 以降、npm版ユーザーは全員 100% 踏む。

**スペースは無関係**。引用符の個数だけで決まるので、`C:\Users\user\` のようなスペース無しのパスでも発生する。

## 修正

**実行ファイルパスを引用符で囲んだうえで、全体をもう一組の引用符で囲む**。引用符付きの引数がいくつ増えても壊れない。

ネイティブ版(.exe)も同じ形に統一した。ネイティブ版は引用符が2個に収まるため今回の回帰は踏まないが、**実行ファイルパスを引用符で囲んでいなかった**ため、ユーザー名にスペースを含む環境では同種の破綻を起こす状態だった。`TerminalConstants.BuildClaudeCodeArgs` には `--mcp-config` / `--settings` について「パスは必ず引用符で囲む（実測で確認済み）」という注意書きが既にあったのに、実行ファイルパス自体には適用されていなかった。

副作用として、ネイティブ版も cmd.exe を1段多く経由する（npm版・Codex・Antigravity・Grok は元からこの形なので、既存の構成と揃う形になる）。

## 検証

`cmd.exe` に実際に渡る文字列そのままで、ダミーの .cmd を起動して実測（コントロール付き）。

修正前の形:

| ケース | 結果 |
|---|---|
| 引用符2個（v1.0.71 より前の形） | 正常起動 |
| 引用符4個（--settings 追加後の形） | **`The filename, directory name, or volume label syntax is incorrect.`** |
| 内側 cmd を外しただけ | **同じく失敗**（対症療法にならないことを確認） |

修正後の形（いずれも正常起動・引数の欠落なし）:

| ケース | 結果 |
|---|---|
| 引数あり / パスにスペース無し | 正常 |
| 引数あり / **パスにスペースあり** | 正常 |
| 引数なし | 正常 |
| 引数2つ（`--mcp-config` と `--settings` の併用） | 正常 |

ビルド 0 エラー / 0 警告。

## 備考

- 自動テストは追加していない。`BuildTerminalCommand` は `net10.0-windows` 側の private メソッドで、既存のテストプロジェクト（VTエミュレータ用・`net10.0`）からは到達できないため。組み立て結果の検証は上記の実測で代替した。
- **v1.0.71 利用者に影響する回帰なので、hotfix リリースを出す価値がある。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)