### PR TITLE
ターミナル起動コマンドの組み立てを整理

### DIFF
--- a/TerminalHub.Terminal.Tests/TerminalCommandLineTests.cs
+++ b/TerminalHub.Terminal.Tests/TerminalCommandLineTests.cs
@@ -1,0 +1,58 @@
+using TerminalHub.Services;
+using Xunit;
+
+namespace TerminalHub.Terminal.Tests;
+
+public sealed class TerminalCommandLineTests
+{
+    [Theory]
+    [InlineData(null, "/k codex")]
+    [InlineData("", "/k codex")]
+    [InlineData("--search resume --last", "/k codex --search resume --last")]
+    public void KeepOpenは空の引数による余分な空白を作らない(string? arguments, string expected)
+    {
+        var actual = TerminalCommandLine.KeepOpen("codex", arguments);
+
+        Assert.Equal(("cmd.exe", expected), actual);
+    }
+
+    [Fact]
+    public void ExecuteQuotedはスペース入りパスと引用符付き引数を二重に保護する()
+    {
+        var actual = TerminalCommandLine.ExecuteQuoted(
+            @"C:\Users\John Smith\claude.cmd",
+            @"--settings ""C:\Users\John Smith\hooks.json""");
+
+        Assert.Equal(
+            ("cmd.exe", @"/c """"C:\Users\John Smith\claude.cmd"" --settings ""C:\Users\John Smith\hooks.json"""""),
+            actual);
+    }
+
+    [Fact]
+    public void ExecuteQuotedは引数なしなら実行ファイルだけを引用する()
+    {
+        var actual = TerminalCommandLine.ExecuteQuoted(@"C:\Program Files\claude.exe", null);
+
+        Assert.Equal(("cmd.exe", @"/c ""C:\Program Files\claude.exe"""), actual);
+    }
+
+    [Fact]
+    public void ResolveShellは空白のカスタムコマンドを既定値へ戻す()
+    {
+        var actual = TerminalCommandLine.ResolveShell(
+            new Dictionary<string, string> { ["command"] = "  " },
+            "powershell.exe");
+
+        Assert.Equal(("powershell.exe", string.Empty), actual);
+    }
+
+    [Fact]
+    public void ResolveShellはカスタムコマンドを採用する()
+    {
+        var actual = TerminalCommandLine.ResolveShell(
+            new Dictionary<string, string> { ["command"] = "pwsh.exe" },
+            "powershell.exe");
+
+        Assert.Equal(("pwsh.exe", string.Empty), actual);
+    }
+}

--- a/TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj
+++ b/TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="..\TerminalHub\Services\ConPtyWriteChunker.cs" Link="ConPtyWriteChunker.cs" />
     <Compile Include="..\TerminalHub\Services\SlashCommandMerge.cs" Link="SlashCommandMerge.cs" />
     <Compile Include="..\TerminalHub\Services\SlashCommandFilter.cs" Link="SlashCommandFilter.cs" />
