### PR TITLE
feat: ホストフィルタを追加し DNS リバインディングを塞ぐ

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -90,6 +90,13 @@
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
+                            <button class="nav-link @(activeTab == "security" ? "active" : "")"
+                                    type="button"
+                                    @onclick="@(() => activeTab = "security")">
+                                <i class="bi bi-shield-lock me-1"></i>@L["Settings.Tab.Security"]
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
                             <button class="nav-link @(activeTab == "special" ? "active" : "")"
                                     type="button"
                                     @onclick="@(() => activeTab = "special")">
@@ -899,6 +906,41 @@
                                 }
                             </div>
                         }
+                        else if (activeTab == "security")
+                        {
+                            <div class="tab-pane fade show active">
+                                <small class="text-muted d-block mb-3">
+                                    @L["Settings.Security.Help"]
+                                </small>
+
+                                <div class="mb-3 form-check form-switch">
+                                    <input class="form-check-input" type="checkbox" role="switch"
+                                           @bind="enableHostFilter" id="enableHostFilter">
+                                    <label class="form-check-label" for="enableHostFilter">
+                                        @L["Settings.Security.EnableHostFilter"]
+                                    </label>
+                                    <div class="form-text">@L["Settings.Security.EnableHostFilter.Help"]</div>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label class="form-label" for="additionalAllowedHosts">
+                                        @L["Settings.Security.AdditionalHosts"]
+                                    </label>
+                                    <textarea class="form-control font-monospace" id="additionalAllowedHosts"
+                                              rows="4" @bind="additionalAllowedHosts"
+                                              placeholder="mypc.tail1a2b.ts.net&#10;term.example.com"></textarea>
+                                    <div class="form-text">@L["Settings.Security.AdditionalHosts.Help"]</div>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label class="form-label">@L["Settings.Security.DetectedHosts"]</label>
+                                    <div class="border rounded p-2 bg-body-tertiary font-monospace small">
+                                        @string.Join(", ", TerminalHub.Helpers.HostFilter.GetSelfHosts().OrderBy(h => h))
+                                    </div>
+                                    <div class="form-text">@L["Settings.Security.DetectedHosts.Help"]</div>
+                                </div>
+                            </div>
+                        }
                         else if (activeTab == "special")
                         {
                             <div class="tab-pane fade show active">
@@ -1334,6 +1376,10 @@
     // 実際の値はコンポーネント初期化時 (OnInitialized) に設定する。
     // RequestLocalization middleware が culture を差し替えた後で確定させるため。
     private string currentCulture = "en";
+    // セキュリティ（ホストフィルタ）
+    private bool enableHostFilter = true;
+    private string additionalAllowedHosts = "";
+
     private bool remoteLaunchEnabled = false;
     private string remoteLaunchTopicGuid = "";
     private string remoteLaunchPassword = "";
@@ -1560,6 +1606,10 @@
                 [TerminalType.Antigravity] = cliOptions.Antigravity.Select(CloneCliOption).ToList(),
                 [TerminalType.Grok] = cliOptions.Grok.Select(CloneCliOption).ToList(),
             };
+
+            // セキュリティ設定（ホストフィルタ）
+            enableHostFilter = settings.Security.EnableHostFilter;
+            additionalAllowedHosts = string.Join("\n", settings.Security.AdditionalAllowedHosts);
 
             // リモート起動設定
             remoteLaunchEnabled = settings.RemoteLaunch.Enabled;
@@ -1814,6 +1864,18 @@
                     Grok = editingCliOptions.GetValueOrDefault(TerminalType.Grok, new())
                         .Where(o => !string.IsNullOrWhiteSpace(o.Arguments))
                         .Select(CloneCliOption).ToList(),
