### PR TITLE
fix: detached HEAD の worktree で Git 情報が表示されない問題を修正

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -2848,8 +2848,10 @@
                         result.UseDetached
                             ? L["Root.Toast.WorktreeCreatedDetached"]
                             : string.Format(L["Root.Toast.WorktreeCreatedFormat"], result.BranchName),
+                    // detached HEAD の worktree はブランチ名を持たない（そのままだと '' になる）ので、
+                    // セッションの表示名と同じ worktree 名を出す
                     SubSessionDialog.SubSessionType.AddExisting =>
-                        string.Format(L["Root.Toast.WorktreeAddedFormat"], result.BranchName),
+                        string.Format(L["Root.Toast.WorktreeAddedFormat"], newSession.DisplayName),
                     SubSessionDialog.SubSessionType.SamePath =>
                         string.Format(L["Root.Toast.SamePathSessionCreatedFormat"], GetSessionTypeName(result.TerminalType)),
                     SubSessionDialog.SubSessionType.NewFolder =>

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -2806,7 +2806,7 @@
                     // 既存Worktree追加
                     if (!string.IsNullOrEmpty(result.WorktreePath))
                     {
-                        newSession = await AddExistingWorktreeSession(subSessionParentSessionId.Value, result.WorktreePath, result.BranchName, result.TerminalType, result.Options);
+                        newSession = await AddExistingWorktreeSession(subSessionParentSessionId.Value, result.WorktreePath, result.TerminalType, result.Options);
                     }
                     break;
 
@@ -2891,7 +2891,7 @@
         };
     }
 
-    private async Task<SessionInfo?> AddExistingWorktreeSession(Guid parentSessionId, string worktreePath, string branchName, TerminalType terminalType, Dictionary<string, string> options)
+    private async Task<SessionInfo?> AddExistingWorktreeSession(Guid parentSessionId, string worktreePath, TerminalType terminalType, Dictionary<string, string> options)
     {
         // 親セッション情報を取得
         var parentSession = SessionManager.GetSessionInfo(parentSessionId);
@@ -2902,9 +2902,16 @@
         }
 
         // 既存のWorktreeをセッションとして追加（親はツリー表示でぶら下がるため省略）
