### PR TITLE
fix: SignalR の long polling 転落によるログ洪水を止める

### DIFF
--- a/TerminalHub/Components/App.razor
+++ b/TerminalHub/Components/App.razor
@@ -45,6 +45,16 @@
 
 <body>
     <TerminalHub.Components.Pages.Root />
+
+    <!-- Blazor の初回接続失敗を知らせる帯。blazor.web.js はこの id を探して display:block に
+         するだけなので、置いていないと接続できなかったことが画面に一切出ない。
+         下で transport を WebSocket に固定している以上、これが無いと黙って死ぬ。 -->
+    <div id="blazor-error-ui">
+        サーバーへの接続に失敗しました。
+        <a href="" class="reload">再読み込み</a>
+        <a class="dismiss">×</a>
+    </div>
+
     <script src="_framework/blazor.web.js" autostart="false"></script>
     <script>
         // SignalR のトランスポートを WebSocket に固定する（long polling へフォールバックさせない）。
@@ -54,7 +64,8 @@
         // そのコネクションが生きている限り落ちたまま（実測で3時間以上）になる。
         // long polling はターミナル出力の1バッチごとに HTTP 往復が発生して重く、
         // リクエストログも大量に流れるので、静かに劣化するより繋がらない方がよい。
-        // 張れなければ Blazor 標準の「接続が失われました」UI が出る。
+        // 張れなかった場合、初回接続の失敗は再接続 UI ではなく #blazor-error-ui の帯で出る
+        // （確立済み接続が後から切れたときだけが再接続 UI の担当）。上の div がその受け皿。
         //
         // configureSignalR には Blazor が withUrl("_blazor") 済みのビルダーが渡ってくる。
         // withUrl の第2引数は既存 httpConnectionOptions へマージされるので transport だけ差し替わる。