+    <Compile Include="..\TerminalHub\Services\TerminalCommandLine.cs" Link="TerminalCommandLine.cs" />
     <!-- CLI 出力解析器（UI 非依存の純ロジック）。テーブル駆動テスト用にリンク -->
     <Compile Include="..\TerminalHub\Helpers\AnsiHelper.cs" Link="AnsiHelper.cs" />
     <Compile Include="..\TerminalHub\Analyzers\IOutputAnalyzer.cs" Link="IOutputAnalyzer.cs" />

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -303,6 +303,8 @@ namespace TerminalHub.Services
             {
                 case TerminalType.ClaudeCode:
                     var claudeArgs = TerminalConstants.BuildClaudeCodeArgs(options, ResolveClaudeMcpConfigPath(), ResolveClaudeHookConfigPath(sessionId));
+                    // ネイティブ版(.exe)・npm版(.cmd)とも cmd.exe 経由で同じ形に組み立てる。
+                    // 引用符の二重掛けが必要な理由（v1.0.71 の起動不能回帰）は ExecuteQuoted のコメント参照。
                     return TerminalCommandLine.ExecuteQuoted(GetClaudeCmdPath(), claudeArgs);
 
                 // GeminiCLI は廃止: 既存セッションは default 分岐で通常ターミナルとして起動する

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -303,26 +303,7 @@ namespace TerminalHub.Services
             {
                 case TerminalType.ClaudeCode:
                     var claudeArgs = TerminalConstants.BuildClaudeCodeArgs(options, ResolveClaudeMcpConfigPath(), ResolveClaudeHookConfigPath(sessionId));
-                    var claudeCmdPath = GetClaudeCmdPath();
-
-                    // ネイティブ版(.exe)・npm版(.cmd)とも cmd.exe 経由で同じ形に組み立てる。
-                    //
-                    // cmd.exe /c は「引用符がちょうど2個」の条件を外れると、先頭の引用符と末尾の引用符
-                    // だけを削る旧挙動になる（cmd /? 参照）。この形だと実行対象が "…\claude.cmd\"" のように
-                    // パスの途中へ引用符が残り、「見つからない」ではなく ERROR_INVALID_NAME
-                    // （ファイル名、ディレクトリ名、またはボリューム ラベルの構文が間違っています）で落ちる。
-                    // v1.0.71 で --settings が常時付くようになり引用符が2個→4個になったことで、
-                    // npm版の Claude Code セッションが起動できなくなっていた。
-                    //
-                    // 対策は「実行ファイルパスを引用符で囲んだうえで、全体をもう一組の引用符で囲む」。
-                    // これなら引用符付きの引数がいくつ増えても壊れない（実測確認済み）。
-                    // ネイティブ版も同じ形にするのは、パスにスペースを含むユーザー名で同種の破綻を
-                    // 起こさないため（TerminalConstants.BuildClaudeCodeArgs の引用符と同じ理由）。
-                    var quotedClaudePath = $"\"{claudeCmdPath}\"";
-                    var claudeCmdArgs = string.IsNullOrWhiteSpace(claudeArgs)
-                        ? $"/c {quotedClaudePath}"
-                        : $"/c \"{quotedClaudePath} {claudeArgs}\"";
-                    return ("cmd.exe", claudeCmdArgs);
+                    return TerminalCommandLine.ExecuteQuoted(GetClaudeCmdPath(), claudeArgs);
 
                 // GeminiCLI は廃止: 既存セッションは default 分岐で通常ターミナルとして起動する
 
@@ -334,34 +315,18 @@ namespace TerminalHub.Services
                         codexHookArgs,
                         sessionId,
                         sessionProof);
-                    var codexArgsString = string.IsNullOrWhiteSpace(codexArgs)
-                        ? "/k codex"
-                        : $"/k codex {codexArgs}";
-                    return ("cmd.exe", codexArgsString);
+                    return TerminalCommandLine.KeepOpen("codex", codexArgs);
 
                 case TerminalType.Antigravity:
                     var agyArgs = TerminalConstants.BuildAntigravityArgs(options);
-                    var agyArgsString = string.IsNullOrWhiteSpace(agyArgs)
-                        ? "/k agy"
-                        : $"/k agy {agyArgs}";
-                    return ("cmd.exe", agyArgsString);
+                    return TerminalCommandLine.KeepOpen("agy", agyArgs);
 
                 case TerminalType.Grok:
                     var grokArgs = TerminalConstants.BuildGrokArgs(options);
-                    var grokArgsString = string.IsNullOrWhiteSpace(grokArgs)
-                        ? "/k grok"
-                        : $"/k grok {grokArgs}";
-                    return ("cmd.exe", grokArgsString);
+                    return TerminalCommandLine.KeepOpen("grok", grokArgs);
 
                 default:
-                    if (options.ContainsKey("command") && !string.IsNullOrWhiteSpace(options["command"]))
-                    {
-                        return (options["command"], "");
-                    }
-                    else
-                    {
-                        return (TerminalConstants.DefaultShell, "");
-                    }
+                    return TerminalCommandLine.ResolveShell(options, TerminalConstants.DefaultShell);
             }
         }
 

--- a/TerminalHub/Services/TerminalCommandLine.cs
+++ b/TerminalHub/Services/TerminalCommandLine.cs
@@ -13,8 +13,20 @@ internal static class TerminalCommandLine
     }
 
     /// <summary>
