### PR TITLE
fix: MCP instructions を外部クライアント（Claude Desktop 等）対応に調整

### DIFF
--- a/TerminalHub/Mcp/McpInstructionDefaults.cs
+++ b/TerminalHub/Mcp/McpInstructionDefaults.cs
@@ -17,15 +17,23 @@ public static class McpInstructionDefaults
     public const string Template = """
         # TerminalHub ローカルMCP の使い方
 
-        あなたは TerminalHub が管理する複数ターミナルセッションの1つで動いています。
-        この MCP サーバーは、それらのセッション同士を疎につなぐための最小限のツールを提供します。
+        この MCP サーバーは、TerminalHub が管理する複数ターミナルセッションを疎につなぐための
+        最小限のツールを提供します。接続元は通常それらのセッションの1つですが、
+        外部クライアント（Claude Desktop など、TerminalHub のセッションを持たない接続）からも使えます。
 
         ## 自己識別
-        あなた自身のセッション GUID は、環境変数 `TERMINALHUB_SESSION_ID` に入っている。
-        自分自身を対象にしたいとき（例: 自分のメモ更新）は、この値を target に渡す。
+        あなたが TerminalHub のセッション内で動いている場合、自身のセッション GUID は
+        環境変数 `TERMINALHUB_SESSION_ID` に入っている。自分自身を対象にしたいとき
+        （例: 自分のメモ更新）は、この値を target に渡す。
         ただし CLI によっては tool 実行シェルへ独自の環境変数を渡さない設定があり（例: Codex の
         shell_environment_policy）、その場合 `TERMINALHUB_SESSION_ID` は空に見える。空だったときは、
-        `list_sessions` を自分の作業フォルダ・種別で絞り込み、一致する1件のセッション GUID を自分として使えばよい。
+        `list_sessions` を自分の作業フォルダ・種別で絞り込み、確実に1件へ絞り込めた場合のみ
+        その GUID を自分として使う。
+        **外部クライアント（Claude Desktop 等）から接続している場合、あなたに対応するセッションは
+        存在しない。** 1件に絞り込めないときも含め、自分を特定できないときは「セッションを持たない
+        外部クライアント」として振る舞い、`set_memo` / `set_card` は使わないこと
+        （他セッションを自分と誤認して書き換えるのを防ぐ）。`list_sessions` / `get_card` /
+        `send_to_session` は自由に使ってよい。
 
         ## ツール
         - `list_sessions`: 現在のセッション一覧（表示名・種別・フォルダ・状態・カード有無）を取得する。


### PR DESCRIPTION
## 概要

TerminalHub の `/mcp` は HTTP エンドポイントなので、Claude Desktop 等の**セッションを持たない外部クライアント**からも接続できる（Desktop を「司令塔」にして `list_sessions` → `get_card` → `send_to_session` する使い方が成立する）。しかし既定の MCP instructions テンプレートがセッション内接続を前提に書かれており、外部クライアントに対して危険な誘導があった。

## 問題

- 冒頭で「あなたは TerminalHub が管理するセッションの1つで動いています」と断定 → Desktop から読むと前提が最初から誤り
- 自己識別のフォールバックが「`TERMINALHUB_SESSION_ID` が空なら `list_sessions` を絞り込んで一致する1件を自分とせよ」 → 対応セッションが存在しない外部クライアントが**他セッションを自分と誤認し、そのセッションの memo / card を書き換える**動線がテンプレート自身に書いてあった

## 変更内容（`McpInstructionDefaults.cs` のみ）

- 冒頭: 外部クライアントからの接続もあり得ることを明記
- 自己識別: 「**確実に1件へ絞り込めた場合のみ**自分として扱う」に強化し、特定できないときは「セッションを持たない外部クライアント」として振る舞い `set_memo` / `set_card` を使わない（`list_sessions` / `get_card` / `send_to_session` は自由)という安全弁を追記

## 影響範囲

- 既定テンプレートの変更のみ。設定画面で instructions をカスタム済みのユーザーには影響しない（「既定に戻す」で新文面になる）
- コード動作の変更なし。ビルド 0警告・0エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)