### PR TITLE
feat: ターミナル右クリックメニューに「フォルダを開く」とURL項目を追加

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -883,6 +883,36 @@
     }
 
     /// <summary>
+    /// 右クリックメニューの「フォルダを開く」（JavaScript から呼び出される）。
+    /// パスをセッションのフォルダ基準で解決し、親フォルダを Explorer で開いて対象を選択状態にする。
+    /// ファイルをメール等へドラッグしたい（開くのではなく置き場所へ行きたい）ケース向け。
+    /// </summary>
+    [JSInvokable]
+    public async Task OnTerminalPathOpenFolder(string sessionId, string path)
+    {
+        try
+        {
+            // 解決規則は ResolveTerminalPath と同一（行番号付き表記のフォールバック込み）
+            var resolved = await ResolveTerminalPath(sessionId, path);
+            if (resolved == null)
+            {
+                toast?.ShowWarning(string.Format(L["Root.Toast.PathNotFoundFormat"], path.Trim()));
+                return;
+            }
+
+            if (ExplorerLauncher.OpenFolderAndSelect(resolved))
+            {
+                var parent = System.IO.Path.GetDirectoryName(resolved);
+                toast?.ShowSuccess(string.Format(L["Root.Toast.FolderOpenedFormat"], parent ?? resolved));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "[PathOpenFolder] フォルダを開けませんでした: {Path}", path);
+        }
+    }
+
+    /// <summary>
     /// 選択テキストをセッションのフォルダ基準で解決し、実在すれば絶対パスを返す（JavaScript から呼び出される）。
     /// 右クリックメニューの「フルパスをコピー」用。実在しなければ null を返し、呼び出し側はメニューを出さない。
     /// </summary>

--- a/TerminalHub/Services/ExplorerLauncherService.cs
+++ b/TerminalHub/Services/ExplorerLauncherService.cs
@@ -15,6 +15,12 @@ public interface IExplorerLauncherService
     /// 戻り値は「explorer.exe の起動まで成功したか」。前面化の成否は含まない（非同期のベストエフォート）。
     /// </summary>
     bool OpenFolder(string path);
+
+    /// <summary>
+    /// エクスプローラーで親フォルダを開き、指定したファイル/フォルダを選択状態にして前面に出す
+    /// （explorer /select）。対象が実在しなければ何もしない。戻り値の意味は OpenFolder と同じ。
+    /// </summary>
+    bool OpenFolderAndSelect(string itemPath);
 }
 
 public class ExplorerLauncherService : IExplorerLauncherService
@@ -31,18 +37,32 @@ public class ExplorerLauncherService : IExplorerLauncherService
 
     public bool OpenFolder(string path)
     {
+        if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+            return false;
+
+        return LaunchExplorer($"\"{path.Replace('/', '\\')}\"", path);
+    }
+
+    public bool OpenFolderAndSelect(string itemPath)
+    {
+        if (string.IsNullOrEmpty(itemPath) || (!File.Exists(itemPath) && !Directory.Exists(itemPath)))
+            return false;
+
+        // /select は親フォルダを開いて対象をハイライトする（ファイルにもフォルダにも使える）
+        return LaunchExplorer($"/select,\"{itemPath.Replace('/', '\\')}\"", itemPath);
+    }
+
+    private bool LaunchExplorer(string arguments, string pathForLog)
+    {
         try
         {
-            if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
-                return false;
-
             // 起動前のウィンドウ一覧を控えておき、後で「新しく増えたウィンドウ」を特定する
             var before = ForegroundWindowHelper.FindVisibleWindowsByClass(ExplorerWindowClass).ToHashSet();
 
             Process.Start(new ProcessStartInfo
             {
                 FileName = "explorer.exe",
-                Arguments = $"\"{path.Replace('/', '\\')}\"",
+                Arguments = arguments,
                 UseShellExecute = true,
             });
 
@@ -68,7 +88,7 @@ public class ExplorerLauncherService : IExplorerLauncherService
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "[ExplorerLauncher] ウィンドウ前面化に失敗: {Path}", path);
+                    _logger.LogWarning(ex, "[ExplorerLauncher] ウィンドウ前面化に失敗: {Path}", pathForLog);
                 }
             });
 
@@ -76,7 +96,7 @@ public class ExplorerLauncherService : IExplorerLauncherService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[ExplorerLauncher] フォルダを開けませんでした: {Path}", path);
+            _logger.LogError(ex, "[ExplorerLauncher] フォルダを開けませんでした: {Path}", pathForLog);
             return false;
         }
     }