--- a/TerminalHub/Components/App.razor
+++ b/TerminalHub/Components/App.razor
@@ -1,4 +1,6 @@
-﻿@inject TerminalHub.Services.IAppSettingsService AppSettingsService
+﻿@using Microsoft.Extensions.Localization
+@inject TerminalHub.Services.IAppSettingsService AppSettingsService
+@inject IStringLocalizer<SharedResource> L
 @{
     // テーマをサーバーレンダー時点で決定して <html data-bs-theme> に埋め込む。
     // JS interop 経由で後から当てると、初期レンダリング時に一瞬ライトテーマが
@@ -46,12 +48,14 @@
 <body>
     <TerminalHub.Components.Pages.Root />
 
-    <!-- Blazor の初回接続失敗を知らせる帯。blazor.web.js はこの id を探して display:block に
-         するだけなので、置いていないと接続できなかったことが画面に一切出ない。
-         下で transport を WebSocket に固定している以上、これが無いと黙って死ぬ。 -->
+    <!-- Blazor 標準のエラー帯。blazor.web.js はこの id を探して display:block にするだけなので、
+         置いていないとエラーが画面に一切出ない。
+         出る条件は初回接続の失敗だけではなく、確立済み回路のサーバー側未処理例外（JS.Error）も
+         同じ経路を通るため、文言は接続に限定しない汎用のものにしている。
+         下で transport を WebSocket に固定している以上、これが無いと接続失敗時に黙って死ぬ。 -->
     <div id="blazor-error-ui">
-        サーバーへの接続に失敗しました。
-        <a href="" class="reload">再読み込み</a>
+        @L["App.ErrorUi.Message"]
+        <a href="" class="reload">@L["App.ErrorUi.Reload"]</a>
         <a class="dismiss">×</a>
     </div>
 

--- a/TerminalHub/Components/App.razor
+++ b/TerminalHub/Components/App.razor
@@ -45,7 +45,27 @@
 
 <body>
     <TerminalHub.Components.Pages.Root />
-    <script src="_framework/blazor.web.js"></script>
+    <script src="_framework/blazor.web.js" autostart="false"></script>
+    <script>
+        // SignalR のトランスポートを WebSocket に固定する（long polling へフォールバックさせない）。
+        //
+        // localhost 前提のアプリなので、WebSocket が張れない状況そのものが異常事態。
+        // 一方 long polling へ落ちると、SignalR は WebSocket へ昇格し直さないため
+        // そのコネクションが生きている限り落ちたまま（実測で3時間以上）になる。
+        // long polling はターミナル出力の1バッチごとに HTTP 往復が発生して重く、
+        // リクエストログも大量に流れるので、静かに劣化するより繋がらない方がよい。
+        // 張れなければ Blazor 標準の「接続が失われました」UI が出る。
+        //
+        // configureSignalR には Blazor が withUrl("_blazor") 済みのビルダーが渡ってくる。
+        // withUrl の第2引数は既存 httpConnectionOptions へマージされるので transport だけ差し替わる。
+        Blazor.start({
+            circuit: {
+                configureSignalR: builder => builder.withUrl("_blazor", {
+                    transport: 1 // HttpTransportType.WebSockets
+                })
+            }
+        });
+    </script>
 
     <script src="js/terminal.js"></script>
     <script src="js/helpers.js"></script>

--- a/TerminalHub/Components/App.razor
+++ b/TerminalHub/Components/App.razor
@@ -68,8 +68,9 @@
         // そのコネクションが生きている限り落ちたまま（実測で3時間以上）になる。
         // long polling はターミナル出力の1バッチごとに HTTP 往復が発生して重く、
         // リクエストログも大量に流れるので、静かに劣化するより繋がらない方がよい。
-        // 張れなかった場合、初回接続の失敗は再接続 UI ではなく #blazor-error-ui の帯で出る
-        // （確立済み接続が後から切れたときだけが再接続 UI の担当）。上の div がその受け皿。
+        // 張れなかった場合（WebSocket transport の開始失敗）は上の #blazor-error-ui の帯で出る。
+        // 一方 negotiate 自体の失敗は帯の手前で rethrow され再接続層が担当する。
+        // 帯は初回接続の失敗専用ではなく、確立済み回路の JS.Error とも共用。
         //
         // configureSignalR には Blazor が withUrl("_blazor") 済みのビルダーが渡ってくる。
         // withUrl の第2引数は既存 httpConnectionOptions へマージされるので transport だけ差し替わる。

--- a/TerminalHub/Helpers/SignalRTransportProbe.cs
+++ b/TerminalHub/Helpers/SignalRTransportProbe.cs
@@ -12,6 +12,10 @@ namespace TerminalHub.Helpers
     ///
     /// 判定: WebSocket なら /_blazor?id=... へのリクエストは接続あたり1本（アップグレードして
     /// 開きっぱなし）で終わる。素の HTTP リクエストが何十本も積み上がるのは long polling のときだけ。
+    ///
+    /// 現在は App.razor 側で transport を WebSocket に固定しているので、本来この警告は出ない。
+    /// 古い HTML をキャッシュしたタブや、将来 Blazor 側の仕様が変わった場合の見張りとして残している
+    /// （出たら固定が効いていないということ）。
     /// </summary>
     public static class SignalRTransportProbe
     {

--- a/TerminalHub/Helpers/SignalRTransportProbe.cs
+++ b/TerminalHub/Helpers/SignalRTransportProbe.cs
@@ -1,0 +1,68 @@
+using System.Collections.Concurrent;
+
+namespace TerminalHub.Helpers
+{
+    /// <summary>
+    /// Blazor Server の SignalR コネクションが long polling に落ちていないかを見張るミドルウェア。
+    ///
+    /// 背景: スリープ復帰や瞬断で WebSocket が切れると、SignalR は再接続時に long polling へ
+    /// フォールバックすることがある。一度落ちると WebSocket に昇格し直さないため、そのコネクションが
+    /// 生きている限り（実測で3時間以上）long polling のままになる。この状態はターミナル出力の
+    /// 1バッチごとに HTTP 往復が発生するので体感が重くなり、リクエストログも大量に流れる。
+    ///
+    /// 判定: WebSocket なら /_blazor?id=... へのリクエストは接続あたり1本（アップグレードして
+    /// 開きっぱなし）で終わる。素の HTTP リクエストが何十本も積み上がるのは long polling のときだけ。
+    /// </summary>
+    public static class SignalRTransportProbe
+    {
+        /// <summary>この本数を超えたら long polling と判断する。WebSocket 接続では到達しない。</summary>
+        private const int PollingThreshold = 20;
+
+        /// <summary>追跡中のコネクションがこの数を超えたら丸ごと捨てる（リークさせないため）。</summary>
+        private const int MaxTrackedConnections = 64;
+
+        private static readonly ConcurrentDictionary<string, int> _requestCounts = new();
+
+        public static IApplicationBuilder UseSignalRTransportProbe(this IApplicationBuilder app)
+        {
+            var logger = app.ApplicationServices
+                .GetRequiredService<ILoggerFactory>()
+                .CreateLogger(typeof(SignalRTransportProbe).FullName!);
+
+            return app.Use((context, next) =>
+            {
+                // negotiate や initializers は接続ごとに数回しか来ないので対象外。
+                // WebSocket アップグレード要求も当然対象外。
+                if (!context.Request.Path.StartsWithSegments("/_blazor", out var remaining) ||
+                    remaining.HasValue ||
+                    context.WebSockets.IsWebSocketRequest)
+                {
+                    return next();
+                }
+
+                var id = context.Request.Query["id"].ToString();
+                if (string.IsNullOrEmpty(id))
+                {
+                    return next();
+                }
+
+                if (_requestCounts.Count > MaxTrackedConnections)
+                {
+                    _requestCounts.Clear();
+                }
+
+                var count = _requestCounts.AddOrUpdate(id, 1, (_, c) => c + 1);
+                if (count == PollingThreshold)
+                {
+                    // 閾値ちょうどの1回だけ出す（以降はカウントが増え続けても黙る）。
+                    logger.LogWarning(
+                        "[SignalR] コネクション {ConnectionId} が long polling で動作している模様（/_blazor への素の HTTP リクエストが {Count} 本）。" +
+                        "WebSocket へは自動復帰しないため、重い・ログが流れるようならブラウザをリロードして張り直すこと。",
+                        id, count);
+                }
+
+                return next();
+            });
+        }
+    }
+}

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -2,6 +2,7 @@ using TerminalHub.Services;
 using TerminalHub.Analyzers;
 using TerminalHub.Components;
 using TerminalHub.Models;
+using TerminalHub.Helpers;
 using System.Text.Json;
 using Serilog;
 
@@ -256,6 +257,9 @@ if (!app.Environment.IsDevelopment())
 
 // HTTPSリダイレクトは無効化（ローカル環境での使用を想定）
 // app.UseHttpsRedirection();
+
+// SignalR が long polling に落ちていないかの見張り（詳細は SignalRTransportProbe のコメント参照）
+app.UseSignalRTransportProbe();
 
 app.UseAntiforgery();
 

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -661,4 +661,6 @@
   <data name="Root.Toast.SessionRecreateErrorFormat" xml:space="preserve"><value>Session recreate error: {0}</value></data>
   <data name="Root.Confirm.DeleteSessionFormat" xml:space="preserve"><value>Delete session "{0}"?</value></data>
   <data name="Root.Confirm.ArchiveSessionFormat" xml:space="preserve"><value>Archive session "{0}"?</value></data>
+  <data name="App.ErrorUi.Message" xml:space="preserve"><value>An error has occurred.</value></data>
+  <data name="App.ErrorUi.Reload" xml:space="preserve"><value>Reload</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -661,4 +661,6 @@
   <data name="Root.Toast.SessionRecreateErrorFormat" xml:space="preserve"><value>セッション再作成エラー: {0}</value></data>
   <data name="Root.Confirm.DeleteSessionFormat" xml:space="preserve"><value>セッション「{0}」を削除しますか？</value></data>
   <data name="Root.Confirm.ArchiveSessionFormat" xml:space="preserve"><value>セッション「{0}」をアーカイブしますか？</value></data>
+  <data name="App.ErrorUi.Message" xml:space="preserve"><value>エラーが発生しました。</value></data>
+  <data name="App.ErrorUi.Reload" xml:space="preserve"><value>再読み込み</value></data>
 </root>

--- a/TerminalHub/appsettings.json
+++ b/TerminalHub/appsettings.json
@@ -5,6 +5,14 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft.AspNetCore": "Warning"
+      }
+    }
+  },
   "AllowedHosts": "*",
   "SessionSettings": {
     "DefaultCols": 120,

--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -854,3 +854,36 @@ h1:focus {
 .terminal-context-menu-item:focus-visible {
     background-color: var(--th-sidebar-hover);
 }
+
+/* Blazor の初回接続失敗（WebSocket が張れない等）を知らせる帯。
+   blazor.web.js は #blazor-error-ui を探して display:block にするだけで、
+   要素が無ければ何も表示せず黙って死ぬ。App.razor で transport を WebSocket に
+   固定している以上、張れなかったことが画面で分かる必要があるので必ず置く。
+   （確立済み接続が切れた場合の再接続 UI は Blazor が自前で生成するので別系統） */
+#blazor-error-ui {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1080;
+    padding: 0.75rem 1.25rem;
+    background-color: #dc3545;
+    color: #fff;
+    font-size: 0.875rem;
+    box-shadow: var(--th-shadow-lg);
+}
+
+#blazor-error-ui a {
+    color: #fff;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+#blazor-error-ui .dismiss {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.75rem;
+    text-decoration: none;
+    font-size: 1.1rem;
+}