+                },
+                Security = new SecuritySettings
+                {
+                    EnableHostFilter = enableHostFilter,
+                    AdditionalAllowedHosts = (additionalAllowedHosts ?? "")
+                        .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        // 利用者はアドレスバーからコピーしてくるので、スキームやポートが
+                        // 付いたまま入力されうる。Host ヘッダと比較できる形へ寄せて保存する
+                        .Select(TerminalHub.Helpers.HostFilter.Normalize)
+                        .Where(h => !string.IsNullOrWhiteSpace(h))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList()
                 },
                 RemoteLaunch = new RemoteLaunchSettings
                 {

--- a/TerminalHub/Helpers/HostFilter.cs
+++ b/TerminalHub/Helpers/HostFilter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
@@ -97,8 +98,12 @@ namespace TerminalHub.Helpers
                 .GetRequiredService<ILoggerFactory>()
                 .CreateLogger(typeof(HostFilter).FullName!);
 
-            logger.LogInformation(
-                "[HostFilter] 自動検出した自ホスト名: {Hosts}",
+            // 既定では件数だけ出す。全ホスト名は NIC の IP とマシン名の一覧そのものなので、
+            // 不具合報告でログを共有したときに余計な情報まで渡ることになる。
+            // 必要なときだけ Debug で見られれば足りる。
+            logger.LogInformation("[HostFilter] 自動検出した自ホスト名: {Count} 件", _selfHosts.Count);
+            logger.LogDebug(
+                "[HostFilter] 自動検出した自ホスト名の一覧: {Hosts}",
                 string.Join(", ", _selfHosts.OrderBy(h => h)));
 
             return app.Use(async (context, next) =>
@@ -117,23 +122,65 @@ namespace TerminalHub.Helpers
                 // HostString.Host は "[::1]:5080" のような IPv6 表記も正しく分解してくれる。
                 var host = context.Request.Host.Host;
 
-                if (string.IsNullOrEmpty(host) || IsAllowed(host, settings.AdditionalAllowedHosts))
+                if (IsAllowed(host, settings.AdditionalAllowedHosts))
                 {
                     await next();
                     return;
                 }
 
-                logger.LogWarning(
-                    "[HostFilter] 許可されていないホスト名からのリクエストを拒否しました: {Host} (path={Path})",
-                    host, context.Request.Path);
+                // Host が空のまま素通りさせない。HTTP/1.1 では Kestrel が 400 にするが、
+                // HTTP/1.0 では Host が必須でないため空のままここへ到達しうる。
+                // セキュリティ境界を fail-open にしないため、空も拒否側に倒す
+                // （空 Host で繋ぐ正規の利用経路は無い）。
+                LogRejectionOnce(logger, host, context.Request.Path);
 
                 await WriteRejectionAsync(context, host);
             });
         }
 
