### PR TITLE
feat: セッション一覧に実使用モデルのバッジを追加

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -19,6 +19,7 @@
 @inject INotificationService NotificationService
 @inject IOutputAnalyzerFactory AnalyzerFactory
 @inject IGitService GitService
+@inject ISessionModelService SessionModelService
 @inject ITerminalService TerminalService
 @inject IOutputAnalyzerService OutputAnalyzerService
 @inject IInputHistoryService InputHistoryService
@@ -92,6 +93,7 @@
                      ShowTerminalType=@showTerminalType
                      ShowGitInfo=@showGitInfo
                      GitChangesOnBadgeClick=@gitChangesOnBadgeClick
+                     ShowModel=@showModel
                      OnShowInfoToast="(string msg) => toast?.ShowInfo(msg)"
                      OnShowErrorToast="(string msg) => toast?.ShowError(msg)"
                      OnShowSuccessToast="(string msg) => toast?.ShowSuccess(msg)"
@@ -208,6 +210,7 @@
     private bool showTerminalType = false; // ターミナル種別を表示
     private bool showGitInfo = false; // Git情報を表示
     private bool gitChangesOnBadgeClick = false; // Gitバッジクリックで変更ファイル一覧を表示
+    private bool showModel = false; // 実使用モデルのバッジを表示
     private bool hideInputPanel = false; // 入力パネルを非表示
     private bool perSessionInputText = true; // 入力テキストの下書きをセッションごとに保持（既定ON）
     private bool isMobileSidebarOpen = false; // モバイルサイドバーの開閉状態
@@ -574,6 +577,7 @@
                 showTerminalType = appSettings.Sessions.ShowTerminalType;
                 showGitInfo = appSettings.Sessions.ShowGitInfo;
                 gitChangesOnBadgeClick = appSettings.Sessions.GitChangesOnBadgeClick;
+                showModel = appSettings.Sessions.ShowModel;
                 hideInputPanel = appSettings.Sessions.HideInputPanel;
                 perSessionInputText = appSettings.Sessions.PerSessionInputText;
                 // 表示系4項目はデバイス別 (LocalStorage 優先、無ければ app-settings をシード)。
@@ -758,6 +762,15 @@
                         });
 
                         await Task.WhenAll(tasks);
+
+                        // 起動直後もバッジが出るよう、実使用モデルも同じ裏処理で読む
+                        if (showModel)
+                        {
+                            foreach (var session in sessions.ToList())
+                            {
+                                session.CurrentModel = await SessionModelService.GetCurrentModelAsync(session);
+                            }
+                        }
 
                         // Git情報取得完了後にUIを更新
                         await InvokeAsync(StateHasChanged);
@@ -1090,13 +1103,32 @@
         StateHasChanged();
     }
 
-    private void HandleSessionDisplaySettingsChanged((bool showTerminalType, bool showGitInfo, bool gitChangesOnBadgeClick, bool hideInputPanel, bool perSessionInputText) settings)
+    private async Task HandleSessionDisplaySettingsChanged((bool showTerminalType, bool showGitInfo, bool gitChangesOnBadgeClick, bool showModel, bool hideInputPanel, bool perSessionInputText) settings)
     {
         showTerminalType = settings.showTerminalType;
         showGitInfo = settings.showGitInfo;
         gitChangesOnBadgeClick = settings.gitChangesOnBadgeClick;
         hideInputPanel = settings.hideInputPanel;
         perSessionInputText = settings.perSessionInputText;
+
+        var modelTurnedOn = settings.showModel && !showModel;
+        showModel = settings.showModel;
+        StateHasChanged();
+
+        // ONにした直後にバッジが空のままだと壊れて見えるので、その場で読みに行く
+        if (modelTurnedOn)
+        {
+            await RefreshAllModelsAsync();
+        }
+    }
+
+    /// <summary>全セッションの実使用モデルを読み直す（バッジ表示ONのときのみ意味を持つ）</summary>
+    private async Task RefreshAllModelsAsync()
+    {
+        foreach (var session in sessions.ToList())
+        {
+            session.CurrentModel = await SessionModelService.GetCurrentModelAsync(session);
+        }
         StateHasChanged();
     }
 
@@ -3325,7 +3357,21 @@
     private async Task RefreshGitStatus(Guid sessionId)
     {
         var sessionInfo = sessions.FirstOrDefault(s => s.SessionId == sessionId);
-        if (sessionInfo != null && sessionInfo.IsGitRepository)
+        if (sessionInfo == null) return;
+
+        // 実使用モデルも同じタイミングで更新する。ここは発話が終わった直後なので、
+        // トランスクリプトに最新のモデルが記録済みで、切り替えがあれば確実に拾える
+        if (showModel)
+        {
+            var model = await SessionModelService.GetCurrentModelAsync(sessionInfo);
+            if (model != sessionInfo.CurrentModel)
+            {
+                sessionInfo.CurrentModel = model;
+                StateHasChanged();
+            }
+        }
+
+        if (sessionInfo.IsGitRepository)
         {
             // Gitステータスを更新
             var gitInfo = await GitService.GetGitInfoAsync(sessionInfo.FolderPath);

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1119,6 +1119,22 @@
         }
     }
 
+    /// <summary>
+    /// セッション再起動後にモデルを読み直す。再起動では既定のモデルへ戻ることがあり、
+    /// 次の発話（hook Stop）を待つとその間ずっと古い値を出し続けてしまうため。
+    /// </summary>
+    private async Task RefreshModelAfterRestartAsync(Guid sessionId)
+    {
+        if (!showModel) return;
+
+        var session = sessions.FirstOrDefault(s => s.SessionId == sessionId);
+        if (session == null) return;
+
+        SessionModelService.Invalidate(sessionId);
+        session.CurrentModel = await SessionModelService.GetCurrentModelAsync(session);
+        StateHasChanged();
+    }
+
     /// <summary>全セッションの実使用モデルを読み直す（バッジ表示ONのときのみ意味を持つ）</summary>
     private async Task RefreshAllModelsAsync(bool notify = true)
     {
@@ -3333,6 +3349,9 @@
             {
                 await SaveSessionToStorageAsync(savedSession);
             }
+
+            // 設定ダイアログからは再起動を伴うことがあるため、モデルを読み直す
+            await RefreshModelAfterRestartAsync(settingsSessionId.Value);
         }
 
         // セッションが再起動された場合、ターミナルコンポーネントも再読み込み
@@ -3427,6 +3446,8 @@
                 // forceReinit で強制再初期化（activeSessionId を null にしないので BottomPanel は保持される）
                 await SelectSession(sessionId, forceReinit: true);
                 
+                await RefreshModelAfterRestartAsync(sessionId);
+
                 toast?.ShowInfo(L["Root.Toast.SessionRecreatedWithoutContinue"]);
             }
             else

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1130,8 +1130,8 @@
         var session = sessions.FirstOrDefault(s => s.SessionId == sessionId);
         if (session == null) return;
 
-        SessionModelService.Invalidate(sessionId);
-        session.CurrentModel = await SessionModelService.GetCurrentModelAsync(session);
+        // 再起動直後はキャッシュの値が当てにならないので、無視して読み直させる
+        session.CurrentModel = await SessionModelService.GetCurrentModelAsync(session, forceRefresh: true);
         StateHasChanged();
     }
 

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -766,10 +766,7 @@
                         // 起動直後もバッジが出るよう、実使用モデルも同じ裏処理で読む
                         if (showModel)
                         {
-                            foreach (var session in sessions.ToList())
-                            {
-                                session.CurrentModel = await SessionModelService.GetCurrentModelAsync(session);
-                            }
+                            await RefreshAllModelsAsync(notify: false);
                         }
 
                         // Git情報取得完了後にUIを更新
@@ -1123,13 +1120,16 @@
     }
 
     /// <summary>全セッションの実使用モデルを読み直す（バッジ表示ONのときのみ意味を持つ）</summary>