--- a/TerminalHub/wwwroot/app.css
+++ b/TerminalHub/wwwroot/app.css
@@ -855,11 +855,11 @@ h1:focus {
     background-color: var(--th-sidebar-hover);
 }
 
-/* Blazor の初回接続失敗（WebSocket が張れない等）を知らせる帯。
-   blazor.web.js は #blazor-error-ui を探して display:block にするだけで、
-   要素が無ければ何も表示せず黙って死ぬ。App.razor で transport を WebSocket に
-   固定している以上、張れなかったことが画面で分かる必要があるので必ず置く。
-   （確立済み接続が切れた場合の再接続 UI は Blazor が自前で生成するので別系統） */
+/* Blazor 標準のエラー帯。blazor.web.js は #blazor-error-ui を探して display:block に
+   するだけで、要素が無ければ何も表示せず黙って死ぬ。App.razor で transport を
+   WebSocket に固定している以上、張れなかったことが画面で分かる必要があるので必ず置く。
+   出る条件は WebSocket transport の開始失敗と、確立済み回路の JS.Error。
+   negotiate 自体の失敗と、確立済み接続が後から切れた場合は再接続 UI の担当（別系統）。 */
 #blazor-error-ui {
     display: none;
     position: fixed;


### PR DESCRIPTION
## 背景

