### PR TITLE
fix: セッション削除時に子セッションも一緒に削除する

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1913,9 +1913,13 @@
 
     private async Task DeleteArchivedSession(Guid sessionId)
     {
-        SessionManager.DeleteSession(sessionId);
-        await DeleteSessionFromStorageAsync(sessionId);
-        bottomPanel?.RemoveMemoTabsForSession(sessionId);
+        // DeleteSession は子セッションも道連れにするので、後始末は「実際に消えた全件」に対して行う。
+        var deletedIds = SessionManager.DeleteSession(sessionId);
+        foreach (var deletedId in deletedIds)
+        {
+            await DeleteSessionFromStorageAsync(deletedId);
+            bottomPanel?.RemoveMemoTabsForSession(deletedId);
+        }
 
         sessions = SessionManager.GetAllSessions().ToList();
         StateHasChanged();
@@ -1926,9 +1930,13 @@
         var archivedSessions = SessionManager.GetAllSessions().Where(s => s.IsArchived).ToList();
         foreach (var session in archivedSessions)
         {
-            SessionManager.DeleteSession(session.SessionId);
-            await DeleteSessionFromStorageAsync(session.SessionId);
-            bottomPanel?.RemoveMemoTabsForSession(session.SessionId);
+            // 先に消した親の道連れで既に消えている場合があり、そのときは空が返る（後始末も不要）。
+            var deletedIds = SessionManager.DeleteSession(session.SessionId);
+            foreach (var deletedId in deletedIds)
+            {
+                await DeleteSessionFromStorageAsync(deletedId);
+                bottomPanel?.RemoveMemoTabsForSession(deletedId);
+            }
         }
 
         sessions = SessionManager.GetAllSessions().ToList();

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -695,6 +695,9 @@
                             sessionInfo.SessionId, sessionInfo.DisplayName);
                     }
                 }
+
+                // 全件そろってから孤児を掃除する（復元順で親がまだ居ないだけ、を誤判定しないため）
+                await CleanupOrphanSessionsAsync();
             }
 
             // SessionManagerから全セッションを取得（アーカイブ含む）
@@ -1908,6 +1911,37 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "アーカイブセッションの復元に失敗しました: {SessionId}", sessionId);
+        }
+    }
+
+    /// <summary>
+    /// 親が存在しない子セッション（孤児）を削除する。起動時の復元直後に1回だけ走る。
+    ///
+    /// 削除は子へカスケードするようになったので、これから孤児が生まれることはない。
+    /// 対象はそれ以前に溜まった分で、UI が孤児を最上位に並べるのをやめた結果、
+    /// 人間から見えず削除もできないまま残り続けるのを避けるために掃除する
+    /// （ConPTY を持ったまま生きている孤児があれば、見えないプロセスが動き続けることになる）。
+    /// </summary>
+    private async Task CleanupOrphanSessionsAsync()
+    {
+        // 削除しながら列挙しないよう先にスナップショットを取る
+        var all = SessionManager.GetAllSessions().ToList();
+        var existingIds = all.Select(s => s.SessionId).ToHashSet();
+        var orphans = all
+            .Where(s => s.ParentSessionId.HasValue && !existingIds.Contains(s.ParentSessionId.Value))
+            .ToList();
+
+        foreach (var orphan in orphans)
+        {
+            Logger.LogWarning("[起動] 孤児セッションを削除します: SessionId={SessionId}, Name={Name}, ParentSessionId={ParentSessionId}",
+                orphan.SessionId, orphan.GetDisplayName(), orphan.ParentSessionId);
+
+            // 孤児が孤児を子に持つ場合はカスケードで既に消えているので、空が返る＝後始末も不要
+            var deletedIds = SessionManager.DeleteSession(orphan.SessionId);
+            foreach (var deletedId in deletedIds)
+            {
+                await DeleteSessionFromStorageAsync(deletedId);
+            }
         }
     }
 

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -352,11 +352,6 @@
         // 親セッションのみ抽出
         var parentSessions = filteredSessions.Where(s => !s.ParentSessionId.HasValue).ToList();
 
-        // 親が存在しない子セッション（孤児）も追加
-        var orphanSessions = filteredSessions
-            .Where(s => s.ParentSessionId.HasValue && !Sessions.Any(p => p.SessionId == s.ParentSessionId))
-            .ToList();
-
         // ソート用のキーを計算（lastAccessedの場合は子セッションの最終アクセス日時も考慮）
         // ソート: ピン留め → ピン優先度 → ユーザー設定のソート
         IOrderedEnumerable<SessionInfo> sortedParents;
@@ -421,15 +416,10 @@
             result.Add(group);
         }
 
-        // 孤児セッションを追加
-        foreach (var orphan in orphanSessions)
-        {
-            if (!processed.Contains(orphan.SessionId))
-            {
-                result.Add(new List<SessionInfo> { orphan });
-                processed.Add(orphan.SessionId);
-            }
-        }
+        // 孤児（親が存在しない子）は表示しない。
+        // 削除は子へカスケードするので本来この状態は作られず、それ以前に溜まった分は
+        // 起動時に掃除される（Root の CleanupOrphanSessionsAsync）。掃除の前後で
+        // 一瞬だけ現れうるが、最上位に混ぜて出すと親子の見え方が壊れるので出さない。
 
         return result;
     }