-    /// パスを引用符で囲み、cmd.exe /c に渡すコマンド全体も必要に応じて引用符で囲む。
-    /// 引数内に引用符が増えても cmd.exe が実行ファイルパスの引用符を誤って除去しない形にする。
+    /// 実行ファイルパスを引用符で囲んだうえで、引数があればコマンド全体をもう一組の引用符で囲む。
+    /// **この二重の引用符は冗長に見えるが必須**。単純化すると下記の回帰を再発させる。
+    ///
+    /// cmd.exe /c は「引用符がちょうど2個」の条件を外れると、先頭の引用符と末尾の引用符
+    /// だけを削る旧挙動になる（cmd /? 参照）。この形だと実行対象が "…\claude.cmd\"" のように
+    /// パスの途中へ引用符が残り、「見つからない」ではなく ERROR_INVALID_NAME
+    /// （ファイル名、ディレクトリ名、またはボリューム ラベルの構文が間違っています）で落ちる。
+    /// v1.0.71 で --settings が常時付くようになり引用符が2個→4個になったことで、
+    /// npm版の Claude Code セッションが起動できなくなっていた（4c22b53 / PR #170 で修正）。
+    ///
+    /// 「パスを囲んだうえで全体をもう一組で囲む」形なら、引用符付きの引数がいくつ増えても
+    /// 壊れない（実測確認済み）。ネイティブ版(.exe)も npm版(.cmd)と同じ形にするのは、
+    /// パスにスペースを含むユーザー名で同種の破綻を起こさないため
+    /// （TerminalConstants.BuildClaudeCodeArgs の引用符と同じ理由）。
     /// </summary>
     internal static (string Command, string Arguments) ExecuteQuoted(string executablePath, string? arguments)
     {

--- a/TerminalHub/Services/TerminalCommandLine.cs
+++ b/TerminalHub/Services/TerminalCommandLine.cs
@@ -1,0 +1,45 @@
+namespace TerminalHub.Services;
+
+/// <summary>
+/// CLI を Windows コマンドプロンプト経由で起動するための引数を組み立てる。
+/// ツール固有のオプション生成と、cmd.exe 固有の引用符規則を分離する。
+/// </summary>
+internal static class TerminalCommandLine
+{
+    internal static (string Command, string Arguments) KeepOpen(string executable, string? arguments)
+    {
+        var commandLine = Join(executable, arguments);
+        return ("cmd.exe", $"/k {commandLine}");
+    }
+
+    /// <summary>
+    /// パスを引用符で囲み、cmd.exe /c に渡すコマンド全体も必要に応じて引用符で囲む。
+    /// 引数内に引用符が増えても cmd.exe が実行ファイルパスの引用符を誤って除去しない形にする。
+    /// </summary>
+    internal static (string Command, string Arguments) ExecuteQuoted(string executablePath, string? arguments)
+    {
+        var quotedPath = $"\"{executablePath}\"";
+        var commandLine = Join(quotedPath, arguments);
+        var cmdArguments = string.IsNullOrWhiteSpace(arguments)
+            ? $"/c {commandLine}"
+            : $"/c \"{commandLine}\"";
+
+        return ("cmd.exe", cmdArguments);
+    }
+
+    internal static (string Command, string Arguments) ResolveShell(
+        IReadOnlyDictionary<string, string> options,
+        string defaultShell)
+    {
+        return options.TryGetValue("command", out var command) && !string.IsNullOrWhiteSpace(command)
+            ? (command, string.Empty)
+            : (defaultShell, string.Empty);
+    }
+
+    private static string Join(string executable, string? arguments)
+    {
+        return string.IsNullOrWhiteSpace(arguments)
+            ? executable
+            : $"{executable} {arguments}";
+    }
+}


### PR DESCRIPTION
### Motivation
- `SessionManager.BuildTerminalCommand` に `cmd.exe` 固有の引数組み立てロジックが散在しており可読性とテスト性が低かったため整理する。
- スペースを含むパスや引用符付き引数、空引数、カスタムシェル指定など境界条件で壊れやすい箇所を明確に分離して回帰防止したい。 

### Description
- `TerminalHub/Services/TerminalCommandLine.cs` を追加し、`cmd.exe` 用の引数組み立て（`ExecuteQuoted` / `KeepOpen` / `ResolveShell`）を純粋関数として切り出した。 
- `SessionManager.BuildTerminalCommand` の各分岐（Claude/Codex/Antigravity/Grok/デフォルト）を切り出したヘルパー呼び出しへ置換して責務を簡素化した。 
- テストプロジェクト `TerminalHub.Terminal.Tests` に新しいユニットテスト `TerminalCommandLineTests.cs` を追加し、スペース入りパスや引用符付き引数、空引数、カスタムシェル選択の境界条件を検証するテストケースを用意した。 
- テスト用に `TerminalCommandLine.cs` をテストプロジェクトにリンクするため `TerminalHub.Terminal.Tests.csproj` を更新した。 

### Testing
- `git diff --cached --check` による差分チェックは通過した。 
- `dotnet test TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj --no-restore` を実行しようとしたが、実行環境に `dotnet` がインストールされていないためテストは実行できていない（追加したユニットテストはプロジェクト内に含まれている）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ab3bee630832f933ca6d6076c54d1)