### PR TITLE
fix: 起動直後のリロードで ObjectDisposedException が出るのを修正

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -3483,7 +3483,18 @@
         _selectCts?.Cancel();
         _selectCts?.Dispose();
         _selectCts = null;
-        _switchLock.Dispose();
+
+        // **_switchLock は破棄しない。** Cancel はキャンセルを通知するだけで待ちはしないので、
+        // ここに来た時点で SelectSession がロックを持ったまま await の途中にいることがある
+        // （起動直後のリロードで踏みやすい。OnAfterRenderAsync が SelectSession を await
+        // している最中に破棄が重なる）。破棄すると、その SelectSession が finally で
+        // Release() したときに ObjectDisposedException になる。
+        // SelectSession のキャンセル脱出点はどれも finally を通るため、キャンセルするほど
+        // むしろこの経路に入りやすい。
+        //
+        // SemaphoreSlim は AvailableWaitHandle を使わない限りアンマネージド資源を持たないので、
+        // 破棄しないことによる漏れは無い（SessionDeliveryService の宛先ごとのゲートも同じ理由で
+        // 破棄していない）。_terminalWriteLock も破棄しておらず、こちらに揃う形になる。
 
         // ConPtyConnectionServiceのイベントハンドラーを削除
         if (_dataReceivedHandler != null)


### PR DESCRIPTION
Fixes #208

## 問題

起動直後にページを閉じる／リロードすると `SemaphoreSlim` の `ObjectDisposedException` が出る。

```
System.ObjectDisposedException: Cannot access a disposed object.
  Object name: 'System.Threading.SemaphoreSlim'.
   場所 System.Threading.SemaphoreSlim.Release()
   場所 TerminalHub.Components.Pages.Root.<SelectSession>d__96.MoveNext()
   場所 TerminalHub.Components.Pages.Root.<OnAfterRenderAsync>d__62.MoveNext()
```

## 原因

`DisposeAsync` が `_switchLock` を破棄するが、進行中の `SelectSession` を待ち合わせていない。直前の `_selectCts.Cancel()` は**キャンセルを通知するだけで待ちはしない**ため、ロックを持ったまま await の途中にいる `SelectSession` が残りうる。それが `finally` で `Release()` した時点で破棄済みインスタンスを触ることになる。

`SelectSession` はロック取得後に `Task.Yield()` を含む複数の await を挟み、キャンセルの脱出点（`if (ct.IsCancellationRequested) return;`）が複数ある。**どこから抜けても `finally` は必ず通る**ので、キャンセルするほどむしろこの経路に入りやすい。

起動直後に踏みやすいのは、`OnAfterRenderAsync` から `SelectSession` を await している最中にリロードが重なるため（スタックの経路と一致）。

## 修正

`_switchLock.Dispose()` を削除する。

`SemaphoreSlim` は `AvailableWaitHandle` を使わない限りアンマネージド資源を持たない。リポジトリ全体を確認したが `AvailableWaitHandle` の使用箇所は無いので、破棄しないことによる漏れは無い。

破棄済みフラグを立てて `if (!_disposed) _switchLock.Release();` とする案もあるが、フラグ設定と `Release()` の間に競合が残るため、破棄しない方が確実。

## 既存の判断との整合

同じ理由・同じ結論を、このコードベースは既に採っている。`SessionDeliveryService` の宛先ごとのゲートも破棄しておらず、その根拠がコメントに書かれている。

> 破棄すると、進行中の配送が `gate.Release()` で `ObjectDisposedException` を投げうる …… `SemaphoreSlim` は `AvailableWaitHandle` を使わない限りアンマネージド資源を持たないので、破棄しないことによる漏れは無い

また `Root` のもう一方のロックである `_terminalWriteLock` は `DisposeAsync` で破棄しておらず、`_switchLock` だけ破棄している現状は非対称だった。今回の変更でそちらにも揃う。

## 動作確認

- `dotnet build` 成功（0 警告 / 0 エラー）
- 実機での再現確認は未実施（起動直後のリロードというタイミング依存のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 同種の先例（PR #133）との対比

同じ「Circuit 破棄 × 非同期継続のレースによる `ObjectDisposedException`」は PR #133 でも起きている（あちらは `ConPtyConnectionService` への購読で、経路が `OnAfterRenderAsync` 由来である点まで同じ）。ただし当時の対処は **例外を握りつぶす方式**（`SafeSubscribeToSession`）だった。

今回それを採らなかったのは、握りつぶしでは `Release()` が失敗しうること自体が前提として残り、失敗すればロックが解放されないまま終わるため。破棄をやめれば `Release()` は正常動作に戻るので、そもそも失敗しない。