-    private async Task RefreshAllModelsAsync()
+    private async Task RefreshAllModelsAsync(bool notify = true)
     {
-        foreach (var session in sessions.ToList())
+        var targets = sessions.ToList();
+        var models = await SessionModelService.GetCurrentModelsAsync(targets);
+        foreach (var session in targets)
         {
-            session.CurrentModel = await SessionModelService.GetCurrentModelAsync(session);
+            session.CurrentModel = models.GetValueOrDefault(session.SessionId);
         }
-        StateHasChanged();
+        // 起動時の裏処理からは呼び出し側がまとめて再描画するので、その場合は通知しない
+        if (notify) StateHasChanged();
     }
 
     private void HandleClaudeModeSwitchKeyChanged(string key)

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -498,6 +498,21 @@
                                             <span class="text-muted small">（@L["Settings.Sessions.Display.GitChangesOnBadgeClickSub"]）</span>
                                         </label>
                                     </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" @bind="showModel" id="showModel">
+                                        <label class="form-check-label" for="showModel">
+                                            <i class="bi bi-cpu me-1"></i>@L["Settings.Sessions.Display.ShowModel"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.Display.ShowModelSub"]）</span>
+                                        </label>
+                                    </div>
+                                    @* 反映の遅れは仕様なので、問い合わせになる前に理由を書いておく *@
+                                    @if (showModel)
+                                    {
+                                        <p class="text-muted small ms-4 mt-1 mb-0">
+                                            <i class="bi bi-exclamation-circle me-1"></i>
+                                            @L["Settings.Sessions.Display.ShowModelNote"]
+                                        </p>
+                                    }
                                     <p class="text-muted small mt-2 mb-0">
                                         <i class="bi bi-info-circle me-1"></i>
                                         @L["Settings.Sessions.Display.Help"]
@@ -1335,6 +1350,7 @@
     private bool showTerminalType = false;
     private bool showGitInfo = false;
     private bool gitChangesOnBadgeClick = false;
+    private bool showModel = false;
     private bool hideInputPanel = false;
     private bool perSessionInputText = true;
     private bool terminalLinkCopyMode = false;
@@ -1378,7 +1394,7 @@
     [Parameter] public EventCallback<string> OnSessionSortModeChanged { get; set; }
     [Parameter] public string SessionSortMode { get; set; } = "lastAccessed";
     [Parameter] public EventCallback<string> OnClaudeModeSwitchKeyChanged { get; set; }
-    [Parameter] public EventCallback<(bool showTerminalType, bool showGitInfo, bool gitChangesOnBadgeClick, bool hideInputPanel, bool perSessionInputText)> OnSessionDisplaySettingsChanged { get; set; }
+    [Parameter] public EventCallback<(bool showTerminalType, bool showGitInfo, bool gitChangesOnBadgeClick, bool showModel, bool hideInputPanel, bool perSessionInputText)> OnSessionDisplaySettingsChanged { get; set; }
     [Parameter] public EventCallback<double> OnSessionListScaleChanged { get; set; }
     [Parameter] public EventCallback<int> OnTerminalFontSizeChanged { get; set; }
     [Parameter] public EventCallback<int> OnTerminalHeightPercentChanged { get; set; }
@@ -1496,6 +1512,7 @@
             showTerminalType = settings.Sessions.ShowTerminalType;
             showGitInfo = settings.Sessions.ShowGitInfo;
             gitChangesOnBadgeClick = settings.Sessions.GitChangesOnBadgeClick;
+            showModel = settings.Sessions.ShowModel;
             hideInputPanel = settings.Sessions.HideInputPanel;
             perSessionInputText = settings.Sessions.PerSessionInputText;
 
@@ -1743,6 +1760,7 @@
                     ShowTerminalType = showTerminalType,
                     ShowGitInfo = showGitInfo,
                     GitChangesOnBadgeClick = gitChangesOnBadgeClick,
+                    ShowModel = showModel,
                     HideInputPanel = hideInputPanel,
                     PerSessionInputText = perSessionInputText
                 },
@@ -1839,7 +1857,7 @@
             await OnSessionSortModeChanged.InvokeAsync(sessionSortMode);
 
             // セッション表示設定の変更を通知
-            await OnSessionDisplaySettingsChanged.InvokeAsync((showTerminalType, showGitInfo, gitChangesOnBadgeClick, hideInputPanel, perSessionInputText));
+            await OnSessionDisplaySettingsChanged.InvokeAsync((showTerminalType, showGitInfo, gitChangesOnBadgeClick, showModel, hideInputPanel, perSessionInputText));
 
             // モード切替キーの変更を通知
             await OnClaudeModeSwitchKeyChanged.InvokeAsync(claudeModeSwitchKey);

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -118,6 +118,13 @@
                             {
                                 <span class="badge bg-info ms-2">@GetTerminalTypeBadge(session.TerminalType)</span>
                             }