+        /// <summary>
+        /// 拒否ログは同じホスト名につき一度だけ出す。
+        /// 拒否は「1リクエスト1行」になるため、rebind 先へ fetch をループで撃たれると
+        /// それだけでログが洪水になる（＝拒否した側が困る、本末転倒な状態になる）。
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, byte> _loggedRejections = new();
+
+        /// <summary>記録済みホスト名がこの数を超えたら丸ごと捨てる（リークさせないため）。</summary>
+        private const int MaxLoggedRejections = 64;
+
+        private static void LogRejectionOnce(ILogger logger, string host, PathString path)
+        {
+            var key = string.IsNullOrEmpty(host) ? "(なし)" : host;
+
+            if (_loggedRejections.Count > MaxLoggedRejections)
+            {
+                _loggedRejections.Clear();
+            }
+
+            if (!_loggedRejections.TryAdd(key, 0))
+            {
+                return;
+            }
+
+            logger.LogWarning(
+                "[HostFilter] 許可されていないホスト名からのリクエストを拒否しました: {Host} (path={Path})。" +
+                "同じホスト名の以降の拒否はログに出しません。",
+                key, path);
+        }
+
         private static bool IsAllowed(string host, List<string> additional)
         {
-            if (_selfHosts.Contains(host))
+            if (string.IsNullOrEmpty(host))
+            {
+                return false;
+            }
+
+            // リクエスト側も設定側も同じ正規化を通してから比べる。
+            // 片側だけ正規化すると、利用者が末尾ドットや Unicode 表記で登録したときに
+            // 「登録したのに通らない」になる（安全側には倒れるが原因が分からない）。
+            var canonical = Canonicalize(host);
+
+            if (_selfHosts.Contains(canonical) || _selfHosts.Contains(host))
                 return true;
 
             foreach (var extra in additional)
@@ -143,11 +190,42 @@ namespace TerminalHub.Helpers
 
                 // 設定欄にポート付きやスキーム付きで書かれても拾えるようにする
                 // (利用者はブラウザのアドレスバーからコピーしてくる)
-                if (string.Equals(Normalize(extra), host, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(Canonicalize(Normalize(extra)), canonical, StringComparison.OrdinalIgnoreCase))
                     return true;
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// 比較用の最終形へ寄せる。末尾ドット (evil.com.) を落とし、
+        /// Unicode 表記の国際化ドメインを Punycode へ揃える
+        /// （ブラウザが送る Host は Punycode なので、設定側だけ Unicode だと一致しない）。
+        /// </summary>
+        private static string Canonicalize(string host)
+        {
+            if (string.IsNullOrEmpty(host))
+                return host;
+
+            var h = host.TrimEnd('.');
+
+            // IP リテラル（IPv6 は角括弧付き）は IdnMapping に渡すと例外になるうえ、
+            // 変換の必要も無いのでそのまま返す。
+            if (h.Length == 0 || h[0] == '[' || h.All(c => char.IsAsciiDigit(c) || c == '.'))
+                return h;
+
+            if (!h.Any(c => c > 127))
+                return h;
+
+            try
+            {
+                return new System.Globalization.IdnMapping().GetAscii(h);
+            }
+            catch
+            {
+                // 変換できない入力は変換せずに返す。一致しなければ拒否される（安全側）。
+                return h;
+            }
         }
 
         /// <summary>設定欄の入力を Host ヘッダと比較できる形へ寄せる。</summary>
@@ -164,6 +242,11 @@ namespace TerminalHub.Helpers
             var slash = v.IndexOf('/');
             if (slash >= 0)
                 v = v[..slash];
+
+            // user@host 形式で貼られた場合は user 部分を落とす
+            var at = v.LastIndexOf('@');
+            if (at >= 0)
+                v = v[(at + 1)..];
 
             // IPv6 の角括弧内のコロンは残し、末尾のポートだけ落とす
             if (v.StartsWith('['))
@@ -195,20 +278,34 @@ namespace TerminalHub.Helpers
             // 許可リストの中身は出さない。ここに載せると、このマシンの LAN IP・ホスト名・
             // トンネルのドメインを攻撃者に教えることになる。
             // 出すのは拒否したホスト名だけで、これは相手が既に知っている情報。
-            var safeHost = WebUtility.HtmlEncode(host);
+            var safeHost = WebUtility.HtmlEncode(
+                string.IsNullOrEmpty(host) ? "(ホスト名なし / no host header)" : host);
+
+            // 復旧先の URL はポートを決め打ちしない（TerminalHub は起動時にポートを変えられる）。
+            // 実際に待ち受けているポートを使う。
+            var port = context.Connection.LocalPort;
+            var localUrl = WebUtility.HtmlEncode($"http://localhost:{port}");
+
+            // 日英併記にする。アプリ本体は ja/en 対応だが、この画面は Blazor の外で
+            // 出るためローカライズの仕組みに乗らない。Accept-Language で出し分けると
+            // 「読めない言語だけが出る」事故が起きうるので、両方載せる方を選ぶ。
+            // このアプリは更新頻度が低くリリースノートが読まれないため、この画面が
+            // 「設定が要る」と伝えられる事実上唯一の経路になる。
             var html = $$"""
                 <!DOCTYPE html>
                 <html lang="ja">
                 <head>
                   <meta charset="utf-8">
                   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                  <title>TerminalHub - 接続できません</title>
+                  <title>TerminalHub - 接続できません / Cannot connect</title>
                   <style>
                     body { font-family: "Noto Sans JP", -apple-system, BlinkMacSystemFont, sans-serif;
                            background: #0f172a; color: #f1f5f9; margin: 0;
                            display: flex; justify-content: center; padding: 2rem 1rem; }
                     main { max-width: 34rem; }
                     h1 { font-size: 1.25rem; margin: 0 0 1rem; }
+                    h2 { font-size: 1rem; margin: 2.5rem 0 1rem; color: #94a3b8;
+                         border-top: 1px solid #334155; padding-top: 1.5rem; }
                     p { line-height: 1.7; color: #cbd5e1; }
                     .host { display: block; margin: 1rem 0; padding: 0.75rem 1rem;
                             background: #1e293b; border-left: 3px solid #dc3545;
@@ -228,7 +325,7 @@ namespace TerminalHub.Helpers
                     <span class="host">{{safeHost}}</span>
                     <p>この名前を使い続けるには、次の手順で許可してください。</p>
                     <ol>
-                      <li><strong>TerminalHub が動いている PC 本体</strong>で <code>http://localhost:5080</code> を開く<br>
+                      <li><strong>TerminalHub が動いている PC 本体</strong>で <code>{{localUrl}}</code> を開く<br>
                           <span class="note">この端末からは設定できません（今まさに拒否されているため）</span></li>
                       <li>設定 → セキュリティ →「追加で許可するホスト名」に上記の名前を追加</li>
                       <li>保存して、この画面を再読み込み</li>
@@ -236,6 +333,19 @@ namespace TerminalHub.Helpers
                     <p class="note">心当たりが無いのにこの画面が出た場合、
                        他のサイトがあなたのブラウザから TerminalHub へアクセスしようとした可能性があります。
                        その場合は許可せず、そのまま閉じてください。</p>
+
+                    <h2>English</h2>
+                    <p>TerminalHub only accepts connections from allowed host names, to stop malicious
+                       websites from controlling it through your browser.</p>
+                    <p>Rejected host name: <code>{{safeHost}}</code></p>
+                    <ol>
+                      <li>On <strong>the PC running TerminalHub</strong>, open <code>{{localUrl}}</code>
+                          (this cannot be done from the device you are using now)</li>
+                      <li>Go to Settings &rarr; Security &rarr; "Additional allowed host names" and add the name above</li>
+                      <li>Save, then reload this page</li>
+                    </ol>
+                    <p class="note">If you did not expect this page, another website may have tried to reach
+                       TerminalHub through your browser. In that case, do not allow it &mdash; just close this page.</p>
                   </main>
                 </body>
                 </html>

--- a/TerminalHub/Helpers/HostFilter.cs
+++ b/TerminalHub/Helpers/HostFilter.cs
@@ -89,7 +89,11 @@ namespace TerminalHub.Helpers
             return hosts;
         }
 
-        /// <summary>現在有効な許可リスト（自動検出 + 設定の追加分）。診断・設定画面の表示用。</summary>
+        /// <summary>
+        /// 自動検出したこのマシン自身の名前だけを返す（設定の追加分は含まない）。
+        /// 実際の許可判定は、これに <see cref="TerminalHub.Models.SecuritySettings.AdditionalAllowedHosts"/> を
+        /// 加えたもので行う。診断・設定画面の表示用。
+        /// </summary>
         public static IReadOnlyCollection<string> GetSelfHosts() => _selfHosts;
 
         public static IApplicationBuilder UseHostFilter(this IApplicationBuilder app)

--- a/TerminalHub/Helpers/HostFilter.cs
+++ b/TerminalHub/Helpers/HostFilter.cs
@@ -1,0 +1,247 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
+using TerminalHub.Services;
+
+namespace TerminalHub.Helpers
+{
+    /// <summary>
+    /// Host ヘッダを検査し、許可されていないホスト名からのリクエストを拒否するミドルウェア。
+    ///
+    /// 目的は DNS リバインディング対策。攻撃者は自分のドメインの DNS を一時的に 127.0.0.1 へ
+    /// 向け替えることで、被害者のブラウザから TerminalHub へ「同一オリジンとして」到達できる。
+    /// この経路はユーザー自身のブラウザ → ループバックなので、Tailscale や Cloudflare など
+    /// 外側の認証はまったく通らない（＝外側へ委譲できない唯一の穴）。
+    /// 成立すると画面の読み取りに加え、無認証の /mcp 経由でセッションへ文字列を送り込める。
+    ///
+    /// 判別できる材料は Host ヘッダしかない。攻撃者のリクエストは自分のドメイン名を名乗るので、
+    /// 「このマシンが自分について知っている名前」だけを通せば塞げる。
+    ///
+    /// 標準の HostFilteringMiddleware を使わず自前で持つ理由:
+    /// - 拒否時に素の 400 を返すだけで、何が起きたのか利用者に伝わらない。
+    ///   このアプリは更新頻度が低く、リリースノートは読まれないまま更新されるため、
+    ///   拒否ページが「設定が要る」と伝えられる事実上唯一の経路になる
+    /// - 許可リストを appsettings.json ではなく app-settings.json (%LOCALAPPDATA%) から
+    ///   読みたい。インストール先の appsettings.json は更新のたびに上書きされてしまう
+    /// </summary>
+    public static class HostFilter
+    {
+        /// <summary>
+        /// 起動時に構築する、このマシン自身を指す名前の一覧。
+        /// 保存はしない（毎起動で作り直す）。DHCP で LAN の IP が変わったり、
+        /// Tailscale を入れ直したりしても、再起動すれば勝手に追従させるため。
+        /// </summary>
+        private static readonly HashSet<string> _selfHosts = BuildSelfHosts();
+
+        private static HashSet<string> BuildSelfHosts()
+        {
+            var hosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "localhost",
+                "127.0.0.1",
+                "::1",
+                "[::1]",
+            };
+
+            try
+            {
+                hosts.Add(Dns.GetHostName());
+            }
+            catch
+            {
+                // ホスト名が引けない環境でも、localhost 分だけで動作は続けられる
+            }
+
+            try
+            {
+                foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    if (nic.OperationalStatus != OperationalStatus.Up)
+                        continue;
+
+                    foreach (var addr in nic.GetIPProperties().UnicastAddresses)
+                    {
+                        var ip = addr.Address;
+                        if (ip.AddressFamily == AddressFamily.InterNetwork)
+                        {
+                            // LAN の 192.168.x / Tailscale の 100.x はここで拾える
+                            hosts.Add(ip.ToString());
+                        }
+                        else if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+                        {
+                            // Host ヘッダ上の IPv6 は角括弧付きで来る。スコープ ID は落とす
+                            var plain = ip.ScopeId != 0
+                                ? new IPAddress(ip.GetAddressBytes()).ToString()
+                                : ip.ToString();
+                            hosts.Add(plain);
+                            hosts.Add($"[{plain}]");
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // NIC の列挙に失敗しても localhost からは使える状態を保つ
+            }
+
+            return hosts;
+        }
+
+        /// <summary>現在有効な許可リスト（自動検出 + 設定の追加分）。診断・設定画面の表示用。</summary>
+        public static IReadOnlyCollection<string> GetSelfHosts() => _selfHosts;
+
+        public static IApplicationBuilder UseHostFilter(this IApplicationBuilder app)
+        {
+            var logger = app.ApplicationServices
+                .GetRequiredService<ILoggerFactory>()
+                .CreateLogger(typeof(HostFilter).FullName!);
+
+            logger.LogInformation(
+                "[HostFilter] 自動検出した自ホスト名: {Hosts}",
+                string.Join(", ", _selfHosts.OrderBy(h => h)));
+
+            return app.Use(async (context, next) =>
+            {
+                var settings = context.RequestServices
+                    .GetRequiredService<IAppSettingsService>()
+                    .GetSettings().Security;
+
+                if (!settings.EnableHostFilter)
+                {
+                    await next();
+                    return;
+                }
+
+                // Host ヘッダからポートを落として比較する。
+                // HostString.Host は "[::1]:5080" のような IPv6 表記も正しく分解してくれる。
+                var host = context.Request.Host.Host;
+
+                if (string.IsNullOrEmpty(host) || IsAllowed(host, settings.AdditionalAllowedHosts))
+                {
+                    await next();
+                    return;
+                }
+
+                logger.LogWarning(
+                    "[HostFilter] 許可されていないホスト名からのリクエストを拒否しました: {Host} (path={Path})",
+                    host, context.Request.Path);
+
+                await WriteRejectionAsync(context, host);
+            });
+        }
+
+        private static bool IsAllowed(string host, List<string> additional)
+        {
+            if (_selfHosts.Contains(host))
+                return true;
+
+            foreach (var extra in additional)
+            {
+                if (string.IsNullOrWhiteSpace(extra))
+                    continue;
+
+                // 設定欄にポート付きやスキーム付きで書かれても拾えるようにする
+                // (利用者はブラウザのアドレスバーからコピーしてくる)
+                if (string.Equals(Normalize(extra), host, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>設定欄の入力を Host ヘッダと比較できる形へ寄せる。</summary>
+        public static string Normalize(string value)
+        {
+            var v = value.Trim();
+            if (v.Length == 0)
+                return v;
+
+            var schemeIndex = v.IndexOf("//", StringComparison.Ordinal);
+            if (schemeIndex >= 0)
+                v = v[(schemeIndex + 2)..];
+
+            var slash = v.IndexOf('/');
+            if (slash >= 0)
+                v = v[..slash];
+
+            // IPv6 の角括弧内のコロンは残し、末尾のポートだけ落とす
+            if (v.StartsWith('['))
+            {
+                var close = v.IndexOf(']');
+                if (close >= 0)
+                    return v[..(close + 1)];
+            }
+
+            var colon = v.LastIndexOf(':');
+            if (colon > 0)
+                v = v[..colon];
+
+            return v;
+        }
+
+        private static async Task WriteRejectionAsync(HttpContext context, string host)
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+
+            // ブラウザのページ表示以外（SignalR / MCP / hook API）は素の 403 で十分。
+            // HTML を返しても読む人がいないうえ、ログを汚す。
+            var accept = context.Request.Headers.Accept.ToString();
+            if (!accept.Contains("text/html", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            context.Response.ContentType = "text/html; charset=utf-8";
+
+            // 許可リストの中身は出さない。ここに載せると、このマシンの LAN IP・ホスト名・
+            // トンネルのドメインを攻撃者に教えることになる。
+            // 出すのは拒否したホスト名だけで、これは相手が既に知っている情報。
+            var safeHost = WebUtility.HtmlEncode(host);
+            var html = $$"""
+                <!DOCTYPE html>
+                <html lang="ja">
+                <head>
+                  <meta charset="utf-8">
+                  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                  <title>TerminalHub - 接続できません</title>
+                  <style>
+                    body { font-family: "Noto Sans JP", -apple-system, BlinkMacSystemFont, sans-serif;
+                           background: #0f172a; color: #f1f5f9; margin: 0;
+                           display: flex; justify-content: center; padding: 2rem 1rem; }
+                    main { max-width: 34rem; }
+                    h1 { font-size: 1.25rem; margin: 0 0 1rem; }
+                    p { line-height: 1.7; color: #cbd5e1; }
+                    .host { display: block; margin: 1rem 0; padding: 0.75rem 1rem;
+                            background: #1e293b; border-left: 3px solid #dc3545;
+                            border-radius: 0.375rem; font-family: Consolas, monospace;
+                            word-break: break-all; color: #f1f5f9; }
+                    ol { line-height: 1.9; color: #cbd5e1; padding-left: 1.25rem; }
+                    code { background: #1e293b; padding: 0.1rem 0.35rem; border-radius: 0.25rem; }
+                    .note { font-size: 0.875rem; color: #94a3b8; margin-top: 1.5rem; }
+                  </style>
+                </head>
+                <body>
+                  <main>
+                    <h1>このホスト名では接続できません</h1>
+                    <p>TerminalHub は、あらかじめ許可されたホスト名からの接続だけを受け付けます。
+                       悪意のあるサイトが、あなたのブラウザ経由で TerminalHub を操作するのを防ぐためです。</p>
+                    <p>受け取ったホスト名:</p>
+                    <span class="host">{{safeHost}}</span>
+                    <p>この名前を使い続けるには、次の手順で許可してください。</p>
+                    <ol>
+                      <li><strong>TerminalHub が動いている PC 本体</strong>で <code>http://localhost:5080</code> を開く<br>
+                          <span class="note">この端末からは設定できません（今まさに拒否されているため）</span></li>
+                      <li>設定 → セキュリティ →「追加で許可するホスト名」に上記の名前を追加</li>
+                      <li>保存して、この画面を再読み込み</li>
+                    </ol>
+                    <p class="note">心当たりが無いのにこの画面が出た場合、
+                       他のサイトがあなたのブラウザから TerminalHub へアクセスしようとした可能性があります。
+                       その場合は許可せず、そのまま閉じてください。</p>
+                  </main>
+                </body>
+                </html>
+                """;
+
+            await context.Response.WriteAsync(html, Encoding.UTF8);
+        }
+    }
+}

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -16,6 +16,7 @@ public class AppSettings
     public RemoteLaunchSettings RemoteLaunch { get; set; } = new();
     public ExperimentalSettings Experimental { get; set; } = new();
     public SessionDefaultsSettings SessionDefaults { get; set; } = new();
+    public SecuritySettings Security { get; set; } = new();
 }
 
 /// <summary>
@@ -177,6 +178,28 @@ public class DevToolsSettings
 /// <summary>
 /// 一般設定
 /// </summary>
+/// <summary>
+/// セキュリティ設定。
+/// 現状はホストフィルタ（DNS リバインディング対策）のみ。
+/// </summary>
+public class SecuritySettings
+{
+    /// <summary>
+    /// ホストフィルタを有効にするか。既定 true。
+    /// 無効にすると、どんな Host ヘッダのリクエストも受け付ける（従来動作）。
+    /// </summary>
+    public bool EnableHostFilter { get; set; } = true;
+
+    /// <summary>
+    /// 自動検出に加えて許可するホスト名。
+    /// 自動検出は「このマシンが自分について知っていること」（localhost / 自ホスト名 /
+    /// 全 NIC の IP）しか拾えないため、外部 DNS にしか存在しない名前はここへ。
+    /// 例: Tailscale の MagicDNS 名 (mypc.tail1a2b.ts.net)、
+    ///     Cloudflare トンネルのドメイン (term.example.com)。
+    /// </summary>
+    public List<string> AdditionalAllowedHosts { get; set; } = new();
+}
+
 public class GeneralSettings
 {
     public string DefaultFolderPath { get; set; } = "";

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -176,9 +176,6 @@ public class DevToolsSettings
 }
 
 /// <summary>
-/// 一般設定
-/// </summary>
-/// <summary>
 /// セキュリティ設定。
 /// 現状はホストフィルタ（DNS リバインディング対策）のみ。
 /// </summary>
@@ -200,6 +197,9 @@ public class SecuritySettings
     public List<string> AdditionalAllowedHosts { get; set; } = new();
 }
 
+/// <summary>
+/// 一般設定
+/// </summary>
 public class GeneralSettings
 {
     public string DefaultFolderPath { get; set; } = "";

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -265,6 +265,10 @@ if (!app.Environment.IsDevelopment())
 // HTTPSリダイレクトは無効化（ローカル環境での使用を想定）
 // app.UseHttpsRedirection();
 
+// Host ヘッダの検査（DNS リバインディング対策）。判定に使う設定を読むだけなので軽いが、
+// 拒否すべきリクエストを他のミドルウェアに触らせないよう、できるだけ手前に置く。
+app.UseHostFilter();
+
 // SignalR が long polling に落ちていないかの見張り（詳細は SignalRTransportProbe のコメント参照）
 app.UseSignalRTransportProbe();
 

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -668,4 +668,12 @@
   <data name="Root.Confirm.ArchiveSessionFormat" xml:space="preserve"><value>Archive session "{0}"?</value></data>
   <data name="App.ErrorUi.Message" xml:space="preserve"><value>An error has occurred.</value></data>
   <data name="App.ErrorUi.Reload" xml:space="preserve"><value>Reload</value></data>
+  <data name="Settings.Tab.Security" xml:space="preserve"><value>Security</value></data>
+  <data name="Settings.Security.Help" xml:space="preserve"><value>Prevents malicious websites from controlling TerminalHub through your browser (DNS rebinding protection). Such attacks reach 127.0.0.1 directly from the browser, so outer layers like Tailscale or Cloudflare cannot stop them.</value></data>
+  <data name="Settings.Security.EnableHostFilter" xml:space="preserve"><value>Accept connections only from allowed host names</value></data>
+  <data name="Settings.Security.EnableHostFilter.Help" xml:space="preserve"><value>Turning this off accepts connections from any host name (previous behaviour). Intended as a temporary workaround if you cannot connect; not recommended for everyday use.</value></data>
+  <data name="Settings.Security.AdditionalHosts" xml:space="preserve"><value>Additional allowed host names</value></data>
+  <data name="Settings.Security.AdditionalHosts.Help" xml:space="preserve"><value>One per line. Only names that auto-detection cannot find, e.g. a Tailscale MagicDNS name or a Cloudflare tunnel domain. You can paste straight from the address bar; the scheme and port are stripped automatically.</value></data>
+  <data name="Settings.Security.DetectedHosts" xml:space="preserve"><value>Automatically allowed host names</value></data>
+  <data name="Settings.Security.DetectedHosts.Help" xml:space="preserve"><value>Names that point at this PC. They are re-detected on every start, so no configuration is needed when the LAN IP changes. Connecting with a name not listed here is rejected.</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -675,5 +675,5 @@
   <data name="Settings.Security.AdditionalHosts" xml:space="preserve"><value>Additional allowed host names</value></data>
   <data name="Settings.Security.AdditionalHosts.Help" xml:space="preserve"><value>One per line. Only names that auto-detection cannot find, e.g. a Tailscale MagicDNS name or a Cloudflare tunnel domain. You can paste straight from the address bar; the scheme and port are stripped automatically.</value></data>
   <data name="Settings.Security.DetectedHosts" xml:space="preserve"><value>Automatically allowed host names</value></data>
-  <data name="Settings.Security.DetectedHosts.Help" xml:space="preserve"><value>Names that point at this PC. They are re-detected on every start, so no configuration is needed when the LAN IP changes. Connecting with a name not listed here is rejected.</value></data>
+  <data name="Settings.Security.DetectedHosts.Help" xml:space="preserve"><value>Names that point at this PC. They are re-detected on every start, so no configuration is needed when the LAN IP changes. Connecting with a name listed neither here nor in &quot;Additional allowed host names&quot; above is rejected.</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -675,5 +675,5 @@
   <data name="Settings.Security.AdditionalHosts" xml:space="preserve"><value>追加で許可するホスト名</value></data>
   <data name="Settings.Security.AdditionalHosts.Help" xml:space="preserve"><value>1行に1つ。下の自動検出で拾えない名前だけ書きます。例: Tailscale の MagicDNS 名、Cloudflare トンネルのドメイン。アドレスバーからそのまま貼っても、スキームとポートは自動で取り除きます。</value></data>
   <data name="Settings.Security.DetectedHosts" xml:space="preserve"><value>自動的に許可されているホスト名</value></data>
-  <data name="Settings.Security.DetectedHosts.Help" xml:space="preserve"><value>この PC 自身を指す名前です。起動のたびに検出し直すので、LAN の IP が変わっても設定は不要です。ここに無い名前で接続すると拒否されます。</value></data>
+  <data name="Settings.Security.DetectedHosts.Help" xml:space="preserve"><value>この PC 自身を指す名前です。起動のたびに検出し直すので、LAN の IP が変わっても設定は不要です。ここと上の「追加で許可するホスト名」のどちらにも無い名前で接続すると拒否されます。</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -668,4 +668,12 @@
   <data name="Root.Confirm.ArchiveSessionFormat" xml:space="preserve"><value>セッション「{0}」をアーカイブしますか？</value></data>
   <data name="App.ErrorUi.Message" xml:space="preserve"><value>エラーが発生しました。</value></data>
   <data name="App.ErrorUi.Reload" xml:space="preserve"><value>再読み込み</value></data>
+  <data name="Settings.Tab.Security" xml:space="preserve"><value>セキュリティ</value></data>
+  <data name="Settings.Security.Help" xml:space="preserve"><value>悪意のあるサイトが、あなたのブラウザ経由で TerminalHub を操作するのを防ぐ設定です（DNS リバインディング対策）。この攻撃はブラウザから 127.0.0.1 へ直接届くため、Tailscale や Cloudflare など外側の認証では防げません。</value></data>
+  <data name="Settings.Security.EnableHostFilter" xml:space="preserve"><value>許可したホスト名からのみ接続を受け付ける</value></data>
+  <data name="Settings.Security.EnableHostFilter.Help" xml:space="preserve"><value>オフにすると、どんなホスト名からの接続も受け付けます（従来の動作）。接続できない問題が起きたときの一時的な回避用で、常用は勧めません。</value></data>
+  <data name="Settings.Security.AdditionalHosts" xml:space="preserve"><value>追加で許可するホスト名</value></data>
+  <data name="Settings.Security.AdditionalHosts.Help" xml:space="preserve"><value>1行に1つ。下の自動検出で拾えない名前だけ書きます。例: Tailscale の MagicDNS 名、Cloudflare トンネルのドメイン。アドレスバーからそのまま貼っても、スキームとポートは自動で取り除きます。</value></data>
+  <data name="Settings.Security.DetectedHosts" xml:space="preserve"><value>自動的に許可されているホスト名</value></data>
+  <data name="Settings.Security.DetectedHosts.Help" xml:space="preserve"><value>この PC 自身を指す名前です。起動のたびに検出し直すので、LAN の IP が変わっても設定は不要です。ここに無い名前で接続すると拒否されます。</value></data>
 </root>


### PR DESCRIPTION
## 背景

利用者から DNS リバインディングの指摘を受けて対応。

悪意あるサイトが自分のドメインの DNS を一時的に `127.0.0.1` へ向け替えると、被害者のブラウザから TerminalHub へ**同一オリジンとして**到達できる。ブラウザは名前でオリジンを判定していて IP を見ていないため成立する。

重要なのは、**この経路がブラウザ → ループバックである**こと。Tailscale や Cloudflare など外側の認証はこの経路の上に無いので、まったく効かない。外側へ委譲できない唯一の穴になっている。

成立すると画面の読み取りに加え、**無認証の `/mcp` 経由で任意のセッションへ文字列を送り込める**（`send_to_session` はキー無しの外部クライアントでも使えるため）。

緊急性は低い（TerminalHub を狙い撃ちする必要があり、利用者は20人程度）が、塞ぐ手当てが安いので入れる。

## 方針

判別できる材料は Host ヘッダしかない。攻撃者は自分のドメイン名を名乗るので、**「このマシンが自分について知っている名前」だけを通せば塞げる**。

- **許可リストは起動時に自動生成**（localhost / `127.0.0.1` / `::1` / 自ホスト名 / 全 NIC の IP）。
  LAN の `192.168.x` も Tailscale の `100.x` もここで拾えるので、**通常は設定不要**
- **保存しない**（毎起動で作り直す）。保存すると DHCP で IP が変わったとき追従できず「昨日まで繋がったのに」になる
- 外部 DNS にしか存在しない名前（Tailscale の MagicDNS 名、Cloudflare トンネルのドメイン）だけ設定へ

## 実装

### 標準の `HostFilteringMiddleware` を使わない理由

1. 拒否時に素の 400 を返すだけで、何が起きたのか利用者に伝わらない。**このアプリは更新頻度が低くリリースノートが読まれないまま更新されるため、拒否ページが「設定が要る」と伝えられる事実上唯一の経路**になる
2. 許可リストを `appsettings.json` ではなく `%LOCALAPPDATA%\TerminalHub\app-settings.json` から読みたい。インストール先の `appsettings.json` は更新のたびに上書きされる

### 拒否時の応答

| リクエスト | 応答 |
|---|---|
| ブラウザのページ表示（`Accept: text/html`） | 403 + 理由と復帰手順を書いた HTML |
| `/_blazor`・`/mcp`・`/api/hook` | 403 のみ（本文なし） |

リダイレクトはしない。飛ばし先が無いため（`localhost` はスマホから届かず、同じホスト名の別パスも拒否対象）。

**拒否ページに許可リストは載せない。** 載せるとこのマシンの LAN IP・ホスト名・トンネルのドメインを攻撃者に教えることになる。出すのは「拒否したホスト名」だけで、これは相手が既に知っている情報。

### 設定

設定ダイアログに「セキュリティ」タブを追加。

- ホストフィルタの有効/無効（既定 ON）
- 追加で許可するホスト名（1行1つ。アドレスバーからの貼り付けを想定し、スキームとポートは自動で除去）
- 自動的に許可されているホスト名の一覧表示（身に覚えのない名前が混じっていないか目視できるように）

## 検証（ローカル、ポート5099）

| 確認項目 | 結果 |
|---|---|
| `Host: evil.example.com`（攻撃者を模す） | 403 + 説明 HTML |
| 拒否ページに許可リストが漏れていないか | 漏洩なし |
| `/_blazor` `/mcp` `/api/hook` | 403・本文0バイト |
| `localhost` / `127.0.0.1` | 200 |
| LAN `192.168.0.117` | 200（自動検出） |
| Tailscale `100.119.181.76` | 200（自動検出） |
| ホスト名 | 200（自動検出） |

ビルド警告0。

## 影響

既存利用者のうち、**トンネルや MagicDNS 名など外部 DNS の名前で接続している人だけ**、初回に設定が必要になる。それ以外（localhost / LAN / Tailscale の IP）は設定不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
