### PR TITLE
fix: 設定を保存すると SessionDefaults が初期化される問題を修正

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -1787,8 +1787,19 @@
             }
 
             // ファイルに設定を保存
+            // このダイアログが編集しないセクションは、いま保存されている値から引き継ぐ。
+            // 下は AppSettings を丸ごと組み立て直す形なので、書き忘れたセクションは
+            // 保存のたびに既定へ戻る（SessionDefaults が実際にそうなっていた）。
+            var current = AppSettingsService.GetSettings();
+
             var settings = new AppSettings
             {
+                // 設定画面では触らないが、アプリが実行中に書き込む値
+                // （最後に確定したターミナル実寸・前回のターミナル種別・
+                //   Claude/Codex の権限モードなど）。引き継がないと、
+                //   設定を保存しただけで起動時サイズが 120x30 に戻ってしまう。
+                SessionDefaults = current.SessionDefaults,
+
                 Notifications = new NotificationSettings
                 {
                     EnableBrowserNotifications = browserNotificationEnabled,
@@ -1884,7 +1895,7 @@
                     PasswordHash = remoteLaunchPasswordCleared
                         ? null
                         : remoteLaunchPassword == Constants.MqttConstants.PasswordDummy || string.IsNullOrEmpty(remoteLaunchPassword)
-                            ? AppSettingsService.GetSettings().RemoteLaunch.PasswordHash
+                            ? current.RemoteLaunch.PasswordHash
                             : MqttService.ComputePasswordHash(remoteLaunchPassword)
                 }
             };


### PR DESCRIPTION
## 症状

設定画面で保存すると、アプリが実行中に書き込んでいる値が既定へ戻る。

失われていたもの:
- `LastTerminalCols` / `LastTerminalRows`（最後に確定したターミナル実寸）
- `LastTerminalType`（前回選んだターミナル種別）
- Claude / Codex の権限モード・サンドボックス・承認ポリシー等の記憶

とくに実寸は `4634d26` で「起動直後の描画崩れ」を直すために入れた値なので、**設定を保存するとその修正が無効化され、次回のセッション起動が既定の 120x30 に戻る**。`claude -c` のように起動直後へ大量の履歴を描くケースで折り返しがズレたまま焼き付く、という元の症状が再発しうる。

## 原因

`SettingsDialog.SaveSettings` は `new AppSettings { ... }` で全セクションを組み立て直す形になっているが、`SessionDefaults` がそこに含まれていなかった。結果、保存のたびに `new SessionDefaultsSettings()` で上書きされていた。

この形はセクションを足すたびに同じ取りこぼしが起きうる（PR #211 で `Security` を追加したときも、書き忘れていれば同じことになっていた）。

## 修正

保存前に現在の設定を取得し、**このダイアログが編集しないセクションはそこから引き継ぐ**。あわせて、同じ間違いを繰り返さないための注意書きをコメントに残した。

## 検証

実機（ポート5099）で確認。

1. `app-settings-dev.json` の `sessionDefaults.lastClaudePermissionMode` に `"bypass"` を投入
2. アプリを起動し、設定画面を開いて「閉じる」（= `SaveAndClose` で保存）
3. ファイルを再読み込み → `lastClaudePermissionMode: bypass` が**残存**

修正前はここが `null` に戻る。あわせて `Security` セクションも正しく往復することを確認済み。ビルド警告0。

（検証に使った dev 設定ファイルはバックアップから復元済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)