+                            @* 実使用モデル（トランスクリプト由来）。切替直後は次に発話するまで前の値のまま *@
+                            @if (ShowModel && !string.IsNullOrEmpty(session.CurrentModel))
+                            {
+                                <span class="badge bg-dark ms-1" title="@L["SessionList.Badge.ModelTitle"]">
+                                    @session.CurrentModel
+                                </span>
+                            }
                             @if (ShowGitInfo && session.IsGitRepository && !string.IsNullOrEmpty(session.GitBranch))
                             {
                                 @* クリック領域は赤丸＋Gitアイコンのみに限定（ブランチ名クリックでは履歴を開かない）。
@@ -246,6 +253,7 @@
     [Parameter] public int WidthPercent { get; set; } = 25;
     /// <summary>Git バッジのクリックで変更ファイル一覧を表示する（設定のサブオプション）</summary>
     [Parameter] public bool GitChangesOnBadgeClick { get; set; }
+    [Parameter] public bool ShowModel { get; set; }
     [Parameter] public EventCallback<string> OnShowInfoToast { get; set; }
     [Parameter] public EventCallback<string> OnShowErrorToast { get; set; }
     [Parameter] public EventCallback<string> OnShowSuccessToast { get; set; }

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -121,7 +121,9 @@
                             @* 実使用モデル（トランスクリプト由来）。切替直後は次に発話するまで前の値のまま *@
                             @if (ShowModel && !string.IsNullOrEmpty(session.CurrentModel))
                             {
-                                <span class="badge bg-dark ms-1" title="@L["SessionList.Badge.ModelTitle"]">
+                                @* text-bg-* はテーマの配色変数を使うので、ダークでも背景と同化しない
+                                   （bg-dark はダークテーマで背景に溶けて見えなくなる） *@
+                                <span class="badge text-bg-secondary ms-1" title="@L["SessionList.Badge.ModelTitle"]">
                                     @session.CurrentModel
                                 </span>
                             }

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -150,6 +150,8 @@ public class SessionDisplaySettings
     public bool ShowGitInfo { get; set; }
     /// <summary>Git バッジのクリックで変更ファイル一覧を表示する（ShowGitInfo が有効な場合のみ意味を持つ）。既定 false。</summary>
     public bool GitChangesOnBadgeClick { get; set; }
+    /// <summary>実使用モデルのバッジを表示する（ClaudeCode / CodexCLI のみ）。既定 false。</summary>
+    public bool ShowModel { get; set; }
     public bool HideInputPanel { get; set; }
     /// <summary>
     /// 入力テキスト欄の下書きをセッションごとに保持するか。既定 true（＝セッション固定）。

--- a/TerminalHub/Models/SessionInfo.cs
+++ b/TerminalHub/Models/SessionInfo.cs
@@ -190,6 +190,13 @@ namespace TerminalHub.Models
         
         [System.Text.Json.Serialization.JsonIgnore]
         public bool IsWorktree { get; set; }
+
+        /// <summary>
+        /// トランスクリプトから読んだ実使用モデルの短縮名（例: "opus-5"）。取得できない種別では null。
+        /// Git 情報と同じく起動のたびに読み直すため保存しない。
+        /// </summary>
+        [System.Text.Json.Serialization.JsonIgnore]
+        public string? CurrentModel { get; set; }
         
         // ParentSessionIdは保存して復元時に親子関係を維持
         public Guid? ParentSessionId { get; set; } // Worktreeの場合の親セッション

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -120,6 +120,7 @@ builder.Services.AddScoped<INotificationService, NotificationService>();
 
 // GitServiceを登録
 builder.Services.AddSingleton<IGitService, GitService>();
+builder.Services.AddSingleton<ISessionModelService, SessionModelService>();
 
 // OutputAnalyzerFactoryを登録
 builder.Services.AddSingleton<IOutputAnalyzerFactory, OutputAnalyzerFactory>();

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -151,6 +151,9 @@
   <data name="Settings.Sessions.Display.ShowGitInfoSub" xml:space="preserve"><value>Branch name badge</value></data>
   <data name="Settings.Sessions.Display.GitChangesOnBadgeClick" xml:space="preserve"><value>Show Git changes on badge click</value></data>
   <data name="Settings.Sessions.Display.GitChangesOnBadgeClickSub" xml:space="preserve"><value>Shows changed files; toast when clean</value></data>
+  <data name="Settings.Sessions.Display.ShowModel" xml:space="preserve"><value>Show model</value></data>
+  <data name="Settings.Sessions.Display.ShowModelSub" xml:space="preserve"><value>Claude Code / Codex only</value></data>
+  <data name="Settings.Sessions.Display.ShowModelNote" xml:space="preserve"><value>The model is read from the transcript, so right after switching with /model the previous value is still shown. It updates once that session speaks again.</value></data>
   <data name="Settings.Sessions.Display.Help" xml:space="preserve"><value>Choose which additional info to display in the session list.</value></data>
   <data name="Settings.Sessions.InputPanel.Label" xml:space="preserve"><value>Input panel settings</value></data>
   <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>Hide input panel</value></data>
@@ -574,6 +577,7 @@
   <data name="CommitInfo.CopyHash" xml:space="preserve"><value>Copy hash</value></data>
   <data name="CommitInfo.Copied" xml:space="preserve"><value>Copied</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>Remote control connected</value></data>
+  <data name="SessionList.Badge.ModelTitle" xml:space="preserve"><value>Model used in the latest reply (stale right after switching)</value></data>
   <data name="SessionList.Badge.ChildrenCountFormat" xml:space="preserve"><value>{0} children</value></data>
   <data name="SessionList.Tooltip.Settings" xml:space="preserve"><value>Session settings</value></data>
   <data name="SessionList.Tooltip.Delete" xml:space="preserve"><value>Delete session</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -151,6 +151,9 @@
   <data name="Settings.Sessions.Display.ShowGitInfoSub" xml:space="preserve"><value>ブランチ名バッジ</value></data>
   <data name="Settings.Sessions.Display.GitChangesOnBadgeClick" xml:space="preserve"><value>Gitの変更状態をバッジクリックで表示</value></data>
   <data name="Settings.Sessions.Display.GitChangesOnBadgeClickSub" xml:space="preserve"><value>変更ファイル一覧を表示。変更なしはトースト通知</value></data>
+  <data name="Settings.Sessions.Display.ShowModel" xml:space="preserve"><value>モデルを表示</value></data>
+  <data name="Settings.Sessions.Display.ShowModelSub" xml:space="preserve"><value>Claude Code / Codex のみ</value></data>
+  <data name="Settings.Sessions.Display.ShowModelNote" xml:space="preserve"><value>実際に使われたモデルを記録から読むため、/model で切り替えた直後は前の値のまま表示されます。そのセッションが次に発話すると更新されます。</value></data>
   <data name="Settings.Sessions.Display.Help" xml:space="preserve"><value>セッション一覧に表示する追加情報を選択できます。</value></data>
   <data name="Settings.Sessions.InputPanel.Label" xml:space="preserve"><value>入力パネル設定</value></data>
   <data name="Settings.Sessions.InputPanel.Hide" xml:space="preserve"><value>入力パネルを非表示</value></data>
@@ -574,6 +577,7 @@
   <data name="CommitInfo.CopyHash" xml:space="preserve"><value>ハッシュをコピー</value></data>
   <data name="CommitInfo.Copied" xml:space="preserve"><value>コピーしました</value></data>
   <data name="SessionList.Badge.RemoteControl" xml:space="preserve"><value>リモートコントロール接続中</value></data>
+  <data name="SessionList.Badge.ModelTitle" xml:space="preserve"><value>直近の発話で使われたモデル（切替直後は前の値のまま）</value></data>
   <data name="SessionList.Badge.ChildrenCountFormat" xml:space="preserve"><value>{0} 件</value></data>
   <data name="SessionList.Tooltip.Settings" xml:space="preserve"><value>セッション設定</value></data>
   <data name="SessionList.Tooltip.Delete" xml:space="preserve"><value>セッション削除</value></data>

--- a/TerminalHub/Services/ISessionModelService.cs
+++ b/TerminalHub/Services/ISessionModelService.cs
@@ -17,5 +17,11 @@ namespace TerminalHub.Services
         /// 切り替え直後は前の値が返る。これは仕様であり取得失敗ではない。
         /// </remarks>
         Task<string?> GetCurrentModelAsync(SessionInfo session);
+
+        /// <summary>
+        /// 複数セッション分をまとめて取得する。1件ずつ引くと同じ走査を人数分繰り返すため、
+        /// 起動時など全件を埋めたい場面ではこちらを使う。
+        /// </summary>
+        Task<IReadOnlyDictionary<Guid, string?>> GetCurrentModelsAsync(IReadOnlyList<SessionInfo> sessions);
     }
 }

--- a/TerminalHub/Services/ISessionModelService.cs
+++ b/TerminalHub/Services/ISessionModelService.cs
@@ -16,7 +16,9 @@ namespace TerminalHub.Services
         /// モデル名は「切り替え後に次に発話したとき」に初めて記録へ残るため、
         /// 切り替え直後は前の値が返る。これは仕様であり取得失敗ではない。
         /// </remarks>
-        Task<string?> GetCurrentModelAsync(SessionInfo session);
+        /// <param name="forceRefresh">true でキャッシュを無視して読み直す。セッション再起動のように、
+        /// 発話を待たずに値が変わりうる場面で使う</param>
+        Task<string?> GetCurrentModelAsync(SessionInfo session, bool forceRefresh = false);
 
         /// <summary>
         /// 複数セッション分をまとめて取得する。1件ずつ引くと同じ走査を人数分繰り返すため、
@@ -24,10 +26,5 @@ namespace TerminalHub.Services
         /// </summary>
         Task<IReadOnlyDictionary<Guid, string?>> GetCurrentModelsAsync(IReadOnlyList<SessionInfo> sessions);
 
-        /// <summary>
-        /// キャッシュを捨てて次回に読み直させる。セッション再起動のように、
-        /// 発話を待たずに値が変わりうる場面で使う。
-        /// </summary>
-        void Invalidate(Guid sessionId);
     }
 }

--- a/TerminalHub/Services/ISessionModelService.cs
+++ b/TerminalHub/Services/ISessionModelService.cs
@@ -1,0 +1,21 @@
+using TerminalHub.Models;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// セッションが「実際に今どのモデルで動いているか」を CLI のトランスクリプトから取得する。
+    /// 起動オプションではなく実測値を見るのは、/model による途中切り替えが頻繁に行われるため。
+    /// </summary>
+    public interface ISessionModelService
+    {
+        /// <summary>
+        /// 実使用モデルの短縮名（例: "opus-5", "gpt-5.6-sol"）を取得する。
+        /// 取得できない種別・記録が見つからない場合は null。
+        /// </summary>
+        /// <remarks>
+        /// モデル名は「切り替え後に次に発話したとき」に初めて記録へ残るため、
+        /// 切り替え直後は前の値が返る。これは仕様であり取得失敗ではない。
+        /// </remarks>
+        Task<string?> GetCurrentModelAsync(SessionInfo session);
+    }
+}

--- a/TerminalHub/Services/ISessionModelService.cs
+++ b/TerminalHub/Services/ISessionModelService.cs
@@ -23,5 +23,11 @@ namespace TerminalHub.Services
         /// 起動時など全件を埋めたい場面ではこちらを使う。
         /// </summary>
         Task<IReadOnlyDictionary<Guid, string?>> GetCurrentModelsAsync(IReadOnlyList<SessionInfo> sessions);
+
+        /// <summary>
+        /// キャッシュを捨てて次回に読み直させる。セッション再起動のように、
+        /// 発話を待たずに値が変わりうる場面で使う。
+        /// </summary>
+        void Invalidate(Guid sessionId);
     }
 }

--- a/TerminalHub/Services/SessionModelService.cs
+++ b/TerminalHub/Services/SessionModelService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text;
 using System.Text.RegularExpressions;
 using TerminalHub.Models;
