### PR TITLE
chore: NuGet パッケージの棚卸し更新（MQTTnet 5.2.0 / テスト基盤 / パッチ各種）

### DIFF
--- a/TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj
+++ b/TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj
@@ -13,14 +13,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <!-- ContextRepository の status 遷移判定（条件付き UPDATE）を実 SQLite で検証するため -->
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <!-- 本体と同じく CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) 回避のため SQLitePCLRaw を 3.x にオーバーライド -->
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj
+++ b/TerminalHub.Terminal.Tests/TerminalHub.Terminal.Tests.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
     <!-- ContextRepository の status 遷移判定（条件付き UPDATE）を実 SQLite で検証するため -->
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />

--- a/TerminalHub/TerminalHub.csproj
+++ b/TerminalHub/TerminalHub.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.0.0-preview.1" />
     <!-- CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) を回避するため、SQLitePCLRaw を 3.x にオーバーライド -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
-    <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
+    <PackageReference Include="MQTTnet" Version="5.2.0.1603" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/TerminalHub/TerminalHub.csproj
+++ b/TerminalHub/TerminalHub.csproj
@@ -26,10 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.0.0-preview.1" />
     <!-- CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) を回避するため、SQLitePCLRaw を 3.x にオーバーライド -->
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />


### PR DESCRIPTION
## 概要

MCP SDK 更新（#199）の機会に、依存パッケージを棚卸しして更新した。脆弱性は更新前後とも 0 件で、これは予防的な追随。

コミットは影響範囲ごとに 3 つに分けてある。

### 1. パッチ更新

| パッケージ | 変更 | 対象 |
|---|---|---|
| Microsoft.Data.Sqlite | 10.0.2 → 10.0.10 | 本体・テスト |
| SQLitePCLRaw.bundle_e_sqlite3 | 3.0.3 → 3.0.5 | 本体・テスト |
| Microsoft.Extensions.Logging.Abstractions | 10.0.2 → 10.0.10 | テスト |
| xunit | 2.9.2 → 2.9.3 | テスト |

SQLitePCLRaw は CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) 回避のために明示オーバーライドしている箇所なので、3.x 系のパッチに追随した。

### 2. MQTTnet 5.1.0.1559 → 5.2.0.1603

5.2.0 の変更はすべてクライアント側の不具合修正と SOCKS5 プロキシ対応で、破壊的変更は含まれない（5.1.0 の BREAKING CHANGE はサーバー側の `InterceptingClientEnqueue` で、TerminalHub はクライアントのみ利用）。

特に「キャンセル/タイムアウトした要求への遅延 ACK がプロトコル違反扱いになって接続が切れる」問題の修正（dotnet/MQTTnet#2078）はリモート起動の安定性に効くはず。

### 3. テスト基盤のメジャー更新

| パッケージ | 変更 |
|---|---|
| Microsoft.NET.Test.Sdk | 17.11.1 → 18.8.1 |
| xunit.runner.visualstudio | 2.8.2 → 3.1.5 |
| Xunit.SkippableFact | 1.4.13 → 1.5.61 |

本体の動作には影響しないテスト専用の依存。

## 検証

- ソリューション全体のビルド成功・警告 0
- ヘッドレステスト 282 件すべて成功（スキップ 0）
- CLAUDE.md 記載の `--filter` 実行も従来どおり動作（`FullyQualifiedName~EmulatedStateBufferTests` で 22 件成功）
- 更新後も `dotnet list package --vulnerable --include-transitive` は 0 件

### 未検証

MQTTnet 更新後のリモート起動（MQTT 疎通）は実機での確認が必要。マージ後にインストールして動作確認したい。

## 補足

このブランチは master 起点で、#199（MCP SDK 2.1.0）とは独立している。両方マージすると `dotnet list package --outdated` は空になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
