### PR TITLE
fix: ConPTYの初期サイズに前回の実寸を使い起動直後の折り返しズレを減らす

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -2016,6 +2016,36 @@
     }
 
     /// <summary>
+    /// 確定した実寸を「次回の ConPTY 初期サイズ」として設定に保存する。
+    /// リサイズはドラッグ中に何度も走るため、値が変わったときだけ書き込む
+    /// （設定はファイル保存なので毎回書くと無駄な I/O になる）。
+    /// 保存に失敗しても表示には影響しないので握りつぶす（次回また記録される）。
+    /// </summary>
+    private void RememberTerminalSize(int cols, int rows)
+    {
+        if (cols <= 0 || rows <= 0) return;
+
+        try
+        {
+            var settings = AppSettingsService.GetSettings();
+            if (settings.SessionDefaults.LastTerminalCols == cols &&
+                settings.SessionDefaults.LastTerminalRows == rows)
+            {
+                return; // 変化なし
+            }
+
+            settings.SessionDefaults.LastTerminalCols = cols;
+            settings.SessionDefaults.LastTerminalRows = rows;
+            AppSettingsService.SaveSettings(settings);
+            Logger.LogDebug("[Resize] 次回の初期サイズとして記録: {Cols}x{Rows}", cols, rows);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "[Resize] 初期サイズの記録に失敗（無害・次回再記録される）");
+        }
+    }
+
+    /// <summary>
     /// ConPTY へのリサイズを即時適用する。
     /// Claude Code 等の TUI はリサイズ(WINCH)や更新のたびに ESC[H アンカーで全画面を再描画するため、
     /// サイズさえ一致していれば再描画は上書きで無害。逆にサイズ不一致の期間があると
@@ -2050,6 +2080,12 @@
         // ConPtyにリサイズを通知（activeSession と selectedSession.ConPtySession は同一インスタンス。
         // 以前は両方に Resize を呼んでいたため ResizePseudoConsole が2回走り多重化の原因になっていた）
         activeSession.Resize(cols, rows);
+
+        // 確定した実寸を次回の ConPTY 初期サイズとして覚えておく（SessionManager.ResolveInitialSize が読む）。
+        // 既定の 120x30 のまま子プロセスを起動すると実寸（166x80 前後）が確定するまで誤った桁数で
+        // 描画され、claude -c のように起動直後へ大量の履歴を描くケースでは折り返しのズレが焼き付く。
+        // ここは実寸が ConPTY に適用される唯一の合流点なので、記録もここで行う。
+        RememberTerminalSize(cols, rows);
 
         // 行数「増加」時は xterm をエミュレータ状態から再同期する（デバウンス付き）。
         // conhost は行数増加でスクロール履歴から行を引き戻してビューポートに含め、TUI の

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -2017,27 +2017,67 @@
 
     /// <summary>
     /// 確定した実寸を「次回の ConPTY 初期サイズ」として設定に保存する。
-    /// リサイズはドラッグ中に何度も走るため、値が変わったときだけ書き込む
-    /// （設定はファイル保存なので毎回書くと無駄な I/O になる）。
+    /// ドラッグ中は中間サイズが毎フレーム流れてくるので、**デバウンスしてから**書き込む。
+    /// 呼び出し元の <see cref="ApplyConPtyResize"/> は「デバウンス禁止」の即時パスであり、
+    /// そこに設定ファイルの同期全書き込み（AppSettingsService.SaveSettings）を載せると、
+    /// ドラッグ1回で数十回のブロッキング I/O が即時パスへ挟まる。記録したいのは
+    /// 「落ち着いた後の実寸」だけなので、遅らせて最後の1回だけ書けば足りる。
     /// 保存に失敗しても表示には影響しないので握りつぶす（次回また記録される）。
     /// </summary>
