### PR TITLE
fix: MCP SDK を 2.1.0 へ更新（tools/list の resultType 欠落で MCP が全滅する問題）

### DIFF
--- a/TerminalHub/TerminalHub.csproj
+++ b/TerminalHub/TerminalHub.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.0.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.1.0" />
     <!-- CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) を回避するため、SQLitePCLRaw を 3.x にオーバーライド -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="MQTTnet" Version="5.1.0.1559" />


### PR DESCRIPTION
## 症状

Claude Code の `/mcp` で TerminalHub MCP が「connected · tools fetch failed」となり、ツールが一切使えなくなった。

```
Invalid result for tools/list: missing required resultType — servers implementing
protocol revision 2026-07-28 MUST include it
```

## 原因

Claude Code が MCP プロトコル **2026-07-28** でネゴシエートするようになったが、参照していた `ModelContextProtocol.AspNetCore` **2.0.0-preview.1** の `tools/list` 応答に必須フィールド `resultType` が無い（新仕様の実装が途中の版）。TerminalHub 側のコードは無関係。

稼働中インスタンスへの実測:

```
result keys: ['tools', 'ttlMs', 'cacheScope']   ← resultType が無い
```

## 対処

`ModelContextProtocol.AspNetCore` を **2.1.0** へ更新（1行）。

## 検証

- ビルド成功・警告 0・API 破壊なし
- 別ポートで起動して実応答を確認:
  `result keys: ['tools', 'ttlMs', 'cacheScope', 'resultType', '_meta']` / `resultType: "complete"` / tools 11本
- 懸念していた instructions の配布経路も確認済み。`server/discover` の応答に載る形で健在で、`Program.cs` の `ConfigureSessionOptions` による接続ごとの動的読み込みもそのまま効く（＝「この接続について」付記の仕組みは設計変更不要）

### 未検証

接続キー付きでの本人確定付記の表示は、実セッション起動が必要なため未確認。マージ後にインストールして `/mcp` で付記が出ることを確認したい。

### 検証時のメモ（新仕様で生リクエストを叩く場合）

ヘッダ `MCP-Protocol-Version: 2026-07-28` と `Mcp-Method: <method>`、さらに params の `_meta` に `io.modelcontextprotocol/protocolVersion` と `io.modelcontextprotocol/clientCapabilities` が必須。欠けると 400 で理由が返る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