@@ -15,8 +16,9 @@ namespace TerminalHub.Services
         private readonly ILogger<SessionModelService> _logger;
 
         // 直近の取得結果。短時間に何度も呼ばれても実ファイルを読み直さないための緩衝。
-        private readonly Dictionary<Guid, (string? Model, DateTime ReadAt)> _cache = new();
-        private readonly SemaphoreSlim _lock = new(1, 1);
+        // ロックは張らない（取得は読み取り専用で、同時に走っても結果は同じ。
+        // 走査中に他セッションの取得を待たせる方が害が大きい）。
+        private readonly ConcurrentDictionary<Guid, (string? Model, DateTime ReadAt)> _cache = new();
 
         private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(15);
         /// <summary>Claude のプロジェクト一覧（直接検索が外れたときの保険）を作り直す間隔</summary>
@@ -36,15 +38,14 @@ namespace TerminalHub.Services
             _logger = logger;
         }
 
-        public async Task<string?> GetCurrentModelAsync(SessionInfo session)
+        public async Task<string?> GetCurrentModelAsync(SessionInfo session, bool forceRefresh = false)
         {
             if (!IsSupported(session)) return null;
 
-            await _lock.WaitAsync();
+            if (!forceRefresh && TryGetCached(session.SessionId, out var cached)) return cached;
+
             try
             {
-                if (TryGetCached(session.SessionId, out var cached)) return cached;
-
                 var model = await Task.Run(() => session.TerminalType == TerminalType.ClaudeCode
                     ? ReadClaudeModel(session.FolderPath)
                     : ReadCodexModel(session.FolderPath));
@@ -57,10 +58,6 @@ namespace TerminalHub.Services
                 _logger.LogWarning(ex, "[SessionModelService] モデル取得に失敗: {Path}", session.FolderPath);
                 return null;
             }
-            finally
-            {
-                _lock.Release();
-            }
         }
 
         public async Task<IReadOnlyDictionary<Guid, string?>> GetCurrentModelsAsync(IReadOnlyList<SessionInfo> sessions)
@@ -69,17 +66,16 @@ namespace TerminalHub.Services
             var result = new Dictionary<Guid, string?>();
             if (targets.Count == 0) return result;
 
-            await _lock.WaitAsync();
+            var pending = new List<SessionInfo>();
+            foreach (var s in targets)
+            {
+                if (TryGetCached(s.SessionId, out var cached)) result[s.SessionId] = cached;
+                else pending.Add(s);
+            }
+            if (pending.Count == 0) return result;
+
             try
             {
-                var pending = new List<SessionInfo>();
-                foreach (var s in targets)
-                {
-                    if (TryGetCached(s.SessionId, out var cached)) result[s.SessionId] = cached;
-                    else pending.Add(s);
-                }
-                if (pending.Count == 0) return result;
-
                 await Task.Run(() =>
                 {
                     // Claude は 1 セッション = 1 ディレクトリ直接参照で済むので個別に引く
@@ -109,18 +105,6 @@ namespace TerminalHub.Services
                 _logger.LogWarning(ex, "[SessionModelService] モデルの一括取得に失敗");
                 return result;
             }
-            finally
-            {
-                _lock.Release();
-            }
-        }
-
-        public void Invalidate(Guid sessionId)
-        {
-            // 取得中でも捨てて構わない値なので、ロック待ちはせず取れたときだけ消す
-            if (!_lock.Wait(0)) return;
-            try { _cache.Remove(sessionId); }
-            finally { _lock.Release(); }
         }
 
         private static bool IsSupported(SessionInfo session) =>
@@ -188,12 +172,16 @@ namespace TerminalHub.Services
             return GetClaudeProjectIndex(root).GetValueOrDefault(key);
         }
 
-        private Dictionary<string, string>? _claudeIndex;
-        private DateTime _claudeIndexAt;
+        // 複数スレッドから同時に読まれるので、作りかけを見せないよう完成品を丸ごと差し替える。
+        // 同時に作り直しが走っても結果は同じなので、作成自体は直列化しない。
+        private volatile ClaudeProjectIndex? _claudeIndex;
+
+        private sealed record ClaudeProjectIndex(Dictionary<string, string> Map, DateTime BuiltAt);
 
         private Dictionary<string, string> GetClaudeProjectIndex(string root)
         {
-            if (_claudeIndex != null && DateTime.UtcNow - _claudeIndexAt < IndexTtl) return _claudeIndex;
+            var current = _claudeIndex;
+            if (current != null && DateTime.UtcNow - current.BuiltAt < IndexTtl) return current.Map;
 
             var index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var dir in Directory.EnumerateDirectories(root))
@@ -201,8 +189,7 @@ namespace TerminalHub.Services
                 var k = ToProjectKey(Path.GetFileName(dir));
                 if (k != null) index[k] = dir;
             }
-            _claudeIndex = index;
-            _claudeIndexAt = DateTime.UtcNow;
+            _claudeIndex = new ClaudeProjectIndex(index, DateTime.UtcNow);
             return index;
         }
 

--- a/TerminalHub/Services/SessionModelService.cs
+++ b/TerminalHub/Services/SessionModelService.cs
@@ -19,8 +19,10 @@ namespace TerminalHub.Services
         private readonly SemaphoreSlim _lock = new(1, 1);
 
         private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(15);
-        /// <summary>この時間より古い記録は「別のセッションのもの」とみなして拾わない</summary>
-        private static readonly TimeSpan ActiveWithin = TimeSpan.FromHours(24);
+        /// <summary>Codex の rollout 一覧（cwd 付き）を作り直す間隔</summary>
+        private static readonly TimeSpan IndexTtl = TimeSpan.FromMinutes(2);
+        /// <summary>Codex の走査上限。全件でも数百程度だが、増え続ける前提で頭を抑える</summary>
+        private const int CodexScanLimit = 500;
         /// <summary>末尾から読むバイト数。巨大な jsonl 全体を読むと極端に遅くなる</summary>
         private const int TailBytes = 256 * 1024;
 
@@ -84,7 +86,12 @@ namespace TerminalHub.Services
                 .FirstOrDefault(d => string.Equals(ToProjectKey(Path.GetFileName(d)), key, StringComparison.Ordinal));
             if (dir == null) return null;
 
-            var jsonl = NewestRecentFile(Directory.EnumerateFiles(dir, "*.jsonl"));
+            // 更新日時での足切りはしない。長く放置したセッションでもモデルは変わらず有効なため
+            // （フォルダが一致した時点で対象は確定しているので、その中の最新ファイルを見れば足りる）
+            var jsonl = Directory.EnumerateFiles(dir, "*.jsonl")
+                .Select(p => new FileInfo(p))
+                .OrderByDescending(f => f.LastWriteTime)
+                .FirstOrDefault()?.FullName;
             if (jsonl == null) return null;
 
             // 末尾から遡り、最後に assistant が喋ったときのモデルを拾う
@@ -92,7 +99,7 @@ namespace TerminalHub.Services
             {
                 if (!line.Contains("\"type\":\"assistant\"", StringComparison.Ordinal)) continue;
                 var m = ModelRegex.Match(line);
-                if (m.Success) return Shorten(m.Groups[1].Value);
+                if (m.Success && IsRealModel(m.Groups[1].Value)) return Shorten(m.Groups[1].Value);
             }
             return null;
         }
@@ -113,52 +120,73 @@ namespace TerminalHub.Services
 
         private string? ReadCodexModel(string folderPath)
         {
-            var root = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "sessions");
-            if (!Directory.Exists(root)) return null;
-
-            var cutoff = DateTime.Now - ActiveWithin;
             var target = folderPath.Trim().TrimEnd('\\', '/', ' ');
 