+    private CancellationTokenSource? _rememberSizeCts;
+    private (int Cols, int Rows)? _pendingRememberSize;
+    private const int RememberSizeDebounceMs = 1000;
+
     private void RememberTerminalSize(int cols, int rows)
     {
         if (cols <= 0 || rows <= 0) return;
 
+        _pendingRememberSize = (cols, rows);
+        var previousCts = _rememberSizeCts;
+        previousCts?.Cancel();
+        previousCts?.Dispose();
+        var cts = new CancellationTokenSource();
+        _rememberSizeCts = cts;
+        _ = SaveTerminalSizeAfterDelayAsync(cts);
+    }
+
+    private async Task SaveTerminalSizeAfterDelayAsync(CancellationTokenSource cts)
+    {
+        try
+        {
+            await Task.Delay(RememberSizeDebounceMs, cts.Token);
+        }
+        catch (TaskCanceledException)
+        {
+            return; // ドラッグ継続中。より新しいサイズに置き換えられた
+        }
+
+        FlushRememberedTerminalSize();
+    }
+
+    /// <summary>
+    /// 保留中の実寸を設定へ書き出す。デバウンス満了時のほか、破棄時にも呼ぶ
+    /// （リサイズ直後にタブを閉じた場合、取り消すと記録が落ちてしまうため）。
+    /// </summary>
+    private void FlushRememberedTerminalSize()
+    {
+        var pending = _pendingRememberSize;
+        if (pending == null) return;
+        _pendingRememberSize = null;
+
         try
         {
             var settings = AppSettingsService.GetSettings();
-            if (settings.SessionDefaults.LastTerminalCols == cols &&
-                settings.SessionDefaults.LastTerminalRows == rows)
+            if (settings.SessionDefaults.LastTerminalCols == pending.Value.Cols &&
+                settings.SessionDefaults.LastTerminalRows == pending.Value.Rows)
             {
                 return; // 変化なし
             }
 
-            settings.SessionDefaults.LastTerminalCols = cols;
-            settings.SessionDefaults.LastTerminalRows = rows;
+            settings.SessionDefaults.LastTerminalCols = pending.Value.Cols;
+            settings.SessionDefaults.LastTerminalRows = pending.Value.Rows;
             AppSettingsService.SaveSettings(settings);
-            Logger.LogDebug("[Resize] 次回の初期サイズとして記録: {Cols}x{Rows}", cols, rows);
+            Logger.LogDebug("[Resize] 次回の初期サイズとして記録: {Cols}x{Rows}", pending.Value.Cols, pending.Value.Rows);
         }
         catch (Exception ex)
         {
@@ -3309,6 +3349,12 @@
         _emulatorResyncCts?.Cancel();
         _emulatorResyncCts?.Dispose();
         _emulatorResyncCts = null;
+
+        // 実寸の記録は「取り消す」のではなく書き切る（リサイズ直後に閉じた分を落とさない）
+        _rememberSizeCts?.Cancel();
+        _rememberSizeCts?.Dispose();
+        _rememberSizeCts = null;
+        FlushRememberedTerminalSize();
 
         // 進行中のセッション切替をキャンセル
         _selectCts?.Cancel();

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -30,6 +30,18 @@ public class SessionDefaultsSettings
 {
     /// <summary>前回選んだターミナル種別。</summary>
     public TerminalType? LastTerminalType { get; set; }
+
+    // ConPTY の初期サイズ。既定の 120x30 のまま子プロセスを起動すると、ブラウザの実寸
+    // （実測で 166x80 前後）が確定するまでの間、CLI が誤った桁数で描画してしまう。
+    // 通常起動ならプロンプトだけなので描き直しで消えるが、claude -c のように
+    // 起動直後へ大量の履歴を描くケースでは折り返しがズレたまま焼き付き、
+    // 行頭に前の行の残骸が残る（ウィンドウをリサイズすると直る、という症状になる）。
+    // ターミナルは右側の1枠を使い回すためサイズはセッション横断で共通。よって
+    // アプリ全体で「最後に確定した実寸」を1つ覚え、次回の起動時サイズに使う。
+    /// <summary>最後に確定したターミナルの桁数。未計測なら null（設定既定へフォールバック）。</summary>
+    public int? LastTerminalCols { get; set; }
+    /// <summary>最後に確定したターミナルの行数。未計測なら null（設定既定へフォールバック）。</summary>
+    public int? LastTerminalRows { get; set; }
     /// <summary>Claude Code の権限モード（"bypass" | "auto" | "default"）。</summary>
     public string? LastClaudePermissionMode { get; set; }
     /// <summary>Gemini CLI の承認モード（"default" | "auto_edit" | "yolo"）。</summary>

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -502,8 +502,11 @@ namespace TerminalHub.Services
                 }
 
                 // ConPtyセッションを初期化
-                var cols = _configuration.GetValue<int>("SessionSettings:DefaultCols", TerminalConstants.DefaultCols);
-                var rows = _configuration.GetValue<int>("SessionSettings:DefaultRows", TerminalConstants.DefaultRows);
+                var (cols, rows) = ResolveInitialSize();
+                // エミュレータも同じサイズで始める。ここを揃えないと、ConPTY だけ実寸で起動して
+                // エミュレータは既定の 120x30 のまま解釈することになり、折り返しがズレた状態が
+                // 切替時リプレイの正本に焼き付く（ConPTY より先に呼ぶ＝ITerminalStateBuffer の約束）
+                sessionInfo.ResizeTerminalBuffer(cols, rows);
 
                 // 設定画面は再起動なしでも Options を更新できるため、起動に使う値をここで固定する。
                 var terminalType = sessionInfo.TerminalType;
@@ -1065,8 +1068,8 @@ namespace TerminalHub.Services
                 // 再起動で全サブエージェントは消えるため、稼働追跡もリセット（取りこぼし時の復旧経路）
                 sessionInfo.ClearRunningSubagents();
 
-                var cols = _configuration.GetValue<int>("SessionSettings:DefaultCols", TerminalConstants.DefaultCols);
-                var rows = _configuration.GetValue<int>("SessionSettings:DefaultRows", TerminalConstants.DefaultRows);
+                var (cols, rows) = ResolveInitialSize();
+                sessionInfo.ResizeTerminalBuffer(cols, rows); // ConPTY と同じサイズで始める（上と同じ理由）
                 var options = PrepareSessionOptions(sessionInfo, removeContinueOption);
                 var terminalType = sessionInfo.TerminalType;
                 var sessionProof = RotateSessionProof(sessionInfo);
@@ -1148,8 +1151,8 @@ namespace TerminalHub.Services
                     sessionInfo.HasContinueErrorOccurred = false;
                 }
 
-                var cols = _configuration.GetValue<int>("SessionSettings:DefaultCols", TerminalConstants.DefaultCols);
-                var rows = _configuration.GetValue<int>("SessionSettings:DefaultRows", TerminalConstants.DefaultRows);
+                var (cols, rows) = ResolveInitialSize();
+                sessionInfo.ResizeTerminalBuffer(cols, rows); // ConPTY と同じサイズで始める（上と同じ理由）
                 var options = PrepareSessionOptions(sessionInfo);
                 var terminalType = sessionInfo.TerminalType;
                 var sessionProof = RotateSessionProof(sessionInfo);

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -980,6 +980,35 @@ namespace TerminalHub.Services
         }
 
         /// <summary>