--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -112,9 +112,11 @@ namespace TerminalHub.Services
         Task<SessionInfo?> RestoreArchivedSessionAsync(Guid sessionId);
 
         /// <summary>
-        /// セッションを完全削除（アーカイブ含む）
+        /// セッションを完全削除（アーカイブ含む）。
+        /// 子セッション（worktree）も一緒に削除し、実際に削除した SessionId を返す。
+        /// 呼び出し側は返った ID すべてについて永続化側の後始末を行うこと。
         /// </summary>
-        void DeleteSession(Guid sessionId);
+        IReadOnlyList<Guid> DeleteSession(Guid sessionId);
     }
 
     public class SessionManager : ISessionManager, IDisposable
@@ -1308,66 +1310,116 @@ namespace TerminalHub.Services
         }
 
         /// <summary>
-        /// セッションを完全削除（アーカイブ含む）
+        /// セッションを完全削除（アーカイブ含む）。子セッションも一緒に削除する。
+        ///
+        /// 親だけを消すと、子は ParentSessionId が誰も指さない孤児として残る
+        /// （ParentSessionId をクリアする処理はどこにも無く、永続化側にも残り続ける）。
+        /// アーカイブ済みの親は UI で子ごと畳まれて見えないため、そこから親を削除すると
+        /// 「見えない孤児」だけが積み上がっていた。親を消すなら子も道連れにする。
+        ///
+        /// 戻り値は実際に削除した SessionId（親を含む）。呼び出し側はこの全件について
+        /// 永続化側（DB・メモタブ等）の後始末を行うこと。
         /// </summary>
-        public void DeleteSession(Guid sessionId)
+        public IReadOnlyList<Guid> DeleteSession(Guid sessionId)
         {
-            ConPtySession? sessionToDispose = null;
-            ConPtySession? sessionInfoConPtyToDispose = null;
-            SemaphoreSlim? initLockToDispose = null;
-            bool deleted = false;
+            var toDispose = new List<IDisposable>();
+            var deletedIds = new List<Guid>();
 
             lock (_lockObject)
             {
-                // ConPtyセッションが存在する場合は取得
-                if (_sessions.TryRemove(sessionId, out var session))
+                foreach (var id in CollectSelfAndDescendants(sessionId))
                 {
-                    sessionToDispose = session;
-                    deleted = true;
-                }
+                    ConPtySession? sessionToDispose = null;
+                    var deleted = false;
 
-                // SessionInfoを削除
-                if (_sessionInfos.TryRemove(sessionId, out var sessionInfo))
-                {
-                    // 二重Dispose防止
-                    if (sessionInfo.ConPtySession != null &&
-                        !ReferenceEquals(sessionInfo.ConPtySession, sessionToDispose))
+                    // ConPtyセッションが存在する場合は取得
+                    if (_sessions.TryRemove(id, out var session))
                     {
-                        sessionInfoConPtyToDispose = sessionInfo.ConPtySession;
+                        sessionToDispose = session;
+                        toDispose.Add(session);
+                        deleted = true;
                     }
-                    sessionInfo.ConPtySession = null;
-                    deleted = true;
+
+                    // SessionInfoを削除
+                    if (_sessionInfos.TryRemove(id, out var sessionInfo))
+                    {
+                        // 二重Dispose防止
+                        if (sessionInfo.ConPtySession != null &&
+                            !ReferenceEquals(sessionInfo.ConPtySession, sessionToDispose))
+                        {
+                            toDispose.Add(sessionInfo.ConPtySession);
+                        }
+                        sessionInfo.ConPtySession = null;
+                        deleted = true;
+                    }
+
+                    // 初期化ロックを削除
+                    if (_initializationLocks.TryRemove(id, out var initLock))
+                    {
+                        toDispose.Add(initLock);
+                    }
+
+                    if (deleted)
+                    {
+                        deletedIds.Add(id);
+                    }
                 }
 
-                // 初期化ロックを削除
-                if (_initializationLocks.TryRemove(sessionId, out var initLock))
-                {
-                    initLockToDispose = initLock;
-                }
-
-                // アクティブセッションの更新
-                if (deleted && _activeSessionId == sessionId)
+                // アクティブセッションの更新（消えたのが表示中なら別のものへ寄せる）
+                if (_activeSessionId.HasValue && deletedIds.Contains(_activeSessionId.Value))
                 {
                     _activeSessionId = _sessionInfos.Keys.FirstOrDefault();
                 }
             }
 
             // ロック外でDispose（デッドロック防止）
-            sessionToDispose?.Dispose();
-            sessionInfoConPtyToDispose?.Dispose();
-            initLockToDispose?.Dispose();
+            foreach (var d in toDispose)
+            {
+                d.Dispose();
+            }
 
-            if (deleted)
+            foreach (var id in deletedIds)
             {
                 // 生ストリームキャプチャのライターも閉じる（ハンドルリーク防止）
-                _rawStreamCapture?.CloseSession(sessionId);
+                _rawStreamCapture?.CloseSession(id);
                 // --settings 用 hook 設定ファイルの後始末（残っても実害はないが溜めない）
-                _claudeHookService?.DeleteHookConfigFile(sessionId);
+                _claudeHookService?.DeleteHookConfigFile(id);
                 // --mcp-config 用 MCP 設定ファイルの後始末（接続キーが書かれたファイルなので残さない）
-                _mcpConfigService?.DeleteMcpConfigFile(sessionId);
-                _logger.LogInformation("セッションを完全削除しました: {SessionId}", sessionId);
+                _mcpConfigService?.DeleteMcpConfigFile(id);
+                _logger.LogInformation("セッションを完全削除しました: {SessionId}", id);
+            }
+
+            if (deletedIds.Count > 0)
+            {
                 NotifySessionsChanged();
             }
+
+            return deletedIds;
+        }
+
+        /// <summary>
+        /// 自分自身と、その配下の子セッションを列挙する（親が先・子が後）。
+        /// 階層は worktree の1段だけだが、取りこぼしと循環参照のどちらでも壊れないよう
+        /// 訪問済みを持って推移的にたどる。呼び出しは _lockObject 保持下で行うこと。
+        /// </summary>
+        private List<Guid> CollectSelfAndDescendants(Guid rootId)
+        {
+            var ordered = new List<Guid> { rootId };
+            var visited = new HashSet<Guid> { rootId };
+
+            for (var i = 0; i < ordered.Count; i++)
+            {
+                var parentId = ordered[i];
+                foreach (var child in _sessionInfos.Values)
+                {
+                    if (child.ParentSessionId == parentId && visited.Add(child.SessionId))
+                    {
+                        ordered.Add(child.SessionId);
+                    }
+                }
+            }
+
+            return ordered;
         }
 
         /// <summary>