-            var candidates = Directory.EnumerateFiles(root, "rollout-*.jsonl", SearchOption.AllDirectories)
-                .Select(f => new FileInfo(f))
-                .Where(f => f.LastWriteTime >= cutoff)
-                .OrderByDescending(f => f.LastWriteTime)
-                .Take(200);
-
-            foreach (var file in candidates)
+            // 一覧作りはセッション毎にやると同じ走査を人数分繰り返すので、まとめて作って使い回す
+            foreach (var (path, cwd) in GetCodexIndex())
             {
-                var head = ReadHead(file.FullName);
-                if (head == null) continue;
+                if (!string.Equals(cwd, target, StringComparison.OrdinalIgnoreCase)) continue;
 
-                // サブエージェントの記録にはモデル名ではない値（審査エージェント名等）が入るため除外する
-                if (head.Contains("\"thread_source\":\"subagent\"", StringComparison.Ordinal)) continue;
-
-                var cwd = CwdRegex.Match(head);
-                if (!cwd.Success) continue;
-                var recorded = cwd.Groups[1].Value.Replace("\\\\", "\\").Trim().TrimEnd('\\', '/', ' ');
-                if (!string.Equals(recorded, target, StringComparison.OrdinalIgnoreCase)) continue;
-
-                foreach (var line in ReadTailLines(file.FullName).Reverse())
+                foreach (var line in ReadTailLines(path).Reverse())
                 {
                     var m = ModelRegex.Match(line);
-                    if (m.Success) return Shorten(m.Groups[1].Value);
+                    if (m.Success && IsRealModel(m.Groups[1].Value)) return Shorten(m.Groups[1].Value);
                 }
                 return null;
             }
             return null;
         }
 
+        private List<(string Path, string Cwd)>? _codexIndex;
+        private DateTime _codexIndexAt;
+
+        /// <summary>rollout を新しい順に並べ、先頭行から cwd を取った一覧。サブエージェントは除く</summary>
+        private List<(string Path, string Cwd)> GetCodexIndex()
+        {
+            if (_codexIndex != null && DateTime.UtcNow - _codexIndexAt < IndexTtl) return _codexIndex;
+
+            var index = new List<(string, string)>();
+            var root = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "sessions");
+            if (!Directory.Exists(root))
+            {
+                _codexIndex = index;
+                _codexIndexAt = DateTime.UtcNow;
+                return index;
+            }
+
+            var files = Directory.EnumerateFiles(root, "rollout-*.jsonl", SearchOption.AllDirectories)
+                .Select(f => new FileInfo(f))
+                .OrderByDescending(f => f.LastWriteTime)
+                .Take(CodexScanLimit);
+
+            foreach (var file in files)
+            {
+                var head = ReadHead(file.FullName);
+                if (head == null) continue;
+
+                // サブエージェントの記録には、モデル名ではない値（審査エージェント名等）が入るため除外する
+                if (head.Contains("\"thread_source\":\"subagent\"", StringComparison.Ordinal)) continue;
+
+                var cwd = CwdRegex.Match(head);
+                if (!cwd.Success) continue;
+
+                index.Add((file.FullName, cwd.Groups[1].Value.Replace("\\\\", "\\").Trim().TrimEnd('\\', '/', ' ')));
+            }
+
+            _codexIndex = index;
+            _codexIndexAt = DateTime.UtcNow;
+            return index;
+        }
+
         // --- 共通 -------------------------------------------------------------
 
-        private static string? NewestRecentFile(IEnumerable<string> paths)
-        {
-            var cutoff = DateTime.Now - ActiveWithin;
-            return paths.Select(p => new FileInfo(p))
-                        .Where(f => f.LastWriteTime >= cutoff)
-                        .OrderByDescending(f => f.LastWriteTime)
-                        .FirstOrDefault()?.FullName;
-        }
+        /// <summary>
+        /// 実モデル名か。Claude Code は API エラー時の代替応答等に "&lt;synthetic&gt;" を記録するので、
+        /// これをバッジに出さないよう弾き、さらに遡って本物のモデルを探す
+        /// </summary>
+        private static bool IsRealModel(string model) =>
+            !string.IsNullOrEmpty(model) && !model.StartsWith('<');
 
         /// <summary>表示用の短縮（"claude-opus-5" -> "opus-5"）</summary>
         private static string Shorten(string model) =>

--- a/TerminalHub/Services/SessionModelService.cs
+++ b/TerminalHub/Services/SessionModelService.cs
@@ -19,7 +19,7 @@ namespace TerminalHub.Services
         private readonly SemaphoreSlim _lock = new(1, 1);
 
         private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(15);
-        /// <summary>Codex の rollout 一覧（cwd 付き）を作り直す間隔</summary>
+        /// <summary>Claude のプロジェクト一覧（直接検索が外れたときの保険）を作り直す間隔</summary>
         private static readonly TimeSpan IndexTtl = TimeSpan.FromMinutes(2);
         /// <summary>Codex の走査上限。全件でも数百程度だが、増え続ける前提で頭を抑える</summary>
         private const int CodexScanLimit = 500;
