### PR TITLE
feat: コピー系UIにコピー成功のフィードバックを追加

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -35,9 +35,9 @@
                                 <div class="d-flex align-items-start">
                                     <code class="flex-grow-1 me-2 text-break" style="word-wrap: break-word; overflow-wrap: break-word;">@sessionInfo.FolderPath</code>
                                     <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
-                                            @onclick="() => CopyToClipboard(sessionInfo.FolderPath)"
-                                            title="@L["SessionSettings.Info.CopyFolderPath"]">
-                                        <i class="bi bi-clipboard"></i>
+                                            @onclick="() => CopyToClipboard(sessionInfo.FolderPath, CopyKeyFolderPath)"
+                                            title="@(copiedKey == CopyKeyFolderPath ? L["Common.Copied"] : L["SessionSettings.Info.CopyFolderPath"])">
+                                        <i class="bi @(copiedKey == CopyKeyFolderPath ? "bi-check2 text-success" : "bi-clipboard")"></i>
                                     </button>
                                     <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0 ms-1"
                                             @onclick="() => OpenFolder(sessionInfo.FolderPath)"
@@ -53,9 +53,9 @@
                                 <div class="d-flex align-items-center">
                                     <code class="text-muted small">@sessionInfo.SessionId</code>
                                     <button type="button" class="btn btn-link btn-sm text-muted ms-2"
-                                            @onclick="() => CopyToClipboard(sessionInfo.SessionId.ToString())"
-                                            title="@L["SessionSettings.Info.CopySessionId"]">
-                                        <i class="bi bi-clipboard small"></i>
+                                            @onclick="() => CopyToClipboard(sessionInfo.SessionId.ToString(), CopyKeySessionId)"
+                                            title="@(copiedKey == CopyKeySessionId ? L["Common.Copied"] : L["SessionSettings.Info.CopySessionId"])">
+                                        <i class="bi @(copiedKey == CopyKeySessionId ? "bi-check2 text-success" : "bi-clipboard") small"></i>
                                     </button>
                                 </div>
                             </div>
@@ -629,12 +629,17 @@
         return Task.CompletedTask;
     }
 
-    private async Task CopyToClipboard(string text)
+    // コピー成功時にアイコンを ✓ へ切り替えるための対象キー（数秒で元に戻す）。
+    // このダイアログには複数のコピーボタンがあるため bool ではなくキーで保持する
+    private string? copiedKey;
+
+    private async Task CopyToClipboard(string text, string key)
     {
+        var copied = false;
         try
         {
             await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
-            // 成功時の視覚的フィードバックを追加する場合はここに
+            copied = true;
         }
         catch (Exception)
         {
@@ -642,13 +647,30 @@
             try
             {
                 await JSRuntime.InvokeVoidAsync("eval", $"document.execCommand('copy'); var textarea = document.createElement('textarea'); textarea.value = '{text}'; document.body.appendChild(textarea); textarea.select(); document.execCommand('copy'); document.body.removeChild(textarea);");
+                copied = true;
             }
             catch
             {
-                // コピーに失敗した場合は何もしない
+                // コピーに失敗した場合は何もしない（フィードバックも出さない）
             }
         }
+
+        if (!copied) return;
+
+        copiedKey = key;
+        StateHasChanged();
+        await Task.Delay(CopiedFeedbackMs);
+        // 待機中に別のボタンが押されていたら、そちらの表示を消さない
+        if (copiedKey == key)
+        {
+            copiedKey = null;
+            StateHasChanged();
+        }
     }
+
+    private const int CopiedFeedbackMs = 2000;
+    private const string CopyKeyFolderPath = "folderPath";
+    private const string CopyKeySessionId = "sessionId";
 
     private void OpenFolder(string path)
     {

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -382,6 +382,7 @@
                 LoadSessionInfo();
                 await RefreshMemoExistsAsync();
                 _loadedSessionId = SessionId;
+                copiedKey = null; // 前回対象の「コピーしました」表示を持ち越さない
             }
         }
         else if (!IsVisible)

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -827,8 +827,8 @@
                                                 </a>
                                                 <button class="btn btn-outline-secondary btn-sm" type="button"
                                                         @onclick="() => CopyToClipboardText(GetRemoteLaunchAccessUrl())"