「ログがすごい勢いで流れる」との報告。実測で原因は2つの合わせ技だった。

### 1. Serilog が appsettings の設定を読んでいなかった（増幅器）

`"Logging": { "LogLevel": { "Microsoft.AspNetCore": "Warning" } }` は**効いていない**。`UseSerilog` が `SerilogLoggerFactory` を差し込むため MS の `Logging:LogLevel` は参照されず、かつ `Serilog` セクションが appsettings に無いので `ReadFrom.Configuration` も何も読めていなかった。

結果、ASP.NET Core のリクエストログが全部 Information で出ていた（当日ログの **99%** = 25,142/25,400行）。

### 2. SignalR が long polling へ転落したまま戻らなかった（本体）

スリープ復帰と思われるタイミング（MQTT も同時刻に切断→再接続）で WebSocket が切れ、再接続時に long polling へフォールバック。**一度落ちると WebSocket へ昇格し直さない**ため、04:04 の転落から 06:58 のリロードまで**約3時間**その状態だった。

long polling はターミナル出力の1バッチごとに HTTP 往復が発生し、1往復あたり4行 × 約12往復/秒 = **6,000行/分**。体感も重かったはず。

## 変更内容

| コミット | 内容 |
|---|---|
| `d6b29f8` | Serilog 設定の修正 + long polling 検知ミドルウェア |
| `0c15f0c` | transport を WebSocket に固定（フォールバック自体を塞ぐ） |
| `79aef90` | `#blazor-error-ui` を追加（初回接続失敗を画面に出す） |

- `appsettings.json` に `Serilog:MinimumLevel:Override:Microsoft.AspNetCore = Warning` を追加（既存の `Logging` セクションは `AppDataPaths` が `Logging:FolderName` を読むので残置）
- `Helpers/SignalRTransportProbe.cs`: `/_blazor` への素の HTTP リクエストが同一コネクションで20本を超えたら一度だけ WRN。WebSocket なら接続あたり1本しか出ないので、積み上がるのは long polling のときだけ
- `Components/App.razor`: `blazor.web.js` を `autostart="false"` にし、`Blazor.start` の `configureSignalR` で `transport: 1`（WebSockets のみ）を指定

**判断**: localhost 前提のアプリなので WebSocket が張れない事態そのものが異常。静かに劣化して重いまま動き続けるより、繋がらないと分かる方がよい。

## Codex レビューでの指摘（P3）と、その裏取りで見つかった実害

当初のコメントは「張れなければ Blazor 標準の再接続 UI が出る」と書いていたが、実装と違っていた。

- 確立済み接続が切れた → `reconnectionHandler.onConnectionDown`（再接続 UI）
- **初回の `connection.start()` が失敗** → `showErrorNotification`

`showErrorNotification` の実体は `document.querySelector("#blazor-error-ui")` を探して `display:block` にするだけで、**要素が無ければ何もしない**。そして TerminalHub には `#blazor-error-ui` がどこにも存在しなかった（`App.razor` が `<Root />` を直接置く構成で標準テンプレートのレイアウトを経由していないため）。

つまり WebSocket 固定の前提「張れなければ繋がらないと分かる」が成立しておらず、接続失敗時は半端に描画された画面のまま無言で止まる状態だった。`79aef90` で要素と CSS を追加して解消。

## 確認したこと

- ビルド警告0 / テスト282件全通過（`TerminalHub.Terminal.Tests`）
- デバッグインスタンス（5081）で実機確認
  - コンソールに `WebSocket connected to ws://localhost:5081/_blazor?id=...`
  - `/_blazor` 系のリクエストは `initializers` と `negotiate` の2本のみ。`GET /_blazor?id=...` は1本も出ていない
- ミドルウェア単体: `/_blazor?id=TESTFAKEID` を22本投げて WRN がちょうど1回
- Serilog: リクエストを5本投げて `Request starting` の出力が0件
- エラー帯: 初期状態 `display:none`、表示させると `bottom:0` に幅いっぱい・高さ45px、中心の `elementFromPoint` が帯自身を返す（何にも覆われていない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)