### PR TITLE
fix: 起動コマンドラインの hook 引数をコンソールでは畳む

### DIFF
--- a/TerminalHub/Helpers/CommandLineSummary.cs
+++ b/TerminalHub/Helpers/CommandLineSummary.cs
@@ -1,0 +1,72 @@
+using System.Text.RegularExpressions;
+
+namespace TerminalHub.Helpers
+{
+    /// <summary>
+    /// 起動コマンドラインをコンソール表示用に短くする。
+    ///
+    /// Codex の lifecycle hook は起動引数として注入するため（CodexHookService）、
+    /// <c>-c "hooks.&lt;イベント名&gt;=..."</c> が8個並ぶ。値には PowerShell の
+    /// -EncodedCommand の Base64 が丸ごと入るので、1セッション分で数千文字になり、
+    /// コンソールに出すと他のログが流れて読めなくなる。
+    ///
+    /// hook の引数だけを畳み、それ以外（--sandbox 等の起動オプションや作業フォルダ）は
+    /// そのまま残す。起動オプションの確認はコンソールのままできる、というのが狙い。
+    /// 全文はファイルログに残す。
+    /// </summary>
+    public static class CommandLineSummary
+    {
+        // -c "hooks.Stop=[...]" 形式。値の中では引用符に ' を使うので、閉じの " は曖昧にならない
+        private static readonly Regex HookArgRegex = new(
+            "-c \"hooks\\.[^\"]*\"",
+            RegexOptions.Compiled);
+
+        /// <summary>
+        /// hook 注入の引数を「&lt;hooks 引数 N 件を省略: M 文字&gt;」に畳んだものを返す。
+        /// 対象が無ければ元の文字列をそのまま返す。
+        /// </summary>
+        public static string FoldHookArguments(string commandLine)
+        {
+            if (string.IsNullOrEmpty(commandLine))
+                return commandLine;
+
+            var matches = HookArgRegex.Matches(commandLine);
+            if (matches.Count == 0)
+                return commandLine;
+
+            var omittedChars = matches.Sum(m => m.Length);
+            var placeholder = $"<hooks 引数 {matches.Count} 件を省略: {omittedChars:N0} 文字>";
+
+            // hook の引数は連続して並ぶ（CodexHookService が続けて足す）ので、
+            // 最初から最後までを丸ごと1つの目印に置き換える。
+            // こうすると前後の区切り空白がそのまま活きるため、空白の詰め直しが要らない。
+            var first = matches[0];
+            var last = matches[^1];
+            if (IsOnlyWhitespaceBetween(commandLine, matches))
+            {
+                var tailStart = last.Index + last.Length;
+                return string.Concat(
+                    commandLine.AsSpan(0, first.Index),
+                    placeholder,
+                    commandLine.AsSpan(tailStart));
+            }
+
+            // 連続していない場合（現状の実装では起きない）は、間に挟まった引数を巻き込まないよう
+            // 1件ずつ個別に畳む
+            return HookArgRegex.Replace(commandLine, "<hooks 引数を省略>");
+        }
+
+        /// <summary>ヒット同士の間が空白だけか（＝ひとかたまりとして畳んでよいか）。</summary>
+        private static bool IsOnlyWhitespaceBetween(string commandLine, MatchCollection matches)
+        {
+            for (var i = 1; i < matches.Count; i++)
+            {
+                var gapStart = matches[i - 1].Index + matches[i - 1].Length;
+                var gapLength = matches[i].Index - gapStart;
+                if (gapLength > 0 && !commandLine.AsSpan(gapStart, gapLength).IsWhiteSpace())
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/TerminalHub/Helpers/LogSinkRouting.cs
+++ b/TerminalHub/Helpers/LogSinkRouting.cs
@@ -1,0 +1,29 @@
+using Serilog.Context;
+
+namespace TerminalHub.Helpers
+{
+    /// <summary>
+    /// 同じ出来事をコンソールとファイルで出し分けるための目印。
+    ///
+    /// 既定ではコンソールとファイルに同じイベントが流れる（Program.cs のシンク設定）。
+    /// 起動コマンドラインのように「全文はファイルに残したいが、コンソールに出すと
+    /// 画面が流れてしまう」ものだけ、要約版と全文版の2イベントに分けて片方ずつ送る。
+    ///
+    /// 目印は LogContext のプロパティとして載せる（Program.cs で Enrich.FromLogContext 済み）。
+    /// シンク側は WriteTo.Conditional でこのプロパティの有無を見て振り分ける。
+    /// </summary>
+    public static class LogSinkRouting
+    {
+        /// <summary>このプロパティが付いたイベントはコンソールにだけ出す（ファイルへは出さない）。</summary>
+        public const string ConsoleOnlyProperty = "TerminalHubConsoleOnly";
+
+        /// <summary>このプロパティが付いたイベントはファイルにだけ出す（コンソールへは出さない）。</summary>
+        public const string FileOnlyProperty = "TerminalHubFileOnly";
+
+        /// <summary>using で囲んだ範囲のログをコンソール限定にする。</summary>
+        public static IDisposable ConsoleOnly() => LogContext.PushProperty(ConsoleOnlyProperty, true);
+
+        /// <summary>using で囲んだ範囲のログをファイル限定にする。</summary>
+        public static IDisposable FileOnly() => LogContext.PushProperty(FileOnlyProperty, true);
+    }
+}

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -28,17 +28,23 @@ builder.Host.UseSerilog((context, configuration) =>
     // シンクは Async でラップする（フリーズ調査の実験を兼ねた対策）。
     // 同期シンクだと、コンソールの QuickEdit（画面上のテキスト選択）やディスク停滞で
     // ログを書く全スレッドが巻き添えブロックし、プロセス全体フリーズの形になる。
+    // 既定では両シンクに同じイベントが流れる。ただし LogSinkRouting の目印が付いたものだけは
+    // 片方に寄せる（起動コマンドラインを「コンソールは要約・ファイルは全文」に分けるため）。
     configuration
         .ReadFrom.Configuration(context.Configuration)
         .Enrich.FromLogContext()
-        .WriteTo.Async(a => a.Console())
-        .WriteTo.Async(a => a.File(
-            logPath,
-            rollingInterval: RollingInterval.Day,
-            retainedFileCountLimit: 7,
-            fileSizeLimitBytes: 10 * 1024 * 1024, // 10MB
-            rollOnFileSizeLimit: true,
-            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}"));
+        .WriteTo.Conditional(
+            e => !e.Properties.ContainsKey(LogSinkRouting.FileOnlyProperty),
+            w => w.Async(a => a.Console()))
+        .WriteTo.Conditional(
+            e => !e.Properties.ContainsKey(LogSinkRouting.ConsoleOnlyProperty),
+            w => w.Async(a => a.File(
+                logPath,
+                rollingInterval: RollingInterval.Day,
+                retainedFileCountLimit: 7,
+                fileSizeLimitBytes: 10 * 1024 * 1024, // 10MB
+                rollOnFileSizeLimit: true,
+                outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}")));
 });
 
 // Add services to the container.

--- a/TerminalHub/Services/ConPtyService.cs
+++ b/TerminalHub/Services/ConPtyService.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using TerminalHub.Helpers;
 
 namespace TerminalHub.Services
 {
@@ -297,7 +298,28 @@ namespace TerminalHub.Services
             var fullCommand = string.IsNullOrWhiteSpace(arguments) ? command : $"{command} {arguments}";
             var cmdline = $"cmd.exe /c {fullCommand}";
 
-            _logger.LogInformation($"Creating process: {cmdline} in directory: {workingDirectory ?? "current"}");
+            // コンソールには hook 注入の引数を畳んだ要約を、ファイルには全文を出す。
+            // Codex は hook を起動引数で渡すため、そのまま出すと1セッションで数千文字流れて
+            // 他のログが読めなくなる。全文は調査に要るのでファイル側には残す。
+            var directory = workingDirectory ?? "current";
+            var summary = CommandLineSummary.FoldHookArguments(cmdline);
+
+            if (summary.Length == cmdline.Length)
+            {
+                // 畳む対象が無い（Codex 以外など）。出し分けても同じ内容なので普通に1回出す
+                _logger.LogInformation("Creating process: {CommandLine} in directory: {Directory}", cmdline, directory);
+            }
+            else
+            {
+                using (LogSinkRouting.ConsoleOnly())
+                {
+                    _logger.LogInformation("Creating process: {CommandLine} in directory: {Directory}", summary, directory);
+                }
+                using (LogSinkRouting.FileOnly())
+                {
+                    _logger.LogInformation("Creating process: {CommandLine} in directory: {Directory}", cmdline, directory);
+                }
+            }
             
             // XTerm互換のための環境変数を設定
             var envBlock = CreateEnvironmentBlock();


### PR DESCRIPTION
## 問題

Codex の lifecycle hook は起動引数として注入するため（`CodexHookService`）、`-c "hooks.<イベント名>=..."` が8個並ぶ。値には PowerShell の `-EncodedCommand` の Base64 が丸ごと入るので、**1セッションの起動で 5,000 文字超**がコンソールに流れ、他のログが読めなくなっていた。

`ConPtyService` の `Creating process:` はコンソールにもファイルにも同じ全文を出していた（Serilog のシンクにフィルタが無く、両方に同じイベントが流れるため）。

## 修正

コンソールには hook 引数を畳んだ要約を出し、**ファイルログには全文を残す**。

実ログの Codex 起動行で検証したところ **5,425 文字 → 433 文字**になった。

**修正前（コンソール）**
```
Creating process: cmd.exe /c cmd.exe /k codex --sandbox workspace-write ... -c "hooks.Stop=[{hooks:[{type:'command',command:'powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand JgAgACcAQwA6AFwAVQBzAGUAcgBzAFwAaQBuAGYAbwBcAEEAcABwAEQA...
（以下、同様の行が8イベント分）
```

**修正後（コンソール）**
```
Creating process: cmd.exe /c cmd.exe /k codex --sandbox workspace-write
  --ask-for-approval on-request -c approvals_reviewer=auto_review
  -c windows.sandbox=elevated -c sandbox_workspace_write.network_access=true
  --search -c mcp_servers.terminalhub.url=http://localhost:5081/mcp
  <hooks 引数 8 件を省略: 5,012 文字> resume --last
  in directory: C:\Users\info\source\repos\demo\wf
```

`--sandbox` 等の起動オプションと作業フォルダはそのまま残るので、**起動オプションの確認はこれまでどおりコンソールでできる**。

## 実装

### `Helpers/CommandLineSummary.cs`（新規）

`-c "hooks.…"` にマッチする引数を1つの目印に畳む。hook 引数は連続して並ぶので、**最初から最後までを丸ごと1つの目印に置き換える**（前後の区切り空白がそのまま活きるため、空白の詰め直しが不要）。

連続していない場合（現状の実装では起きない）は、間に挟まった引数を巻き込まないよう1件ずつ個別に畳むフォールバックを用意した。

### `Helpers/LogSinkRouting.cs`（新規）＋ `Program.cs`

同じ出来事をコンソールとファイルで出し分けるための仕組み。`LogContext` のプロパティを目印にし（`Enrich.FromLogContext()` は設定済み）、シンク側は `WriteTo.Conditional` でその有無を見て振り分ける。

### `ConPtyService.cs`

要約版（コンソール限定）と全文版（ファイル限定）の2イベントに分ける。**畳む対象が無いとき（Codex 以外）は出し分けても同じ内容なので、従来どおり1回だけ出す**（無駄な二重出力を避けるため）。

あわせて、補間文字列だったログを構造化パラメータ（`{CommandLine}` / `{Directory}`）に直した。

## 動作確認

- `dotnet build` 成功（0 警告 / 0 エラー）
- 実際のログファイルから取った Codex 起動行（5,425 文字・hook 8件）で畳み処理を検証。余分な空白が残らないことも確認
- 実機での確認は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)