-                                                        title="@L["Settings.RemoteLaunch.CopyUrlTitle"]">
-                                                    <i class="bi bi-clipboard"></i>
+                                                        title="@(urlCopied ? L["Common.Copied"] : L["Settings.RemoteLaunch.CopyUrlTitle"])">
+                                                    <i class="bi @(urlCopied ? "bi-check2 text-success" : "bi-clipboard")"></i>
                                                 </button>
                                             </div>
                                             <div class="alert alert-warning mt-2 py-2">
@@ -2152,13 +2152,22 @@
         return $"{Constants.MqttConstants.WebUiBaseUrl}/{remoteLaunchTopicGuid}";
     }
 
+    // コピー成功時にアイコンを ✓ へ切り替える（数秒で元に戻す）
+    private bool urlCopied;
+
     private async Task CopyToClipboardText(string text)
     {
         try
         {
             await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
         }
-        catch { /* クリップボード API 不許可/回線切断時は失敗するが致命的でないため無視 */ }
+        catch { /* クリップボード API 不許可/回線切断時は失敗するが致命的でないため無視 */ return; }
+
+        urlCopied = true;
+        StateHasChanged();
+        await Task.Delay(2000);
+        urlCopied = false;
+        StateHasChanged();
     }
 
     private async Task BrowseFavoriteFolder()

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -61,6 +61,7 @@
   <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
   <data name="Common.Create" xml:space="preserve"><value>Create</value></data>
   <data name="Common.Unspecified" xml:space="preserve"><value>Unspecified</value></data>
+  <data name="Common.Copied" xml:space="preserve"><value>Copied</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>Error: {0}</value></data>
   <data name="Common.DirectoryNotFoundFormat" xml:space="preserve"><value>Directory not found: {0}</value></data>
 

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -61,6 +61,7 @@
   <data name="Common.Cancel" xml:space="preserve"><value>キャンセル</value></data>
   <data name="Common.Create" xml:space="preserve"><value>作成</value></data>
   <data name="Common.Unspecified" xml:space="preserve"><value>未指定</value></data>
+  <data name="Common.Copied" xml:space="preserve"><value>コピーしました</value></data>
   <data name="Common.ErrorFormat" xml:space="preserve"><value>エラー: {0}</value></data>
   <data name="Common.DirectoryNotFoundFormat" xml:space="preserve"><value>ディレクトリが見つかりません: {0}</value></data>
 


### PR DESCRIPTION
## 概要

フォルダパスやセッションIDなどのコピーボタンは、押しても何も起きないように見えて「コピーできたのか」が分からなかった。クリック時に視覚的なリアクションを出す。

## 変更箇所

アイコンのみでフィードバックが無かった3箇所:

- **セッション設定ダイアログ** — フォルダパス / セッションID
- **設定ダイアログ** — リモート起動アクセスURL

## 挙動

クリックすると `bi-clipboard` → 緑の `bi-check2` にアイコンが変わり、ツールチップも「コピーしました」に切り替わって2秒で元に戻る。

既存の `CommitInfoDialog`（コミットハッシュ）/ `GitChangesDialog`（パス一覧）と同じパターン。あちらはラベル付きボタンなので文言も切り替わるが、今回はアイコンのみのボタンなのでアイコン＋ツールチップで表現している。

## 実装メモ

- セッション設定はダイアログ内にコピーボタンが2つあるため、`bool` ではなく対象キー（`copiedKey`）で保持。2秒待機中に別のボタンが押された場合、そちらの表示を消さないようガードしている
- コピーに失敗したときはフィードバックを出さない（成功したときだけ ✓ にする）
- 文言は `Common.Copied` として ja/en 両方に追加

## 既知の未対応（今回スコープ外）

`SessionSettingsDialog` のフォールバック経路（クリップボードAPI失敗時の `eval`）は、パスを文字列補間でJSに埋め込むため `'` を含むパスで壊れる。今回の変更前からある問題で発火条件も稀なため触っていない。

## 確認

- Release ビルド成功（0 警告 / 0 エラー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