@@ -36,20 +36,12 @@ namespace TerminalHub.Services
 
         public async Task<string?> GetCurrentModelAsync(SessionInfo session)
         {
-            if (string.IsNullOrEmpty(session.FolderPath)) return null;
-
-            // トランスクリプトを持つのは Claude Code と Codex のみ。他種別は対象外
-            if (session.TerminalType != TerminalType.ClaudeCode && session.TerminalType != TerminalType.CodexCLI)
-                return null;
+            if (!IsSupported(session)) return null;
 
             await _lock.WaitAsync();
             try
             {
-                if (_cache.TryGetValue(session.SessionId, out var cached)
-                    && DateTime.UtcNow - cached.ReadAt < CacheTtl)
-                {
-                    return cached.Model;
-                }
+                if (TryGetCached(session.SessionId, out var cached)) return cached;
 
                 var model = await Task.Run(() => session.TerminalType == TerminalType.ClaudeCode
                     ? ReadClaudeModel(session.FolderPath)
@@ -69,21 +61,79 @@ namespace TerminalHub.Services
             }
         }
 
+        public async Task<IReadOnlyDictionary<Guid, string?>> GetCurrentModelsAsync(IReadOnlyList<SessionInfo> sessions)
+        {
+            var targets = sessions.Where(IsSupported).ToList();
+            var result = new Dictionary<Guid, string?>();
+            if (targets.Count == 0) return result;
+
+            await _lock.WaitAsync();
+            try
+            {
+                var pending = new List<SessionInfo>();
+                foreach (var s in targets)
+                {
+                    if (TryGetCached(s.SessionId, out var cached)) result[s.SessionId] = cached;
+                    else pending.Add(s);
+                }
+                if (pending.Count == 0) return result;
+
+                await Task.Run(() =>
+                {
+                    // Claude は 1 セッション = 1 ディレクトリ直接参照で済むので個別に引く
+                    foreach (var s in pending.Where(s => s.TerminalType == TerminalType.ClaudeCode))
+                    {
+                        result[s.SessionId] = ReadClaudeModel(s.FolderPath);
+                    }
+
+                    // Codex は cwd がファイルの中にしかなく、1 件ずつ引くと同じ走査を人数分繰り返すため、
+                    // 新しい順に1回だけ舐めて、全員分が揃った時点で打ち切る
+                    var codex = pending.Where(s => s.TerminalType == TerminalType.CodexCLI).ToList();
+                    if (codex.Count > 0)
+                    {
+                        foreach (var (id, model) in ResolveCodexBatch(codex)) result[id] = model;
+                    }
+                });
+
+                var now = DateTime.UtcNow;
+                foreach (var s in pending)
+                {
+                    _cache[s.SessionId] = (result.GetValueOrDefault(s.SessionId), now);
+                }
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[SessionModelService] モデルの一括取得に失敗");
+                return result;
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+        private static bool IsSupported(SessionInfo session) =>
+            !string.IsNullOrEmpty(session.FolderPath)
+            && (session.TerminalType == TerminalType.ClaudeCode || session.TerminalType == TerminalType.CodexCLI);
+
+        private bool TryGetCached(Guid sessionId, out string? model)
+        {
+            if (_cache.TryGetValue(sessionId, out var e) && DateTime.UtcNow - e.ReadAt < CacheTtl)
+            {
+                model = e.Model;
+                return true;
+            }
+            model = null;
+            return false;
+        }
+
         // --- Claude Code -----------------------------------------------------
         // ~/.claude/projects/<記号を - に潰した cwd>/<uuid>.jsonl
 
         private string? ReadClaudeModel(string folderPath)
         {
-            var root = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude", "projects");
-            if (!Directory.Exists(root)) return null;
-
-            var key = ToProjectKey(folderPath);
-            if (key == null) return null;
-
-            // ディレクトリ名は既にエンコード済みだが、大文字小文字が揃わないので同じ変換をかけて突き合わせる
-            var dir = Directory.EnumerateDirectories(root)
-                .FirstOrDefault(d => string.Equals(ToProjectKey(Path.GetFileName(d)), key, StringComparison.Ordinal));
+            var dir = FindClaudeProjectDir(folderPath);
             if (dir == null) return null;
 
             // 更新日時での足切りはしない。長く放置したセッションでもモデルは変わらず有効なため
@@ -104,6 +154,44 @@ namespace TerminalHub.Services
             return null;
         }
 
+        /// <summary>
+        /// フォルダ名は cwd から機械的に決まるので、まず組み立てて直接叩く（全列挙は不要）。
+        /// Windows のパス比較は大文字小文字を区別しないため、記録側と綴りが違っても直接ヒットする。
+        /// 外れたときだけ、保険として一覧から突き合わせる。
+        /// </summary>
+        private string? FindClaudeProjectDir(string folderPath)
+        {
+            var root = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude", "projects");
+            if (!Directory.Exists(root)) return null;
+
+            var key = ToProjectKey(folderPath);
+            if (key == null) return null;
+
+            var direct = Path.Combine(root, key);
+            if (Directory.Exists(direct)) return direct;
+
+            return GetClaudeProjectIndex(root).GetValueOrDefault(key);
+        }
+
+        private Dictionary<string, string>? _claudeIndex;
+        private DateTime _claudeIndexAt;
+
+        private Dictionary<string, string> GetClaudeProjectIndex(string root)
+        {
+            if (_claudeIndex != null && DateTime.UtcNow - _claudeIndexAt < IndexTtl) return _claudeIndex;
+
+            var index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var dir in Directory.EnumerateDirectories(root))
+            {
+                var k = ToProjectKey(Path.GetFileName(dir));
+                if (k != null) index[k] = dir;
+            }
+            _claudeIndex = index;
+            _claudeIndexAt = DateTime.UtcNow;
+            return index;
+        }
+
         /// <summary>パス -> projects のフォルダ名。末尾の空白や区切りは落としてから記号を潰す</summary>
         private static string? ToProjectKey(string? path)
         {
@@ -112,7 +200,7 @@ namespace TerminalHub.Services
             var sb = new StringBuilder(p.Length);
             foreach (var c in p)
                 sb.Append(char.IsAsciiLetterOrDigit(c) ? c : '-');
-            return sb.ToString().TrimEnd('-').ToLowerInvariant();
+            return sb.ToString().TrimEnd('-');
         }
 
         // --- Codex -----------------------------------------------------------
@@ -120,66 +208,94 @@ namespace TerminalHub.Services
 
         private string? ReadCodexModel(string folderPath)
         {
-            var target = folderPath.Trim().TrimEnd('\\', '/', ' ');
-
-            // 一覧作りはセッション毎にやると同じ走査を人数分繰り返すので、まとめて作って使い回す
-            foreach (var (path, cwd) in GetCodexIndex())
+            var target = NormalizePath(folderPath);
+            foreach (var file in EnumerateRolloutsNewestFirst())
             {
-                if (!string.Equals(cwd, target, StringComparison.OrdinalIgnoreCase)) continue;
-
-                foreach (var line in ReadTailLines(path).Reverse())
-                {
-                    var m = ModelRegex.Match(line);
-                    if (m.Success && IsRealModel(m.Groups[1].Value)) return Shorten(m.Groups[1].Value);
-                }
-                return null;
+                if (MatchCodexCwd(file, target) is not string path) continue;
+                return ReadCodexModelFromFile(path);
             }
             return null;
         }
 
-        private List<(string Path, string Cwd)>? _codexIndex;
-        private DateTime _codexIndexAt;
-
-        /// <summary>rollout を新しい順に並べ、先頭行から cwd を取った一覧。サブエージェントは除く</summary>
-        private List<(string Path, string Cwd)> GetCodexIndex()
+        /// <summary>
+        /// 複数セッション分をまとめて解決する。新しい順に1回舐め、全員分が埋まったら打ち切る。
+        /// </summary>
+        private Dictionary<Guid, string?> ResolveCodexBatch(List<SessionInfo> sessions)
         {
-            if (_codexIndex != null && DateTime.UtcNow - _codexIndexAt < IndexTtl) return _codexIndex;
+            var result = sessions.ToDictionary(s => s.SessionId, _ => (string?)null);
 
-            var index = new List<(string, string)>();
-            var root = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "sessions");
-            if (!Directory.Exists(root))
+            // 同じフォルダに複数セッションがぶら下がることがあるのでまとめて持つ
+            var wanted = new Dictionary<string, List<Guid>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var s in sessions)
             {
-                _codexIndex = index;
-                _codexIndexAt = DateTime.UtcNow;
-                return index;
+                var key = NormalizePath(s.FolderPath);
+                if (!wanted.TryGetValue(key, out var ids)) wanted[key] = ids = new List<Guid>();
+                ids.Add(s.SessionId);
             }
 
-            var files = Directory.EnumerateFiles(root, "rollout-*.jsonl", SearchOption.AllDirectories)
-                .Select(f => new FileInfo(f))
-                .OrderByDescending(f => f.LastWriteTime)
-                .Take(CodexScanLimit);
-
-            foreach (var file in files)
+            foreach (var file in EnumerateRolloutsNewestFirst())
             {
-                var head = ReadHead(file.FullName);
-                if (head == null) continue;
+                if (wanted.Count == 0) break; // 全員分そろったので、残りは見ない
 
-                // サブエージェントの記録には、モデル名ではない値（審査エージェント名等）が入るため除外する
+                var head = ReadHead(file);
+                if (head == null) continue;
                 if (head.Contains("\"thread_source\":\"subagent\"", StringComparison.Ordinal)) continue;
 
                 var cwd = CwdRegex.Match(head);
                 if (!cwd.Success) continue;
 
-                index.Add((file.FullName, cwd.Groups[1].Value.Replace("\\\\", "\\").Trim().TrimEnd('\\', '/', ' ')));
-            }
+                var recorded = NormalizePath(cwd.Groups[1].Value.Replace("\\\\", "\\"));
+                if (!wanted.TryGetValue(recorded, out var ids)) continue;
 
-            _codexIndex = index;
-            _codexIndexAt = DateTime.UtcNow;
-            return index;
+                var model = ReadCodexModelFromFile(file);
+                foreach (var id in ids) result[id] = model;
+                wanted.Remove(recorded);
+            }
+            return result;
+        }
+
+        /// <summary>先頭行の cwd が target と一致すればそのパスを返す。サブエージェントの記録は除外</summary>
+        private string? MatchCodexCwd(string file, string target)
+        {
+            var head = ReadHead(file);
+            if (head == null) return null;
+
+            // サブエージェントの記録には、モデル名ではない値（審査エージェント名等）が入るため除外する
+            if (head.Contains("\"thread_source\":\"subagent\"", StringComparison.Ordinal)) return null;
+
+            var cwd = CwdRegex.Match(head);
+            if (!cwd.Success) return null;
+
+            var recorded = NormalizePath(cwd.Groups[1].Value.Replace("\\\\", "\\"));
+            return string.Equals(recorded, target, StringComparison.OrdinalIgnoreCase) ? file : null;
+        }
+
+        private string? ReadCodexModelFromFile(string path)
+        {
+            foreach (var line in ReadTailLines(path).Reverse())
+            {
+                var m = ModelRegex.Match(line);
+                if (m.Success && IsRealModel(m.Groups[1].Value)) return Shorten(m.Groups[1].Value);
+            }
+            return null;
+        }
+
+        private static IEnumerable<string> EnumerateRolloutsNewestFirst()
+        {
+            var root = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "sessions");
+            if (!Directory.Exists(root)) return Array.Empty<string>();
+
+            return Directory.EnumerateFiles(root, "rollout-*.jsonl", SearchOption.AllDirectories)
+                .Select(f => new FileInfo(f))
+                .OrderByDescending(f => f.LastWriteTime)
+                .Take(CodexScanLimit)
+                .Select(f => f.FullName);
         }
 
         // --- 共通 -------------------------------------------------------------
