### PR TITLE
fix: サイズ記録が実際には一度も走っていなかった（合流点の見落とし）

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1526,6 +1526,10 @@
                     // 必ずエミュレータ → ConPTY の順（再送データより先に画面を空にするため）
                     selectedSession.ResizeTerminalBuffer(size.Cols, size.Rows);
                     activeSession.Resize(size.Cols, size.Rows);
+                    // 実寸が ConPTY に適用される合流点は ApplyConPtyResize とここの2つある。
+                    // むしろセッションを開く通常のフローではこちらだけが通り（ApplyConPtyResize は
+                    // 同サイズガードで早期 return する）、ここで記録しないと保存値が永久に null のままになる。
+                    RememberTerminalSize(size.Cols, size.Rows);
                 }
 
                 // スナップショット生成と同時にライブ出力のテール記録を開始し、
@@ -2077,7 +2081,8 @@
             settings.SessionDefaults.LastTerminalCols = pending.Value.Cols;
             settings.SessionDefaults.LastTerminalRows = pending.Value.Rows;
             AppSettingsService.SaveSettings(settings);
-            Logger.LogDebug("[Resize] 次回の初期サイズとして記録: {Cols}x{Rows}", pending.Value.Cols, pending.Value.Rows);
+            // デバウンス後に1回だけなので Information でよい（効いているかを実機で確認できるようにする）
+            Logger.LogInformation("[Resize] 次回の初期サイズとして記録: {Cols}x{Rows}", pending.Value.Cols, pending.Value.Rows);
         }
         catch (Exception ex)
         {
@@ -2124,7 +2129,8 @@
         // 確定した実寸を次回の ConPTY 初期サイズとして覚えておく（SessionManager.ResolveInitialSize が読む）。
         // 既定の 120x30 のまま子プロセスを起動すると実寸（166x80 前後）が確定するまで誤った桁数で
         // 描画され、claude -c のように起動直後へ大量の履歴を描くケースでは折り返しのズレが焼き付く。
-        // ここは実寸が ConPTY に適用される唯一の合流点なので、記録もここで行う。
+        // 実寸が ConPTY に適用される合流点はここと SelectSession のリプレイ前サイズ同期の2つ。
+        // 両方で記録する（このパスは同サイズガードで早期 return するため、通らないことも多い）。
         RememberTerminalSize(cols, rows);
 
         // 行数「増加」時は xterm をエミュレータ状態から再同期する（デバウンス付き）。

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1529,7 +1529,15 @@
                     // 実寸が ConPTY に適用される合流点は ApplyConPtyResize とここの2つある。
                     // むしろセッションを開く通常のフローではこちらだけが通り（ApplyConPtyResize は
                     // 同サイズガードで早期 return する）、ここで記録しないと保存値が永久に null のままになる。
-                    RememberTerminalSize(size.Cols, size.Rows);
+                    //
+                    // ただし記録するのは復元対象がまだアクティブなときだけにする。上の await をまたぐ間に
+                    // 別の切替や再作成が割り込むと activeSession が別セッションを指しうる（この関数の冒頭の
+                    // 注意書き参照）。リサイズ自体は次の切替で自己修正されるが、保存値は
+                    // ResolveInitialSize が以降の全新規セッションに使うため、取り違えが永続化してしまう。
+                    if (activeSessionId == sessionId)
+                    {
+                        RememberTerminalSize(size.Cols, size.Rows);
+                    }
                 }
 
                 // スナップショット生成と同時にライブ出力のテール記録を開始し、
@@ -2021,8 +2029,11 @@
 
     /// <summary>
     /// 確定した実寸を「次回の ConPTY 初期サイズ」として設定に保存する。
+    /// 呼び出し元は <see cref="ApplyConPtyResize"/> と SelectSession のリプレイ前サイズ同期の2箇所
+    /// （実寸が ConPTY に適用される合流点はこの2つ。通常のセッション選択では前者は同サイズガードで
+    /// 早期 return するため、後者だけが通る）。
     /// ドラッグ中は中間サイズが毎フレーム流れてくるので、**デバウンスしてから**書き込む。