+        //
+        // 表示名は worktree のフォルダ名から親のプレフィックスを落としたもの（worktree-1 等）。
+        // 以前はブランチ名を使っていたが、detached HEAD の worktree はブランチを持たないため
+        // 表示名が空になり、フォルダ名まるごと（AiHackPrd01-worktree-1）へフォールバックしていた。
+        // Worktree 新規作成側も同じサフィックスを表示名にするので、これで両者の見た目が揃う。
+        var displayName = WorktreeNaming.GetShortName(parentSession.FolderPath, worktreePath);
+
         var sessionInfo = await SessionManager.CreateSessionAsync(
             worktreePath,
-            branchName,
+            displayName,
             terminalType,
             options
         );

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -229,8 +229,11 @@
                                         <option value="">@L["SubSession.ExistingWorktree.Placeholder"]</option>
                                         @foreach (var worktree in availableWorktrees)
                                         {
+                                            @* 表示は worktree 名のみ。以前はブランチ名を括弧で出していたが、
+                                               detached HEAD の worktree はブランチを持たないため「()」になり
+                                               何を選んでいるか分からなかった *@
                                             <option value="@worktree.Path">
-                                                (@worktree.BranchName)
+                                                @WorktreeNaming.GetShortName(ParentSessionPath, worktree.Path)
                                                 @if (worktree.IsMain)
                                                 {
                                                     <text> @L["SubSession.WorktreeMainSuffix"]</text>

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -262,6 +262,15 @@
     private string GetGitBadgeTitle(SessionInfo session)
     {
         var kind = session.IsWorktree ? "Worktree" : L["SessionList.Badge.GitBranch"].Value;
+
+        // detached HEAD はバッジ本体が「@短縮ハッシュ」になり、ブランチ名との区別が付きにくい。
+        // 何を見ているのかはツールチップで補う。
+        if (GitInfo.IsDetachedHead(session.GitBranch))
+        {
+            var sha = session.GitBranch!.Substring(GitInfo.DetachedHeadPrefix.Length);
+            kind = $"{kind} - detached HEAD ({sha})";
+        }
+
         return GitChangesOnBadgeClick
             ? $"{kind} - {L["SessionList.Badge.GitBranchClickHint"].Value}"
             : kind;

--- a/TerminalHub/Helpers/WorktreeNaming.cs
+++ b/TerminalHub/Helpers/WorktreeNaming.cs
@@ -1,0 +1,45 @@
+namespace TerminalHub.Helpers
+{
+    /// <summary>
+    /// worktree フォルダの表示名を決める。
+    ///
+    /// TerminalHub が作る worktree は親と同じ階層に「{親フォルダ名}-{サフィックス}」で置かれる
+    /// （SessionManager.CreateWorktreeSessionAsync）。一覧では親の下にぶら下げて描画するので、
+    /// 行に親の名前を再掲しても幅を食うだけになる。ここで親のプレフィックスを落として
+    /// サフィックスだけ（worktree-1 等）にする。
+    ///
+    /// 命名規則に沿わないフォルダ（ユーザーが自分で作った worktree など）はフォルダ名をそのまま使う。
+    /// </summary>
+    public static class WorktreeNaming
+    {
+        public static string GetShortName(string? parentFolderPath, string worktreePath)
+        {
+            if (string.IsNullOrWhiteSpace(worktreePath))
+                return string.Empty;
+
+            var folderName = Path.GetFileName(TrimSeparators(worktreePath));
+            if (string.IsNullOrEmpty(folderName))
+                return worktreePath;
+
+            if (string.IsNullOrWhiteSpace(parentFolderPath))
+                return folderName;
+
+            var parentName = Path.GetFileName(TrimSeparators(parentFolderPath));
+            if (string.IsNullOrEmpty(parentName))
+                return folderName;
+
+            // 「親フォルダ名-」で始まるときだけ削る。削った結果が空になる場合は削らない
+            var prefix = parentName + "-";
+            if (folderName.Length > prefix.Length &&
+                folderName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return folderName.Substring(prefix.Length);
+            }
+
+            return folderName;
+        }
+
+        private static string TrimSeparators(string path) =>
+            path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+}

--- a/TerminalHub/Services/GitService.cs
+++ b/TerminalHub/Services/GitService.cs
@@ -43,7 +43,20 @@ namespace TerminalHub.Services
             try
             {
                 var result = await ExecuteGitCommandAsync(path, "branch --show-current");
-                return result.Success ? result.Output?.Trim() : null;
+                if (!result.Success)
+                    return null;
+
+                var branch = result.Output?.Trim();
+                if (!string.IsNullOrEmpty(branch))
+                    return branch;
+
+                // detached HEAD では branch --show-current が「成功したうえで空文字」を返す。
+                // 空のままだと UI 側の「ブランチ名が空なら Git バッジを出さない」条件に当たり、
+                // worktree の行から Git 情報が丸ごと消えてしまうので、短縮コミットハッシュを代わりに出す。
+                // ブランチ名と区別できるよう先頭に @ を付ける（git の `HEAD detached at <sha>` に相当）。
+                var head = await ExecuteGitCommandAsync(path, "rev-parse --short HEAD");
+                var sha = head.Success ? head.Output?.Trim() : null;
+                return string.IsNullOrEmpty(sha) ? null : GitInfo.DetachedHeadPrefix + sha;
             }
             catch (Exception ex)
             {
@@ -189,7 +202,11 @@ namespace TerminalHub.Services
                 if (!result.Success || string.IsNullOrEmpty(result.Output))
                     return worktrees;
 
-                var lines = result.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                // 行末の \r は落としてから判定する。下の `line == "detached"` 等は完全一致なので、
+                // 改行コードが混ざると黙って素通りしてしまう（フラグが立たないだけでエラーは出ない）。
+                var lines = result.Output
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(l => l.TrimEnd('\r'));
                 WorktreeInfo? currentWorktree = null;
 
                 foreach (var line in lines)
@@ -212,7 +229,14 @@ namespace TerminalHub.Services
                         }
                         else if (line.StartsWith("branch "))
                         {
-                            currentWorktree.BranchName = line.Substring("branch ".Length).Trim();
+                            // --porcelain は完全な ref 名（refs/heads/master）で出す。
+                            // 呼び出し側は「master」のような短い名前と突き合わせるので、ここで揃えておく
+                            // （揃っていないと既存 worktree の再利用判定が常に不成立になる）。
+                            var refName = line.Substring("branch ".Length).Trim();
+                            const string headsPrefix = "refs/heads/";
+                            currentWorktree.BranchName = refName.StartsWith(headsPrefix)
+                                ? refName.Substring(headsPrefix.Length)
+                                : refName;
                         }
                         else if (line == "bare")
                         {
@@ -221,7 +245,9 @@ namespace TerminalHub.Services
                         }
                         else if (line == "detached")
                         {
-                            currentWorktree.BranchName = "(detached HEAD)";
+                            // BranchName は空のままにする。ここに "(detached HEAD)" のような表示用の
+                            // 文字列を入れると、ブランチ名との等値比較に紛れ込んで誤判定の元になる
+                            currentWorktree.IsDetached = true;
                         }
                         else if (line == "locked")
                         {
@@ -442,16 +468,21 @@ namespace TerminalHub.Services
                 var outputBuilder = new StringBuilder();
                 var errorBuilder = new StringBuilder();
 
+                // 改行は必ず LF で連結する（AppendLine は Windows だと CRLF を入れてしまう）。
+                // git 自身の出力は LF なので、AppendLine を使うと本来無い \r が混入し、
+                // 呼び出し側が Split('\n') した行の末尾に \r が残る。StartsWith や Trim 併用の
+                // 箇所は無事だが、`line == "detached"` のような完全一致は必ず false になり、
+                // detached worktree を見落とす原因になっていた。
                 process.OutputDataReceived += (sender, e) =>
                 {
                     if (e.Data != null)
-                        outputBuilder.AppendLine(e.Data);
+                        outputBuilder.Append(e.Data).Append('\n');
                 };
 
                 process.ErrorDataReceived += (sender, e) =>
                 {
                     if (e.Data != null)
-                        errorBuilder.AppendLine(e.Data);
+                        errorBuilder.Append(e.Data).Append('\n');
                 };
 
                 process.Start();

--- a/TerminalHub/Services/IGitService.cs
+++ b/TerminalHub/Services/IGitService.cs
@@ -131,6 +131,17 @@ namespace TerminalHub.Services
 
     public class GitInfo
     {
+        /// <summary>
+        /// detached HEAD のときに「ブランチ名」の代わりに使う表示の目印。
+        /// この後ろに短縮コミットハッシュが続く（例: <c>@87073f2</c>）。
+        /// ブランチ名に @ 始まりは使えないので、実在のブランチと衝突しない。
+        /// </summary>
+        public const string DetachedHeadPrefix = "@";
+
+        /// <summary>ブランチ名が detached HEAD の表示（<see cref="DetachedHeadPrefix"/> 始まり）かどうか。</summary>
+        public static bool IsDetachedHead(string? branch) =>
+            !string.IsNullOrEmpty(branch) && branch.StartsWith(DetachedHeadPrefix);
+
         public string CurrentBranch { get; set; } = string.Empty;
         public bool HasUncommittedChanges { get; set; }
         public bool IsWorktree { get; set; }
@@ -140,8 +151,11 @@ namespace TerminalHub.Services
     public class WorktreeInfo
     {
         public string Path { get; set; } = string.Empty;
+        /// <summary>ブランチ名（refs/heads/ は除いた短い形）。detached HEAD のときは空。</summary>
         public string BranchName { get; set; } = string.Empty;
         public string? CommitHash { get; set; }
+        /// <summary>detached HEAD で作られた worktree（ブランチに紐づいていない）。</summary>
+        public bool IsDetached { get; set; }
         public bool IsMain { get; set; }
         public bool IsLocked { get; set; }
         public bool IsPrunable { get; set; }


### PR DESCRIPTION
## 概要

「Worktree 新規作成」で作った worktree（detached HEAD）まわりで報告された3つの症状は、いずれも **detached HEAD を扱えていない**ことが原因の同じ問題だった。

| 症状 | 直接の原因 |
|---|---|
| セッション行に Git バッジが出ない（待っても・リロードしても出ない） | `branch --show-current` が detached で「成功 + 空文字」を返す |
| 「既存 Worktree 追加」の一覧が `()` になる | 出力の `\r` により `line == "detached"` が常に false |
| 既存ブランチから追加した名前が `AiHackPrd01-worktree-1` になる | 上の結果、空のブランチ名がフォルダ名にフォールバック |

## 1. バッジが出ない

detached HEAD では `git branch --show-current` が**終了コード0のまま空文字**を返す（実測）。

```
$ git branch --show-current
              ← 空。終了コードは 0
$ git status -sb | head -1
## HEAD (no branch)
```

`GetCurrentBranchAsync` は `result.Success ? result.Output?.Trim() : null` なので、`null` ではなく `""` を返す。そのため `?? "unknown"` のフォールバックが効かず `GitBranch` が空になり、UI の表示条件（`!string.IsNullOrEmpty(session.GitBranch)`）で弾かれてバッジごと消えていた。

取得タイミング自体は正常で、worktree 作成直後に同期的に取っている（`SessionManager.CreateWorktreeSessionAsync`）。だから待っても直らない。

**修正**: 空だったら detached とみなし、`rev-parse --short HEAD` の短縮ハッシュを代わりに表示する。ブランチ名と紛れないよう先頭に `@` を付ける（git の `HEAD detached at <sha>` に相当）。detached である旨はツールチップに出す。

```
[git] @87073f2      ツールチップ: Worktree - detached HEAD (87073f2)
```

## 2. 一覧が `()` になる

`ExecuteGitCommandAsync` が出力を `outputBuilder.AppendLine(e.Data)` で連結していた。**`AppendLine` は Windows では CRLF を入れる**が、git 自身の出力は LF。結果、呼び出し側が `Split('\n')` した各行の末尾に本来無い `\r` が残る。

`StartsWith` + `Trim` を併用している行（`worktree `, `HEAD `, `branch `）は無事だが、完全一致で判定している行は必ず false になる。

```csharp
else if (line == "detached")   // 実際の値は "detached\r" → 一致しない
```

`bare` / `locked` / `prunable` も同じく素通りしていた（エラーにはならず、フラグが立たないだけなので気付きにくい）。

**修正**: 連結を LF に統一。あわせて worktree のパース側でも行末の `\r` を落とす（多重防御）。

## 3. 表示名がフォルダ名まるごとになる

2 の結果として `BranchName` が空になり、それが表示名として `CreateSessionAsync` に渡ってフォルダ名へフォールバックしていた。

**修正**: worktree のフォルダ名から親のプレフィックスを落とし、サフィックスだけ（`worktree-1`）を表示名にする。TerminalHub が作る worktree は `{親フォルダ名}-{サフィックス}` という命名なので、「Worktree 新規作成」側の表示名と見た目が揃う。共通処理は `Helpers/WorktreeNaming.cs` に切り出した。命名規則に沿わないフォルダ（ユーザーが自分で作った worktree 等）はフォルダ名をそのまま使う。

ドロップダウンの表示も同じ名前のみにした（従来はブランチ名だけを括弧で出しており、detached だと `()` になって何を選んでいるか分からなかった）。

## あわせて直したもの

`worktree list --porcelain` は完全な ref 名（`refs/heads/master`）を返すが、呼び出し側は短い名前（`master`）と等値比較していた。

- `SessionManager.cs` — 既存 worktree の再利用判定
- `SubSessionDialog.razor` — 選択ブランチに worktree が既にあるかの判定

どちらも**常に不成立**になっていたので、パース時に `refs/heads/` を落として揃えた。

また `WorktreeInfo.BranchName` に入れていた表示用の文字列 `"(detached HEAD)"` をやめ、`IsDetached` フラグに分けた。ブランチ名との等値比較に表示用文字列が紛れ込むのを避けるため。

## 動作確認

- `dotnet build` 成功（0 警告 / 0 エラー）
- detached worktree での git の挙動は実リポジトリで実測して確認
- 実機での UI 確認は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)