+
+        private static string NormalizePath(string path) => path.Trim().TrimEnd('\\', '/', ' ');
 
         /// <summary>
         /// 実モデル名か。Claude Code は API エラー時の代替応答等に "&lt;synthetic&gt;" を記録するので、

--- a/TerminalHub/Services/SessionModelService.cs
+++ b/TerminalHub/Services/SessionModelService.cs
@@ -1,0 +1,206 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using TerminalHub.Models;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// CLI が残すトランスクリプト（.jsonl）から実使用モデルを読み取る。
+    ///
+    /// セッション本人（システムプロンプト）に聞いてはいけない: そこに出るモデル名は起動時の値で、
+    /// 途中の /model 切り替えが反映されない。assistant の発話に記録された model だけが実測値。
+    /// </summary>
+    public class SessionModelService : ISessionModelService
+    {
+        private readonly ILogger<SessionModelService> _logger;
+
+        // 直近の取得結果。短時間に何度も呼ばれても実ファイルを読み直さないための緩衝。
+        private readonly Dictionary<Guid, (string? Model, DateTime ReadAt)> _cache = new();
+        private readonly SemaphoreSlim _lock = new(1, 1);
+
+        private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(15);
+        /// <summary>この時間より古い記録は「別のセッションのもの」とみなして拾わない</summary>
+        private static readonly TimeSpan ActiveWithin = TimeSpan.FromHours(24);
+        /// <summary>末尾から読むバイト数。巨大な jsonl 全体を読むと極端に遅くなる</summary>
+        private const int TailBytes = 256 * 1024;
+
+        private static readonly Regex ModelRegex = new("\"model\":\"([^\"]+)\"", RegexOptions.Compiled);
+        private static readonly Regex CwdRegex = new("\"cwd\":\"([^\"]+)\"", RegexOptions.Compiled);
+
+        public SessionModelService(ILogger<SessionModelService> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task<string?> GetCurrentModelAsync(SessionInfo session)
+        {
+            if (string.IsNullOrEmpty(session.FolderPath)) return null;
+
+            // トランスクリプトを持つのは Claude Code と Codex のみ。他種別は対象外
+            if (session.TerminalType != TerminalType.ClaudeCode && session.TerminalType != TerminalType.CodexCLI)
+                return null;
+
+            await _lock.WaitAsync();
+            try
+            {
+                if (_cache.TryGetValue(session.SessionId, out var cached)
+                    && DateTime.UtcNow - cached.ReadAt < CacheTtl)
+                {
+                    return cached.Model;
+                }
+
+                var model = await Task.Run(() => session.TerminalType == TerminalType.ClaudeCode
+                    ? ReadClaudeModel(session.FolderPath)
+                    : ReadCodexModel(session.FolderPath));
+
+                _cache[session.SessionId] = (model, DateTime.UtcNow);
+                return model;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[SessionModelService] モデル取得に失敗: {Path}", session.FolderPath);
+                return null;
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+        // --- Claude Code -----------------------------------------------------
+        // ~/.claude/projects/<記号を - に潰した cwd>/<uuid>.jsonl
+
+        private string? ReadClaudeModel(string folderPath)
+        {
+            var root = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude", "projects");
+            if (!Directory.Exists(root)) return null;
+
+            var key = ToProjectKey(folderPath);
+            if (key == null) return null;
+
+            // ディレクトリ名は既にエンコード済みだが、大文字小文字が揃わないので同じ変換をかけて突き合わせる
+            var dir = Directory.EnumerateDirectories(root)
+                .FirstOrDefault(d => string.Equals(ToProjectKey(Path.GetFileName(d)), key, StringComparison.Ordinal));
+            if (dir == null) return null;
+
+            var jsonl = NewestRecentFile(Directory.EnumerateFiles(dir, "*.jsonl"));
+            if (jsonl == null) return null;
+
+            // 末尾から遡り、最後に assistant が喋ったときのモデルを拾う
+            foreach (var line in ReadTailLines(jsonl).Reverse())
+            {
+                if (!line.Contains("\"type\":\"assistant\"", StringComparison.Ordinal)) continue;
+                var m = ModelRegex.Match(line);
+                if (m.Success) return Shorten(m.Groups[1].Value);
+            }
+            return null;
+        }
+
+        /// <summary>パス -> projects のフォルダ名。末尾の空白や区切りは落としてから記号を潰す</summary>
+        private static string? ToProjectKey(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return null;
+            var p = path.Trim().TrimEnd('\\', '/', ' ');
+            var sb = new StringBuilder(p.Length);
+            foreach (var c in p)
+                sb.Append(char.IsAsciiLetterOrDigit(c) ? c : '-');
+            return sb.ToString().TrimEnd('-').ToLowerInvariant();
+        }
+
+        // --- Codex -----------------------------------------------------------
+        // ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl（先頭行の session_meta に cwd が生パスで入る）
+
+        private string? ReadCodexModel(string folderPath)
+        {
+            var root = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "sessions");
+            if (!Directory.Exists(root)) return null;
+
+            var cutoff = DateTime.Now - ActiveWithin;
+            var target = folderPath.Trim().TrimEnd('\\', '/', ' ');
+
+            var candidates = Directory.EnumerateFiles(root, "rollout-*.jsonl", SearchOption.AllDirectories)
+                .Select(f => new FileInfo(f))
+                .Where(f => f.LastWriteTime >= cutoff)
+                .OrderByDescending(f => f.LastWriteTime)
+                .Take(200);
+
+            foreach (var file in candidates)
+            {
+                var head = ReadHead(file.FullName);
+                if (head == null) continue;
+
+                // サブエージェントの記録にはモデル名ではない値（審査エージェント名等）が入るため除外する
+                if (head.Contains("\"thread_source\":\"subagent\"", StringComparison.Ordinal)) continue;
+
+                var cwd = CwdRegex.Match(head);
+                if (!cwd.Success) continue;
+                var recorded = cwd.Groups[1].Value.Replace("\\\\", "\\").Trim().TrimEnd('\\', '/', ' ');
+                if (!string.Equals(recorded, target, StringComparison.OrdinalIgnoreCase)) continue;
+
+                foreach (var line in ReadTailLines(file.FullName).Reverse())
+                {
+                    var m = ModelRegex.Match(line);
+                    if (m.Success) return Shorten(m.Groups[1].Value);
+                }
+                return null;
+            }
+            return null;
+        }
+
+        // --- 共通 -------------------------------------------------------------
+
+        private static string? NewestRecentFile(IEnumerable<string> paths)
+        {
+            var cutoff = DateTime.Now - ActiveWithin;
+            return paths.Select(p => new FileInfo(p))
+                        .Where(f => f.LastWriteTime >= cutoff)
+                        .OrderByDescending(f => f.LastWriteTime)
+                        .FirstOrDefault()?.FullName;
+        }
+
+        /// <summary>表示用の短縮（"claude-opus-5" -> "opus-5"）</summary>
+        private static string Shorten(string model) =>
+            model.StartsWith("claude-", StringComparison.Ordinal) ? model["claude-".Length..] : model;
+
+        /// <summary>
+        /// 末尾のみを読む。1行=1JSON なので、全体をパースせず行単位で拾えば足りる。
+        /// 書き込み中のファイルを掴むため ReadWrite 共有で開く。
+        /// </summary>
+        private static IReadOnlyList<string> ReadTailLines(string path)
+        {
+            try
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                var start = Math.Max(0, fs.Length - TailBytes);
+                fs.Seek(start, SeekOrigin.Begin);
+                var buf = new byte[fs.Length - start];
+                var read = fs.Read(buf, 0, buf.Length);
+                var lines = Encoding.UTF8.GetString(buf, 0, read).Split('\n');
+                // 途中から読んだ場合、先頭行は千切れているので捨てる
+                return start > 0 && lines.Length > 1 ? lines[1..] : lines;
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        /// <summary>先頭行（session_meta）だけを読む</summary>
+        private static string? ReadHead(string path, int bytes = 8192)
+        {
+            try
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                var buf = new byte[Math.Min(bytes, fs.Length)];
+                var read = fs.Read(buf, 0, buf.Length);
+                return Encoding.UTF8.GetString(buf, 0, read).Split('\n').FirstOrDefault();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/TerminalHub/Services/SessionModelService.cs
+++ b/TerminalHub/Services/SessionModelService.cs
@@ -25,6 +25,8 @@ namespace TerminalHub.Services
         private const int CodexScanLimit = 500;
         /// <summary>末尾から読むバイト数。巨大な jsonl 全体を読むと極端に遅くなる</summary>
         private const int TailBytes = 256 * 1024;
+        /// <summary>Claude で遡る記録ファイル数。再起動直後の空ファイルを飛ばすための保険</summary>
+        private const int ClaudeFileLookback = 5;
 
         private static readonly Regex ModelRegex = new("\"model\":\"([^\"]+)\"", RegexOptions.Compiled);
         private static readonly Regex CwdRegex = new("\"cwd\":\"([^\"]+)\"", RegexOptions.Compiled);
@@ -113,6 +115,14 @@ namespace TerminalHub.Services
             }
         }
 
+        public void Invalidate(Guid sessionId)
+        {
+            // 取得中でも捨てて構わない値なので、ロック待ちはせず取れたときだけ消す
+            if (!_lock.Wait(0)) return;
+            try { _cache.Remove(sessionId); }
+            finally { _lock.Release(); }
+        }
+
         private static bool IsSupported(SessionInfo session) =>
             !string.IsNullOrEmpty(session.FolderPath)
             && (session.TerminalType == TerminalType.ClaudeCode || session.TerminalType == TerminalType.CodexCLI);
@@ -136,20 +146,24 @@ namespace TerminalHub.Services
             var dir = FindClaudeProjectDir(folderPath);
             if (dir == null) return null;
 
-            // 更新日時での足切りはしない。長く放置したセッションでもモデルは変わらず有効なため
-            // （フォルダが一致した時点で対象は確定しているので、その中の最新ファイルを見れば足りる）
-            var jsonl = Directory.EnumerateFiles(dir, "*.jsonl")
+            // 更新日時での足切りはしない。長く放置したセッションでもモデルは変わらず有効なため。
+            // 再起動直後は新しい記録がまだ空で、最新ファイルだけ見るとバッジが消えてしまうので、
+            // 見つかるまで新しい順に数件遡る（/model の指定は既定として引き継がれるため直前の値が妥当）
+            var files = Directory.EnumerateFiles(dir, "*.jsonl")
                 .Select(p => new FileInfo(p))
                 .OrderByDescending(f => f.LastWriteTime)
-                .FirstOrDefault()?.FullName;
-            if (jsonl == null) return null;
+                .Take(ClaudeFileLookback)
+                .Select(f => f.FullName);
 
-            // 末尾から遡り、最後に assistant が喋ったときのモデルを拾う
-            foreach (var line in ReadTailLines(jsonl).Reverse())
+            foreach (var jsonl in files)
             {
-                if (!line.Contains("\"type\":\"assistant\"", StringComparison.Ordinal)) continue;
-                var m = ModelRegex.Match(line);
-                if (m.Success && IsRealModel(m.Groups[1].Value)) return Shorten(m.Groups[1].Value);
+                // 末尾から遡り、最後に assistant が喋ったときのモデルを拾う
+                foreach (var line in ReadTailLines(jsonl).Reverse())
+                {
+                    if (!line.Contains("\"type\":\"assistant\"", StringComparison.Ordinal)) continue;
+                    var m = ModelRegex.Match(line);
+                    if (m.Success && IsRealModel(m.Groups[1].Value)) return Shorten(m.Groups[1].Value);
+                }
             }
             return null;
         }

--- a/TerminalHub/Services/SessionModelService.cs
+++ b/TerminalHub/Services/SessionModelService.cs
@@ -318,9 +318,18 @@ namespace TerminalHub.Services
         private static bool IsRealModel(string model) =>
             !string.IsNullOrEmpty(model) && !model.StartsWith('<');
 
-        /// <summary>表示用の短縮（"claude-opus-5" -> "opus-5"）</summary>
-        private static string Shorten(string model) =>
-            model.StartsWith("claude-", StringComparison.Ordinal) ? model["claude-".Length..] : model;
+        /// <summary>
+        /// 表示用の短縮（"claude-opus-5" -> "opus-5"、
+        /// "claude-haiku-4-5-20251001" -> "haiku-4-5"）。
+        /// 日付入りのIDは一覧で幅を食うだけで、他のモデルと粒度も揃わないため落とす。
+        /// </summary>
+        private static string Shorten(string model)
+        {
+            var s = model.StartsWith("claude-", StringComparison.Ordinal) ? model["claude-".Length..] : model;
+            return DateSuffixRegex.Replace(s, string.Empty);
+        }
+
+        private static readonly Regex DateSuffixRegex = new(@"-\d{8}$", RegexOptions.Compiled);
 
         /// <summary>
         /// 末尾のみを読む。1行=1JSON なので、全体をパースせず行単位で拾えば足りる。


### PR DESCRIPTION
## 概要

セッション一覧に、そのセッションが**実際にどのモデルで動いているか**を示すバッジを追加する。既定 OFF で、設定の「セッション表示」から有効にできる。

`/model` での切り替えが日常的になり（Fable 5 の追加以降）、一覧からモデルが分からないのが不便になったのが動機。

## なぜ起動オプションではなくトランスクリプトから読むのか

起動時の指定は `/model` で容易に陳腐化する。実測でも、稼働中セッションのモデルは opus-5 / fable-5 / sonnet-5 / opus-4-8 に散らばっており、同名レーンでも別々だった。起動オプション由来では再現できない分布で、**嘘のバッジは無いより悪い**と判断した。

そのため値は CLI のトランスクリプト（assistant の発話に残る `model`）から読む。対象は記録を持つ `ClaudeCode` / `CodexCLI` のみで、他種別はバッジ自体が出ない。

## 反映タイミングの制約（仕様）

モデル名は「切り替え後に次に発話したとき」に初めて記録へ残る。したがって切替直後は前の値が出る。これは取得失敗ではないので、設定画面の注意書きとバッジのツールチップに明記した。

更新契機は次の4つ:

| 契機 | 目的 |
|---|---|
| 起動時（バックグラウンド） | Git 情報取得と同じ裏処理に相乗り |
| hook Stop / タイムアウト完了 | 発話直後＝記録が確定した瞬間 |
| セッション再起動 | 再起動は既定モデルへ戻ることがあり、発話を待つと古い値が残るため |
| 設定を ON にした瞬間 | バッジが空のままだと壊れて見えるため |

ポーリングは追加していない。

## 実装メモ

- **Claude**: フォルダ名は cwd から機械的に決まるので、組み立てて直接参照する（ディレクトリ列挙をしない）。Windows のパス比較は大文字小文字を区別しないため、記録側と綴りが違っても直接当たることを実測で確認（`Source\Repos` 表記でもヒット）。外れたときだけ一覧から引く保険を残し、その一覧も2分キャッシュ
- **Codex**: `cwd` がファイル内にしかないため走査は避けられないが、一括取得 `GetCurrentModelsAsync` で新しい順に1回だけ舐め、全員分そろった時点で打ち切る
- 巨大な jsonl を全部読むと極端に遅いため、末尾 256KB のみ直読み。取得結果は15秒キャッシュ
- サブエージェントの rollout（`thread_source=subagent`）は除外。モデル名ではない値（審査エージェント名など）が入るため
- `<synthetic>`（API エラー時の代替応答）はモデル名として拾わず、さらに遡って実モデルを探す
- 表示は短縮する（`claude-opus-5` → `opus-5`、`claude-haiku-4-5-20251001` → `haiku-4-5`）。日付入りIDは一覧で幅を食い、粒度も揃わないため
- 再起動直後は新しい記録が空でバッジが消えるので、見つかるまで新しい順に数ファイル遡る
- バッジ色は `text-bg-secondary`。`bg-dark` はダークテーマで背景に溶ける

## 確認

- Release ビルド成功（0 警告 / 0 エラー）
- 実機で、`/model` 切替 → 再起動 → バッジが `haiku-4-5` に変わることを確認
- ダークテーマでの視認性を確認
- 値が実データと一致することを確認（本セッションのトランスクリプトから `claude-opus-5`）

## 既知の制約

- Grok / Antigravity は未対応（記録の有無を未調査）
- 切替から次の発話までは前の値が出る（上記のとおり仕様）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
