### PR TITLE
chore: MQTTブローカーのホストを mqtt.zio3.net へ差し替え

### DIFF
--- a/TerminalHub/Services/MqttService.cs
+++ b/TerminalHub/Services/MqttService.cs
@@ -101,7 +101,7 @@ public class MqttService : IHostedService, IDisposable
         var factory = new MqttClientFactory();
         _mqttClient = factory.CreateMqttClient();
 
-        var mqttHost = _configuration.GetValue<string>("Mqtt:Host") ?? "vps3.zio3.net";
+        var mqttHost = _configuration.GetValue<string>("Mqtt:Host") ?? "mqtt.zio3.net";
         var mqttPort = _configuration.GetValue<int>("Mqtt:Port", 1883);
         var mqttUsername = _configuration.GetValue<string>("Mqtt:Username");
         var mqttPassword = _configuration.GetValue<string>("Mqtt:Password");
@@ -204,7 +204,7 @@ public class MqttService : IHostedService, IDisposable
 
         var delays = new[] { 5, 10, 20, 30, 30, 30, 30, 30, 30, 30, 30, 30 };
 
-        var mqttHost = _configuration.GetValue<string>("Mqtt:Host") ?? "vps3.zio3.net";
+        var mqttHost = _configuration.GetValue<string>("Mqtt:Host") ?? "mqtt.zio3.net";
         var mqttPort = _configuration.GetValue<int>("Mqtt:Port", 1883);
         var mqttUsername = _configuration.GetValue<string>("Mqtt:Username");
         var mqttPassword = _configuration.GetValue<string>("Mqtt:Password");

--- a/TerminalHub/appsettings.json
+++ b/TerminalHub/appsettings.json
@@ -11,7 +11,7 @@
     "DefaultRows": 30
   },
   "Mqtt": {
-    "Host": "vps3.zio3.net",
+    "Host": "mqtt.zio3.net",
     "Port": 1883,
     "Username": "",
     "Password": "",

--- a/docs/mqtt-api-spec.md
+++ b/docs/mqtt-api-spec.md
@@ -22,7 +22,7 @@ claude/{TopicGUID}/response  — TerminalHub → クライアント
 ```
 
 - `TopicGUID`: TerminalHubの設定画面で有効化時に自動生成されるGUID
-- ブローカー: `vps3.zio3.net:1883`（TCP）
+- ブローカー: `mqtt.zio3.net:1883`（TCP）
 - ACL: `ClaudeLauncher` ユーザーは `claude/#` 配下のみアクセス可能
 
 ## アクセスURL


### PR DESCRIPTION
@
## 概要

MQTTブローカーの接続先ホストを `vps3.zio3.net` から `mqtt.zio3.net` へ差し替える。

## 背景

両ホストは同一サーバーを指す（実測で確認済み）:

```
mqtt.zio3.net → 160.251.182.192
vps3.zio3.net → 160.251.182.192
```

用途が明確な `mqtt` サブドメインへURLを統一する。

## 変更箇所（全4箇所）

- `TerminalHub/appsettings.json` — `Mqtt:Host` 設定値
- `TerminalHub/Services/MqttService.cs` — 接続・再接続時のフォールバック値（2箇所）
- `docs/mqtt-api-spec.md` — ブローカーアドレスの記述

## 確認

- Release ビルド成功
- `PublicKey` 等その他の Mqtt 設定は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@