--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -399,6 +399,10 @@ function getBufferLineText(line) {
 // （＝表示上クリック可能なパスと、右クリックで拾うパスが必ず一致する）。
 const FILE_PATH_TOKEN_REGEX = /[^\s"'`()\[\]{}<>|;,！？。、（）「」]*[\\/][^\s"'`()\[\]{}<>|;,！？。、（）「」]*|[^\s"'`()\[\]{}<>|;,！？。、（）「」]+\.[A-Za-z][A-Za-z0-9]{0,7}/g;
 
+// URL検出の正規表現（URLフォールバックリンクプロバイダと右クリックメニューで共有）。
+// WebLinksAddon の内部正規表現には触れないため厳密一致は保証できないが、実用上ほぼ同じ範囲を拾う。
+const URL_TOKEN_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
+
 // ファイルパス検出の設定
 // Claude Code 等が出力するファイル/フォルダ表記をクリック可能にする。
 // 検出は割り切り: 「/ または \ を含むトークン（末尾まで丸ごと）」と
@@ -641,8 +645,8 @@ function setupUrlDetection(term) {
 
 // WebLinksAddonが使用できない場合のフォールバック実装
 function setupUrlDetectionFallback(term) {
-    // HTTP/HTTPSのURLパターン
-    const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
+    // HTTP/HTTPSのURLパターン（右クリック検出と共有の URL_TOKEN_REGEX から都度作る）
+    const urlRegex = new RegExp(URL_TOKEN_REGEX.source, 'g');
     
     // registerLinkProvider による手動リンクプロバイダー登録（xterm.js 6.0 でも利用可能）
     if (typeof term.registerLinkProvider === 'function') {
@@ -708,6 +712,13 @@ function setupUrlDetectionFallback(term) {
 function looksLikePath(text) {
     if (!text || text.length > 4096 || /[\r\n]/.test(text)) return false;
     return /[\\/]/.test(text) || /^[A-Za-z]:/.test(text) || /\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(text);
+}
+
+// 選択が URL らしいか。URL は / を含むため looksLikePath にも該当してしまう。
+// 先にこちらで判定して URL 用メニューへ振り分ける（パス用の「開く」はファイル解決に行き空振りするため）。
+function looksLikeUrl(text) {
+    if (!text || text.length > 4096 || /[\r\n\s]/.test(text)) return false;
+    return /^https?:\/\//i.test(text);
 }
 
 function closeTerminalContextMenu() {
@@ -777,6 +788,22 @@ function cellFromMouse(term, e) {
     return { col, row: term.buffer.active.viewportY + rowInViewport };
 }
 
+// バッファ上の (col,row) に URL があればその文字列を返す。無ければ null。
+// 「開きたいのではなく URL をコピーしたいだけ」の右クリックを拾う（左クリック＝開くと分離）。
+function urlTokenAtCell(term, col, row) {
+    const line = term.buffer.active.getLine(row);
+    if (!line) return null;
+    const { text: lineText, columns } = getBufferLineText(line);
+    const re = new RegExp(URL_TOKEN_REGEX.source, 'g');
+    let match;
+    while ((match = re.exec(lineText)) !== null) {
+        const startCol = columns[match.index];
+        const endCol = columns[match.index + match[0].length]; // 次文字の開始列＝排他的終端
+        if (col >= startCol && col < endCol) return match[0];
+    }
+    return null;
+}
+
 // バッファ上の (col,row) にパスリンクのトークンがあればその文字列を返す。無ければ null。
 // リンクプロバイダ（setupFilePathDetection）と同じ正規表現・同じ除外条件を用いるため、
 // 「クリック可能なパスとして表示されているトークン」とちょうど一致する。
@@ -802,7 +829,7 @@ function pathTokenAtCell(term, col, row) {
     return null;
 }
 
-// パス対象の共通コンテキストメニュー項目（コピー / 開く / フルパスをコピー）。
+// パス対象の共通コンテキストメニュー項目（コピー / 開く / フルパスをコピー / フォルダを開く）。
 // 選択テキストにもパスリンクにも同じメニューを出すため共通化する。
 function buildPathMenuItems(sessionId, text) {
     return [
@@ -819,6 +846,25 @@ function buildPathMenuItems(sessionId, text) {
                     .catch(() => copyLinkToClipboard(text));
             }
         },
+        {
+            // 親フォルダを Explorer で開いて対象を選択状態にする（ファイルをメール等へ
+            // ドラッグしたいケース向け。ファイルを「開く」のではなく置き場所へ行きたい）
+            label: 'フォルダを開く',
+            action: () => {
+                if (!window.terminalHubDotNetRef) return;
+                window.terminalHubDotNetRef.invokeMethodAsync('OnTerminalPathOpenFolder', sessionId, text)
+                    .catch(err => console.error('[Path Detection] open folder failed:', err));
+            }
+        },
+    ];
+}
+
+// URL 対象のコンテキストメニュー項目。メニューから選ぶ操作は意図が明示されているため、
+// コピー動作モード(terminalLinkCopyMode)に関わらず「コピー」はコピー、「開く」は開く。
+function buildUrlMenuItems(uri) {
+    return [
+        { label: 'URLをコピー', action: () => copyLinkToClipboard(uri) },
+        { label: '開く', action: () => window.open(uri, '_blank', 'noopener,noreferrer') },
     ];
 }
 
@@ -841,6 +887,13 @@ function attachSelectionContextMenu(term, element, sessionId) {
         }
 
         if (selection) {
+            // URL は / を含み looksLikePath にも該当するため、先に URL として振り分ける
+            // （パス用メニューだと「開く」がファイル解決に行き空振りする）
+            if (looksLikeUrl(selection)) {
+                e.preventDefault();
+                showTerminalContextMenu(e.clientX, e.clientY, buildUrlMenuItems(selection));
+                return;
+            }
             // パスでなければネイティブメニューの方が有用（DeepL・スペルチェック等）なので出さない
             if (!looksLikePath(selection)) return;
             e.preventDefault();
@@ -848,12 +901,18 @@ function attachSelectionContextMenu(term, element, sessionId) {
             return;
         }
 
-        // (2) 選択が無い場合は、右クリック位置にパスリンクがあればそれを対象にする。
-        //     「開きたいのではなくフルパスが欲しい」ケースを、リンク左クリック（＝開く）と分けて拾う。
+        // (2) 選択が無い場合は、右クリック位置に URL / パスリンクがあればそれを対象にする。
+        //     「開きたいのではなくコピー/フルパスが欲しい」ケースを、リンク左クリック（＝開く）と分けて拾う。
         const cell = cellFromMouse(term, e);
         if (!cell) return;
+        const url = urlTokenAtCell(term, cell.col, cell.row);
+        if (url) {
+            e.preventDefault();
+            showTerminalContextMenu(e.clientX, e.clientY, buildUrlMenuItems(url));
+            return;
+        }
         const token = pathTokenAtCell(term, cell.col, cell.row);
-        if (!token || !looksLikePath(token)) return; // パスリンク上でなければネイティブメニュー
+        if (!token || !looksLikePath(token)) return; // URL/パスリンク上でなければネイティブメニュー
         e.preventDefault();
         showTerminalContextMenu(e.clientX, e.clientY, buildPathMenuItems(sessionId, token));
     };


### PR DESCRIPTION
## 概要

ターミナル内のファイルパスを右クリックしたときのメニューに **「フォルダを開く」** を追加する。エクスプローラーで**親フォルダを開き、対象を選択状態にして**前面に出す（`explorer /select`）。

用途は「ファイルを開きたいのではなく、置き場所へ行きたい」ケース。そこからメール等へドラッグできる。

あわせて URL 上の右クリックにも対応した（従来は URL がパス用メニューに流れ、「開く」がファイル解決に行って空振りしていた）。

## 変更内容

### `ExplorerLauncherService`
- `OpenFolderAndSelect(itemPath)` を追加。`explorer.exe /select,"<path>"` で起動する。ファイル・フォルダのどちらにも使える。対象が実在しなければ何もしない
- 既存 `OpenFolder` と共通の起動処理を `LaunchExplorer(arguments, pathForLog)` に括り出した。ウィンドウ前面化（起動前後のウィンドウ差分を取る方式）はそのまま両者で共有する

### `Root.razor`
- `[JSInvokable] OnTerminalPathOpenFolder(sessionId, path)` を追加。パスの解決規則は既存の「フルパスをコピー」と同一（`ResolveTerminalPath`／行番号付き表記のフォールバック込み）。解決できなければトーストで警告して終わる

### `terminal.js`
- パス用メニューに「フォルダを開く」を追加
- URL 用メニュー（`URLをコピー` / `開く`）を追加。選択テキストとリンク位置の両方で拾う
- `looksLikeUrl` で **URL を先に振り分ける**。URL は `/` を含むため `looksLikePath` にも該当してしまうのを避けるため
- フォールバックのリンクプロバイダと右クリック検出で URL 正規表現を `URL_TOKEN_REGEX` として共有

## 補足

メニューから選ぶ操作は意図が明示されているので、コピー動作モード（`terminalLinkCopyMode`）の設定に関わらず「コピー」はコピー、「開く」は開くとした。

## 動作確認

- `dotnet build` 成功（0 警告 / 0 エラー）
- 実機での確認は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)