### PR TITLE
fix: 追加許可ホスト欄のプレースホルダに &#10; が表示される問題を修正

### DIFF
--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -928,7 +928,7 @@
                                     </label>
                                     <textarea class="form-control font-monospace" id="additionalAllowedHosts"
                                               rows="4" @bind="additionalAllowedHosts"
-                                              placeholder="mypc.tail1a2b.ts.net&#10;term.example.com"></textarea>
+                                              placeholder="@("mypc.tail1a2b.ts.net\nterm.example.com")"></textarea>
                                     <div class="form-text">@L["Settings.Security.AdditionalHosts.Help"]</div>
                                 </div>
 


### PR DESCRIPTION
## 概要

設定 > セキュリティの「追加で許可するホスト名」欄のプレースホルダに `&#10;` がそのまま表示されていた問題を修正します。

## 原因

`SettingsDialog.razor:931`

```razor
placeholder="mypc.tail1a2b.ts.net&#10;term.example.com"
```

Blazor は属性値を HTML エンコードして出力するため、`&#10;` が実体参照として解釈されずリテラル文字列のまま表示されていました。

## 修正

C# 式にして実際の改行文字を渡すようにしました。

```razor
placeholder="@("mypc.tail1a2b.ts.net\nterm.example.com")"
```

## 影響

プレースホルダの表示のみ。機能への影響はありません。

## 確認

- `dotnet build` 成功（0 エラー / 0 警告）

🤖 Generated with [Claude Code](https://claude.com/claude-code)