### PR DESCRIPTION
## 概要

セッションを完全削除するとき、その子セッション（worktree）も一緒に削除します。あわせて、孤児（親が存在しない子）を UI から消し、起動時に掃除します。

## なぜ

親だけを消すと、子は `ParentSessionId` が誰も指さない**孤児**として残っていました。`ParentSessionId` をクリアする処理はコード中のどこにも無く、DB にもそのまま残り続けます。

とくに厄介なのがアーカイブ経由です。親をアーカイブすると、その子は UI の一覧から姿を消します（仕様）。

- `GetFilteredSessions()` がアーカイブを除外するので、親は親行の候補から外れる
- 孤児判定は「親が `Sessions` に存在するか」しか見ておらず、アーカイブ済みの親も `GetAllSessions()` には残っているため、子は孤児にもならない

結果、子はどこにも描画されません。その状態でアーカイブ一覧から親を削除すると、**見えない孤児だけが積み上がる**ことになります。

## 変更内容

### 1. 削除を子へカスケード

`SessionManager.DeleteSession` が自分と配下の子を削除し、**実際に削除した SessionId のリストを返す**ようにしました（`void` → `IReadOnlyList<Guid>`）。呼び出し側の `Root.DeleteArchivedSession` / `DeleteAllArchivedSessions` は、返った全件について DB とメモタブの後始末を行います。

- **戻り値で ID を返す理由**: カスケードの規則は階層を知っている `SessionManager` に閉じ込めつつ、永続化の後始末は Root が担うという既存の役割分担を崩さないため。ID を返さないと「メモリからは消えたが DB に残る」子が発生します
- **一括削除の二重処理を回避**: 「アーカイブを全削除」は親→子の順に回るので、子に到達した時点で既に道連れで消えています。その場合は空リストが返るため後始末をスキップできます
- **推移的にたどる**: 階層は worktree の1段だけですが、訪問済み集合を持って辿ります。将来ネストが増えても、循環参照が混ざっても壊れません

### 2. 孤児を UI から消し、起動時に掃除

孤児を最上位に並べる表示をやめました。親子の見え方が壊れるうえ、削除がカスケードする今はそもそも生まれない状態です。

ただし非表示にするだけだと、それ以前に溜まった孤児が人間から見えず削除もできないまま残ります（ConPTY を持ったまま生きている孤児があれば、画面から見えないプロセスが動き続けます）。そこで**起動時の復元直後に1回だけ掃除**します。

- **判定は全件そろってから**: 復元の途中では「親がまだ復元されていないだけ」の子を孤児と誤判定するため
- **起動時1回のみ**: 復元処理と同じ `if (!SessionManager.HasSessions())` の中に置いたので、他ブラウザが既にセッションを持っていれば走りません
- **`LogWarning` で記録**: 黙って消すと「起動したらセッションが減っている」が不可視になります

## 検証

`dotnet build` 0 warnings / 0 errors。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
