### PR TITLE
fix: hashbang形式のURL(#!)がリンクとして途中で切れる問題を修正

### DIFF
--- a/TerminalHub/wwwroot/js/terminal.js
+++ b/TerminalHub/wwwroot/js/terminal.js
@@ -399,9 +399,15 @@ function getBufferLineText(line) {
 // （＝表示上クリック可能なパスと、右クリックで拾うパスが必ず一致する）。
 const FILE_PATH_TOKEN_REGEX = /[^\s"'`()\[\]{}<>|;,！？。、（）「」]*[\\/][^\s"'`()\[\]{}<>|;,！？。、（）「」]*|[^\s"'`()\[\]{}<>|;,！？。、（）「」]+\.[A-Za-z][A-Za-z0-9]{0,7}/g;
 
-// URL検出の正規表現（URLフォールバックリンクプロバイダと右クリックメニューで共有）。
-// WebLinksAddon の内部正規表現には触れないため厳密一致は保証できないが、実用上ほぼ同じ範囲を拾う。
-const URL_TOKEN_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
+// URL検出の正規表現。ここを唯一の定義とし、WebLinksAddon にも urlRegex オプションで渡す
+// （＝左クリックでリンクになる範囲と、右クリック・フォールバックで拾う範囲が必ず一致する）。
+//
+// 中身は WebLinksAddon 0.12.0 の既定パターンから **本体部分の除外文字から `!` を外した** もの。
+// 既定では `!` が本体に入れないため、`https://www.chatwork.com/#!rid443369592` のような
+// hashbang 形式が `.../#` で切れてリンクにならなかった。
+// 末尾の1文字だけは別の（`!` を含む）除外クラスなので、`http://example.com!` の `!` や
+// 文末の `.` `,` は従来どおり URL に巻き込まれない。
+const URL_TOKEN_REGEX = /(https?|HTTPS?):[/]{2}[^\s"'*(){}|\\\^<>`]*[^\s"':,.!?{}|\\\^~\[\]`()<>]/g;
 
 // ファイルパス検出の設定
 // Claude Code 等が出力するファイル/フォルダ表記をクリック可能にする。
@@ -625,10 +631,12 @@ function setupUrlDetection(term) {
     if (typeof WebLinksAddon !== 'undefined' && WebLinksAddon.WebLinksAddon) {
         try {
             // WebLinksAddonを作成（URLをクリック可能にする）
-            // 既定ハンドラは直接 window.open するため、コピー動作モードを差し込めるようカスタムハンドラを渡す
+            // 既定ハンドラは直接 window.open するため、コピー動作モードを差し込めるようカスタムハンドラを渡す。
+            // urlRegex には共通の URL_TOKEN_REGEX を渡し、既定パターン（`!` を拾えず hashbang URL が
+            // 途中で切れる）を上書きする。右クリック側と同じ範囲になるのもこれが理由。
             const webLinksAddon = new WebLinksAddon.WebLinksAddon((event, uri) => {
                 if (isPrimaryClick(event)) activateTerminalLink(uri);
-            });
+            }, { urlRegex: new RegExp(URL_TOKEN_REGEX.source) });
             term.loadAddon(webLinksAddon);
             console.log('[URL Detection] WebLinksAddon loaded successfully');
         } catch (error) {


### PR DESCRIPTION
## 問題

`https://www.chatwork.com/#!rid443369592` のような hashbang 形式の URL が、ターミナル上で `https://www.chatwork.com/#` までしかリンクにならず、クリックしても目的のページに飛べない。

## 原因

左クリックのリンク化を担っている WebLinksAddon 0.12.0 の既定正規表現が、URL 本体の除外文字に `!` を含んでいるため。

```
/(https?|HTTPS?):[/]{2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~\[\]`()<>]/
                              ^ ここ
```

右クリックメニュー側の `URL_TOKEN_REGEX` も同様に `!` を拾えないが、**そちらだけ直しても解決しない**（リンク化はアドオンの仕事なので）。

## 修正

アドオンは `urlRegex` オプションで正規表現を差し替えられる（[実装](https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0.12.0/lib/addon-web-links.js) で `this._options.urlRegex || <既定>` となっている）。共通定義の `URL_TOKEN_REGEX` をここへ渡すようにした。

中身はアドオンの既定パターンから **本体部分の `!` 除外だけを外した**もの。末尾1文字は `!` を含む別の除外クラスのままなので、末尾の記号は従来どおり巻き込まれない。

## 副次的な修正

これまで右クリック側の正規表現はアドオンとは別物で「厳密一致は保証できない」と割り切っていた。今回1つの定義を両方で共有する形になり、右クリック側にあった以下の取りこぼしも解消する。

| 入力 | 旧・右クリック | 修正後 |
|---|---|---|
| `https://www.chatwork.com/#!rid443369592` | `https://www.chatwork.com/#` | 全体 |
| `http://localhost:5081/` | 検出できず | 全体 |
| `https://ja.wikipedia.org/wiki/日本語` | `https://ja.wikipedia.org/wiki/` | 全体 |

## 巻き込み防止の確認

末尾の記号が URL に取り込まれないことを確認済み。

| 入力 | 結果 |
|---|---|
| `これは http://example.com! すごい` | `http://example.com`（`!` を含まない） |
| `http://example.com.` | `http://example.com`（`.` を含まない） |
| `see https://example.com/x?y=1&z=2, next` | `https://example.com/x?y=1&z=2`（`,` を含まない） |

## 動作確認

- 正規表現の挙動を上記ケースで検証済み
- `node --check` 構文チェック通過
- 実機での確認は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)
