### PR TITLE
fix: カスケード削除の順序を子が先になるよう反転する（FK違反の修正）

### DIFF
--- a/TerminalHub/Services/SessionManager.cs
+++ b/TerminalHub/Services/SessionManager.cs
@@ -1319,6 +1319,8 @@ namespace TerminalHub.Services
         ///
         /// 戻り値は実際に削除した SessionId（親を含む）。呼び出し側はこの全件について
         /// 永続化側（DB・メモタブ等）の後始末を行うこと。
+        /// **並びは子が先・親が最後**で、この順に消せば自己参照 FK に引っかからない
+        /// （順序を変えないこと。詳細は CollectSelfAndDescendants）。
         /// </summary>
         public IReadOnlyList<Guid> DeleteSession(Guid sessionId)
         {
@@ -1398,12 +1400,19 @@ namespace TerminalHub.Services
         }
 
         /// <summary>
-        /// 自分自身と、その配下の子セッションを列挙する（親が先・子が後）。
+        /// 自分自身と、その配下の子セッションを列挙する。**順序は子が先・親が最後**。
+        ///
+        /// 順序が要件なのは呼び出し側の永続化のため。Sessions.ParentSessionId は
+        /// Sessions(SessionId) への自己参照 FK（SessionDbContext の CREATE TABLE）なので、
+        /// 子の行が残ったまま親の行を消すと「FOREIGN KEY constraint failed」で落ちる。
+        /// この順で返しておけば、呼び出し側は返り値を順に消すだけで安全になる。
+        ///
         /// 階層は worktree の1段だけだが、取りこぼしと循環参照のどちらでも壊れないよう
         /// 訪問済みを持って推移的にたどる。呼び出しは _lockObject 保持下で行うこと。
         /// </summary>
         private List<Guid> CollectSelfAndDescendants(Guid rootId)
         {
+            // まず親→子の順に幅優先で集める
             var ordered = new List<Guid> { rootId };
             var visited = new HashSet<Guid> { rootId };
 
@@ -1419,6 +1428,8 @@ namespace TerminalHub.Services
                 }
             }
 
+            // 深い側から消せるよう反転する（幅優先で積んだので、逆順なら必ず子が親より先に来る）
+            ordered.Reverse();
             return ordered;
         }
 


### PR DESCRIPTION
## 概要

PR #196 で入れたカスケード削除が、実機で `SQLite Error 19: 'FOREIGN KEY constraint failed'` を出しました。削除順を **子が先・親が最後** に反転して修正します。

## 原因

`Sessions.ParentSessionId` は `Sessions(SessionId)` への**自己参照 FK** です。

https://github.com/zio3/TerminalHub/blob/2c3651a/TerminalHub/Services/SessionDbContext.cs#L421-L422

`CollectSelfAndDescendants` は幅優先で集めるため**親→子の順**で返っていました。呼び出し側の `Root.DeleteArchivedSession` は返り値を順に `DeleteSessionFromStorageAsync` へ渡すので、DB でも親から消しにいきます。子の行が残ったまま親の行を消す＝FK 違反です。

```
Microsoft.Data.Sqlite.SqliteException: SQLite Error 19: 'FOREIGN KEY constraint failed'.
   at TerminalHub.Services.SessionRepository.DeleteSessionAsync(...) SessionRepository.cs:285
   at TerminalHub.Components.Pages.Root.DeleteSessionFromStorageAsync(...) Root.razor:429
   at TerminalHub.Components.Pages.Root.DeleteArchivedSession(...) Root.razor:1954
```

## 影響

軽微ではありません。例外が Root のループを止めるため、**メモリからは消えたのに DB には残る**状態になります。次回起動でセッションが復活します。

## 修正

幅優先で積んだリストを最後に反転します。逆順なら必ず子が親より先に来るので、呼び出し側は返り値を順に消すだけで安全になります。順序が契約になったことを `DeleteSession` と `CollectSelfAndDescendants` の両方のドキュメントコメントに明記しました。

## 再現手順

1. 親セッションを作り、その配下に子セッションを作る
2. 親をアーカイブする（子は生きたまま。アーカイブは子へ伝搬しない）
3. アーカイブ一覧からその親を削除する → 例外

## 検証

実機（dev インスタンス・ポート5081）で上記手順により再現を確認しました。DB を直接照会し、アーカイブ済みの親1件と生きた子2件が残っていることを確認したうえで削除を実行し、例外の発生と DB に3件とも残ることを確認しています。

`dotnet build` 0 warnings / 0 errors。修正後の実機確認は未実施です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