+        /// ConPTY の初期サイズを決める。
+        ///
+        /// 既定の 120x30 で子プロセスを起動すると、ブラウザの実寸（実測で 166x80 前後）が
+        /// 確定するまでの間、CLI が誤った桁数で描画する。通常起動ならプロンプトだけなので
+        /// 描き直しで消えるが、claude -c のように起動直後へ大量の履歴を描くケースでは
+        /// 折り返しがズレたまま焼き付き、行頭に前の行の残骸が残る
+        /// （ウィンドウをリサイズすると直る、という症状になる）。
+        ///
+        /// そこで前回確定した実寸（アプリ全体で1つ。ターミナルは右側の1枠を使い回すため
+        /// セッション横断で共通）を初期サイズに使い、不一致期間そのものを無くす。
+        /// 未計測（初回起動）だけは従来どおり設定既定へフォールバックする。
+        /// </summary>
+        private (int Cols, int Rows) ResolveInitialSize()
+        {
+            var defaultCols = _configuration.GetValue<int>("SessionSettings:DefaultCols", TerminalConstants.DefaultCols);
+            var defaultRows = _configuration.GetValue<int>("SessionSettings:DefaultRows", TerminalConstants.DefaultRows);
+
+            var last = _appSettingsService?.GetSettings().SessionDefaults;
+            var cols = last?.LastTerminalCols ?? defaultCols;
+            var rows = last?.LastTerminalRows ?? defaultRows;
+
+            // 壊れた値が保存されていても起動を壊さない
+            if (cols <= 0 || cols > short.MaxValue) cols = defaultCols;
+            if (rows <= 0 || rows > short.MaxValue) rows = defaultRows;
+
+            return (cols, rows);
+        }
+
+        /// <summary>
         /// セッションオプションを準備（--continueオプションの除外判定含む）
         /// </summary>
         private Dictionary<string, string> PrepareSessionOptions(SessionInfo sessionInfo, bool removeContinueOption = false)


