### PR TITLE
fix: Codex の tool シェルへ TERMINALHUB_SESSION_ID を確実に届ける

### DIFF
--- a/TerminalHub.Terminal.Tests/CodexArgumentsTests.cs
+++ b/TerminalHub.Terminal.Tests/CodexArgumentsTests.cs
@@ -266,6 +266,35 @@ public sealed class CodexArgumentsTests
     }
 
     [Fact]
+    public void SessionIdEnv_IsInjectedViaShellEnvironmentPolicySet()
+    {
+        var sessionId = Guid.Parse("f49cfab0-13ff-46df-8d89-da9ab2d34edc");
+        var options = new Dictionary<string, string>
+        {
+            ["resume-last"] = "true"
+        };
+
+        // tool 実行シェルへ届くよう set で明示注入し、resume より前に置かれること
+        Assert.Equal(
+            "-c shell_environment_policy.set.TERMINALHUB_SESSION_ID=f49cfab0-13ff-46df-8d89-da9ab2d34edc resume --last",
+            TerminalConstants.BuildCodexArgs(options, sessionId: sessionId));
+    }
+
+    [Fact]
+    public void SessionIdEnv_DoesNotOverrideUserSuppliedValue()
+    {
+        var sessionId = Guid.Parse("f49cfab0-13ff-46df-8d89-da9ab2d34edc");
+        var options = new Dictionary<string, string>
+        {
+            ["extra-args"] = "-c shell_environment_policy.set.TERMINALHUB_SESSION_ID=user-value"
+        };
+
+        Assert.Equal(
+            "-c shell_environment_policy.set.TERMINALHUB_SESSION_ID=user-value",
+            TerminalConstants.BuildCodexArgs(options, sessionId: sessionId));
+    }
+
+    [Fact]
     public void TerminalHubHooks_AreAddedBeforeUserArgsAndResume()
     {
         var options = new Dictionary<string, string>

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -99,7 +99,8 @@
         public static string BuildCodexArgs(
             Dictionary<string, string> options,
             string? terminalHubMcpUrl = null,
-            string? terminalHubHookArgs = null)
+            string? terminalHubHookArgs = null,
+            Guid? sessionId = null)
         {
             var args = new List<string>();
 
@@ -119,6 +120,9 @@
             var userSuppliedNetworkAccess = ContainsCodexConfigOverride(options, "sandbox_workspace_write.network_access");
             var userSuppliedWebSearch = ContainsCodexConfigOverride(options, "web_search");
             var userSuppliedTerminalHubMcpUrl = ContainsCodexConfigOverride(options, "mcp_servers.terminalhub.url");
+            var userSuppliedSessionIdEnv = ContainsCodexConfigOverride(
+                options,
+                "shell_environment_policy.set.TERMINALHUB_SESSION_ID");
             if (options.TryGetValue("no-alt-screen", out var noAltScreen) && noAltScreen == "true" &&
                 !userSuppliedNoAltScreen)
             {
@@ -245,6 +249,17 @@
             if (!string.IsNullOrWhiteSpace(terminalHubMcpUrl) && !userSuppliedTerminalHubMcpUrl)
             {
                 args.Add($"-c mcp_servers.terminalhub.url={terminalHubMcpUrl}");
+            }
+
+            // Codex は shell_environment_policy 次第で tool 実行シェルへ環境変数を渡さない
+            // （inherit=core 等）。ConPTY が注入した TERMINALHUB_SESSION_ID が tool シェルから
+            // 空に見える環境があるため、shell_environment_policy.set で明示注入して確実に届ける。
+            // set はフィルタ(inherit/include_only)の後に変数を足す仕組みなので、ユーザー自身の
+            // ポリシー設定と衝突しない。手書き指定があればそちらを優先する。
+            // hook ブリッジ($env:TERMINALHUB_SESSION_ID 参照)の空振り対策も兼ねる。
+            if (sessionId.HasValue && !userSuppliedSessionIdEnv)
+            {
+                args.Add($"-c shell_environment_policy.set.TERMINALHUB_SESSION_ID={sessionId.Value}");
             }
 
             // TerminalHub の lifecycle hook もプロジェクト設定へ永続化せず、起動時だけ注入する。

--- a/TerminalHub/Mcp/McpInstructionDefaults.cs
+++ b/TerminalHub/Mcp/McpInstructionDefaults.cs
@@ -23,17 +23,14 @@ public static class McpInstructionDefaults
 
         ## 自己識別
         あなたが TerminalHub のセッション内で動いている場合、自身のセッション GUID は
-        環境変数 `TERMINALHUB_SESSION_ID` に入っている。自分自身を対象にしたいとき
-        （例: 自分のメモ更新）は、この値を target に渡す。
-        ただし CLI によっては tool 実行シェルへ独自の環境変数を渡さない設定があり（例: Codex の
-        shell_environment_policy）、その場合 `TERMINALHUB_SESSION_ID` は空に見える。空だったときは、
-        `list_sessions` を自分の作業フォルダ・種別で絞り込み、確実に1件へ絞り込めた場合のみ
-        その GUID を自分として使う。
-        **外部クライアント（Claude Desktop 等）から接続している場合、あなたに対応するセッションは
-        存在しない。** 1件に絞り込めないときも含め、自分を特定できないときは「セッションを持たない
-        外部クライアント」として振る舞い、`set_memo` / `set_card` は使わないこと
-        （他セッションを自分と誤認して書き換えるのを防ぐ）。`list_sessions` / `get_card` /
-        `send_to_session` は自由に使ってよい。
+        環境変数 `TERMINALHUB_SESSION_ID` に入っている（Codex には tool 実行シェルへも届くよう
+        起動引数で注入している）。自分自身を対象にしたいとき（例: 自分のメモ更新）は、
+        この値を target に渡す。
+        **`TERMINALHUB_SESSION_ID` が空に見えるなら、あなたは対応するセッションを持たない
+        外部クライアント（Claude Desktop 等）である可能性が高い。** その場合は自分を推測で
+        特定しようとせず、「セッションを持たない外部クライアント」として振る舞い、
+        `set_memo` / `set_card` は使わないこと（他セッションを自分と誤認して書き換えるのを防ぐ）。
+        `list_sessions` / `get_card` / `send_to_session` は自由に使ってよい。
 
         ## ツール
         - `list_sessions`: 現在のセッション一覧（表示名・種別・フォルダ・状態・カード有無）を取得する。
@@ -56,8 +53,8 @@ public static class McpInstructionDefaults
         - 大きな仕様・設計・長文を渡すときは、本文をそのまま送らず、ファイルに書いて「そのパスだけ」を
           send_to_session で送ると軽くて確実（受け手にファイルを読ませる）。ただしこれは好みの問題なので、
           直接送りたければ直接送ってよい。
-        - 返信がほしいときは、本文に自分のセッションID（`TERMINALHUB_SESSION_ID`、取れなければ list_sessions で
-          特定した自分の GUID）を書いておくこと。サーバーは送信元を相手に伝えない（エンベロープなし）ので、
+        - 返信がほしいときは、本文に自分のセッションID（`TERMINALHUB_SESSION_ID`）を書いておくこと。
+          サーバーは送信元を相手に伝えない（エンベロープなし）ので、
           相手はそれを見て send_to_session で返信できる。「終わったらこの ID に一言返して」等と添えるとよい。
         - 送り先は必ず既存セッション。存在しない相手には送れない。
 

--- a/TerminalHub/Mcp/SessionMessagingTools.cs
+++ b/TerminalHub/Mcp/SessionMessagingTools.cs
@@ -209,8 +209,9 @@ namespace TerminalHub.Mcp
         [McpServerTool(Name = "set_card")]
         [Description(
             "自分のセッションの自己紹介カード(「何ができるか」の短い自己申告。他エージェントが宛先選びに使う)を設定する。" +
-            "sessionId には必ず自分自身のセッションGUID(環境変数 TERMINALHUB_SESSION_ID の値。" +
-            "空なら list_sessions を自分の作業フォルダ・種別で絞り込んで特定)を渡すこと。" +
+            "sessionId には必ず自分自身のセッションGUID(環境変数 TERMINALHUB_SESSION_ID の値)を渡すこと。" +
+            "その環境変数が空なら、あなたはセッションを持たない外部クライアントの可能性が高いので、" +
+            "自分を推測で特定せず、このツールを使わないこと。" +
             "他セッションのカードは書き換えてはならない(カードは自己申告制)。" +
             "全体書き換え(部分更新なし)・空文字でクリア。数行の短文を想定(宛先選びの広告であって詳細ドキュメントではない)。")]
         public static async Task<SendResult> SetCard(

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -299,7 +299,8 @@ namespace TerminalHub.Services
                     var codexArgs = TerminalConstants.BuildCodexArgs(
                         options,
                         GetCodexMcpUrl(),
-                        codexHookArgs);
+                        codexHookArgs,
+                        sessionId);
                     var codexArgsString = string.IsNullOrWhiteSpace(codexArgs)
                         ? "/k codex"
                         : $"/k codex {codexArgs}";

--- a/docs/mcp-session-messaging.md
+++ b/docs/mcp-session-messaging.md
@@ -175,6 +175,11 @@ A2A の `capabilities` フィールドは**プロトコル機能宣言**（strea
 
 ## 注意点
 
+- **Codex の tool シェルへの環境変数透過**: Codex は `shell_environment_policy` 次第（`inherit=core` 等）で
+  ConPTY が注入した `TERMINALHUB_SESSION_ID` を tool 実行シェルへ渡さないことがある。このため Codex 起動時に
+  `-c shell_environment_policy.set.TERMINALHUB_SESSION_ID=<GUID>` を注入して確実に届けている
+  （`set` はフィルタ後に変数を足す仕組みでユーザーのポリシー設定と衝突しない。同キーの手書き指定があればそちらを優先）。
+  hook ブリッジ（`$env:TERMINALHUB_SESSION_ID` 参照）の空振り対策も兼ねる。
 - **ConPTY 制約**: 実際の送信テスト（ターミナルへの書き込み）は実機で行うこと。
 - **antiforgery**: 既存の `/api/hook`（JSON POST）は `UseAntiforgery` 下でも通っている実績があり、MCP の POST も通る見込み。もし `/mcp` への POST が 400 になる場合は `app.MapMcp("/mcp").DisableAntiforgery()` にする。
 - **セキュリティ**: ローカル利用前提。無認証で `/mcp` を公開するため、localhost 以外へバインドを広げる際は再評価すること。


### PR DESCRIPTION
## 概要

Codex は `shell_environment_policy` 次第（`inherit=core` 等）で、ConPTY 起動時に注入した環境変数を tool 実行シェルへ渡さない。このため Codex セッションでは `TERMINALHUB_SESSION_ID` が空に見え、MCP instructions に「空なら `list_sessions` で自分を探す」というフォールバックを置いていた。このフォールバックは外部クライアント（Claude Desktop 等）が他セッションを自分と誤認する温床でもあった（PR #176 で文言対処済み）。

本 PR は環境変数を**起動引数で明示注入**して根本解決する。後続の write key 方式（`set_memo`/`set_card` のキー認証化）の土台にもなる。

## 変更内容

### `TerminalConstants.BuildCodexArgs`
- `sessionId` パラメータを追加し、`-c shell_environment_policy.set.TERMINALHUB_SESSION_ID=<GUID>` を注入
- `set` はフィルタ（`inherit` / `include_only`）の**後に**変数を足す仕組みなので、ユーザー自身のポリシー設定と衝突しない
- 同キーを extra-args / custom-args に手書きしていればそちらを優先（既存の MCP URL / hooks 注入と同じ流儀）
- hook ブリッジ（`$env:TERMINALHUB_SESSION_ID` 参照）の空振り対策も兼ねる

### MCP instructions（`McpInstructionDefaults`）
- 「空なら list_sessions で自分を探す」フォールバックを撤去し、「空＝セッションを持たない外部クライアント扱い（`set_memo`/`set_card` は使わない）」に簡素化
- 「作法」節の同種のフォールバック表現も整理

### テスト・docs
- `CodexArgumentsTests` に回帰テスト2件追加（注入される / 手書き優先で注入されない）
- `docs/mcp-session-messaging.md` の注意点に透過問題と対策を記載

## テスト

- ビルド 0警告・0エラー、テスト 183件全合格
- **実機確認済み**: 絞られたポリシー環境（コア変数のみの tool シェル）で `TERMINALHUB_SESSION_ID` が環境変数一覧に出ることをユーザーが確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)