-    /// 呼び出し元の <see cref="ApplyConPtyResize"/> は「デバウンス禁止」の即時パスであり、
+    /// <see cref="ApplyConPtyResize"/> は「デバウンス禁止」の即時パスであり、
     /// そこに設定ファイルの同期全書き込み（AppSettingsService.SaveSettings）を載せると、
     /// ドラッグ1回で数十回のブロッキング I/O が即時パスへ挟まる。記録したいのは
     /// 「落ち着いた後の実寸」だけなので、遅らせて最後の1回だけ書けば足りる。
@@ -2086,7 +2097,9 @@
         }
         catch (Exception ex)
         {
-            Logger.LogDebug(ex, "[Resize] 初期サイズの記録に失敗（無害・次回再記録される）");
+            // 失敗も既定のログ設定で見えるようにする。Debug のままだと「記録されないのに誰も気づけない」
+            // という、この修正が潰したはずの状態を失敗側で再現してしまう（PR #171 の根本原因がそれ）
+            Logger.LogWarning(ex, "[Resize] 初期サイズの記録に失敗（表示には無害・次回再記録される）");
         }
     }
 


### PR DESCRIPTION
## 症状

PR #171 をマージ・インストールしたが効いていなかった。`app-settings.json` の `lastTerminalCols` / `lastTerminalRows` が `null` のまま更新されず、起動のたびに `リプレイ前サイズ同期: 120x30 → 234x116` が出続けていた。

## 原因

**実寸が ConPTY に適用される合流点は2つある。** #171 は `ApplyConPtyResize` にしか記録を入れていなかった。

```
[Resize] ConPTY適用                  0件   ← 記録処理はここ
[SelectSession] リプレイ前サイズ同期    3件   ← 実際にサイズを合わせているのはこちら
```

セッションを開く通常のフローでは `ApplyConPtyResize` は同サイズガード（`activeSession.Cols == cols && activeSession.Rows == rows`）で早期 return するため、記録に到達しない。実際に効いているのは `SelectSession` のリプレイ前サイズ同期のほうで、そこには記録が無かった。

結果、保存されない → 次回起動も保存値なし → `120x30` にフォールバック、という閉じたループになっていた。#171 のコメントにあった「ここは実寸が ConPTY に適用される唯一の合流点」という記述が事実と異なっていた。

## 対策

- `SelectSession` のサイズ同期でも `RememberTerminalSize` を呼ぶ
- 「唯一の合流点」という誤ったコメントを訂正（両方で記録する旨に）
- 記録ログを `LogDebug` → `LogInformation`。Debug は既定のログ設定では出力されず、効いているかを実機で確認する手段が無かった。デバウンス後に1回だけなので Information で問題ない

## 実機確認

**1回目の起動**（保存値がまだ無いので `120x30` 開始が正常）

```
09:15:24  [SelectSession] リプレイ前サイズ同期: 120x30 → 234x116
09:15:25  [Resize] 次回の初期サイズとして記録: 234x116     ← 初めて出た
```

`app-settings.json` に `lastTerminalCols=234` / `lastTerminalRows=116` が入った（従来は null）。デバウンスも効いており記録ログは1件のみ。

**2回目の起動**

```
リプレイ前サイズ同期   0件   ← 今朝の時点で350件出ていたものが消えた
ConPTY適用           0件

リングの先頭マーカー: #0 ---- Resize 229x109 ----   ← 実寸で始まる（従来は 120x30）
```

起動時点でサイズが一致しているため同期そのものが発生しない。従来の114桁ズレが解消され、`claude -c` が履歴を描く前にサイズが確定する。

## 確認

- ビルド 警告0 / エラー0
- テスト 186件すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)