### PR DESCRIPTION
## 症状

`claude -c`（前回の会話を継続）で起動した直後、**行頭に前の行の残骸が残る**表示崩れが出る。ウィンドウをリサイズすると直る。

Windows Terminal で同じ内容を `-c` 起動しても崩れないため、CLI 側ではなく TerminalHub 側の問題と切り分け済み。

## 原因

ConPTY は常に既定の **120x30** で生成される。ブラウザの実寸が確定するのは、ずっと後の「リプレイ前サイズ同期」まで待つ必要がある。

```
ConPTY を 120桁で生成 → Start() → CLI が -c の履歴を「120桁前提」で一気に描画
                                   ↑ 不一致期間。しかも描画量が最大
… 後 …                → 実サイズ(166x80)へ同期
```

通常起動ならプロンプトしか描かれないので描き直しで消えるが、`-c` は**不一致期間に大量の履歴を描く**のでズレが焼き付く。

### 実測

実ログに、セッションを初回起動するたびに以下が記録されていた。

```
リプレイ前サイズ同期: 120x30 → 166x80
```

**46桁 / 50行**の不一致。既存の `Dup6DiagnosticTests.Startup_size_mismatch_then_resize` も同じ構図（`120x30` で前半を解釈 → 実サイズへ Resize）を疑っており、今回それが実測で裏付けられた形。

なお `ApplyConPtyResize` のコメントにも設計思想として明記されている。

> サイズ不一致の期間があると、フレーム下端があふれて上端行がスクロールバックへ漏れるため、**不一致時間の最小化が最重要**

## 対策

最後に確定した実寸を設定に覚えておき、次回の ConPTY 初期サイズに使う。

ターミナルは右側の1枠を使い回すため**サイズはセッション横断で共通**。よってセッション単位ではなくアプリ全体で1つ保持する（DBスキーマ変更が不要になり、既存 `SessionDefaults` の `Last*` パターンにそのまま乗る）。

| ファイル | 変更 |
|---|---|
| `Models/AppSettings.cs` | `SessionDefaults` に `LastTerminalCols` / `LastTerminalRows` を追加 |
| `Services/SessionManager.cs` | `ResolveInitialSize()` を新設し、3箇所あった `DefaultCols/Rows` 直読みを置換。保存値が無い/壊れている場合は従来どおり設定既定へフォールバック |
| `Components/Pages/Root.razor` | `ApplyConPtyResize`（実寸が ConPTY に適用される唯一の合流点）で `RememberTerminalSize()` を呼んで記録。値が変わったときだけ保存 |

過去に「リサイズ2回で補正する」実装があり、`ResizePseudoConsole` が2回走って多重化の原因になったため外された経緯がある（コード内コメントに記録あり）。今回はその轍を踏まず、**不一致期間そのものを短くする**方向で対処している。

## 限界（緩和であって根治ではない）

| ケース | ズレ |
|---|---|
| 前回と同じ環境で起動 | **なし** |
| 前回と違うウィンドウサイズで起動 | あり。ただし**幅が小さい**ので絶対座標の再描画でほぼ覆われる |
| アプリの初回起動（保存値なし） | あり。従来どおり |

不一致期間をゼロにするには「生成前にブラウザで実測して渡す」必要があり、それは別途。本 PR は実装が軽く経路を選ばない緩和として入れる。

## テスト

- `dotnet test` 全パス（151 passed / 22 skipped）
- ビルド 警告0 / エラー0
- 実機動作は未確認（ConPTY 経路のため要ユーザー確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
