### PR TITLE
fix: リンクプラグインの既定採用・空マッチ無限ループ・detect-only を直す

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -1676,10 +1676,9 @@
                 git = new { originUrl, branch = session.GitBranch }
             });
 
-            // 採用しているものだけを順に渡す。登録順がそのまま優先度になる
-            var settings = session.LinkPlugins
-                .Where(p => p.Enabled)
-                .OrderBy(p => p.Order)
+            // 採用しているものだけを順に渡す。登録順がそのまま優先度になる。
+            // 未設定のセッションは既定セットへフォールバックする（LinkPluginDefaults 参照）
+            var settings = LinkPluginDefaults.Resolve(session.LinkPlugins)
                 .Select(p => new { id = p.Id, vars = p.Vars })
                 .ToList();
 

--- a/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionSettingsDialog.razor
@@ -433,10 +433,19 @@
             Vars = new Dictionary<string, string>(p.Vars)
         }).OrderBy(p => p.Order).ToList();
 
+        // 一度も保存していないセッションは既定セット（同梱プラグイン）を有効として見せる。
+        // ここで見えている状態がそのまま保存されるので、実際の適用（Root 側のフォールバック）と揃う。
+        var untouched = session.LinkPlugins.Count == 0;
+
         foreach (var meta in linkPluginCatalog)
         {
             if (saved.Any(s => s.Id == meta.Id)) continue;
-            saved.Add(new LinkPluginSetting { Id = meta.Id, Enabled = false, Order = saved.Count });
+            saved.Add(new LinkPluginSetting
+            {
+                Id = meta.Id,
+                Enabled = untouched && LinkPluginDefaults.IsDefaultEnabled(meta.Id),
+                Order = saved.Count
+            });
         }
 
         editingLinkPlugins = saved;

--- a/TerminalHub/Models/LinkPluginDefaults.cs
+++ b/TerminalHub/Models/LinkPluginDefaults.cs
@@ -1,0 +1,35 @@
+namespace TerminalHub.Models
+{
+    /// <summary>
+    /// リンクプラグインの既定採用。
+    ///
+    /// 設定が空（＝一度も設定画面を触っていない既存セッション・新規セッション）のとき、
+    /// 同梱プラグインのうちここに挙げたものを「有効」として扱う。
+    /// 従来 terminal.js に直書きだった PR 番号（#123）のリンク化はプラグインへ移したため、
+    /// 既定で入れておかないと何も設定していないユーザーから機能が消えてしまう。
+    ///
+    /// 一度でも保存すれば設定は空でなくなるので、そこから先はユーザーの指定が優先される
+    /// （全部オフにした状態も保存されて、この既定で復活したりはしない）。
+    /// </summary>
+    public static class LinkPluginDefaults
+    {
+        /// <summary>設定が空のときに有効として扱う同梱プラグインの id（この順で登録する）</summary>
+        public static readonly string[] EnabledIds = ["github-pr"];
+
+        public static bool IsDefaultEnabled(string id) => Array.IndexOf(EnabledIds, id) >= 0;
+
+        /// <summary>
+        /// セッションの保存済み設定から、実際に採用するものを順に返す。
+        /// 保存が無ければ既定セットへフォールバックする。
+        /// </summary>
+        public static IEnumerable<LinkPluginSetting> Resolve(List<LinkPluginSetting> saved)
+        {
+            if (saved.Count > 0)
+            {
+                return saved.Where(p => p.Enabled).OrderBy(p => p.Order);
+            }
+
+            return EnabledIds.Select((id, i) => new LinkPluginSetting { Id = id, Enabled = true, Order = i });
+        }
+    }
+}

--- a/TerminalHub/wwwroot/js/link-plugins.js
+++ b/TerminalHub/wwwroot/js/link-plugins.js
@@ -47,8 +47,10 @@ async function loadLinkPlugins() {
                 console.error(`[LinkPlugins] ${entry.file}: id がありません`);
                 continue;
             }
-            if (typeof plugin.url !== 'function') {
-                console.error(`[LinkPlugins] ${entry.file}: url(text, ctx) が関数ではありません`);
+            // detect() は hit に url を持たせて返すので、url() は要らない。
+            // pattern 方式のときだけ url() が要る（ドキュメントの detect-only と揃える）。
+            if (typeof plugin.detect !== 'function' && typeof plugin.url !== 'function') {
+                console.error(`[LinkPlugins] ${entry.file}: detect() か url(text, ctx) のどちらかが要ります`);
                 continue;
             }
             // g フラグが無いと exec() が lastIndex を見ずに毎回先頭へ戻り、
@@ -184,6 +186,11 @@ function* matchPlugin(plugin, lineText, ctx) {
         const start = match.index;
         const end = start + text.length;
 
+        // 空マッチ（/^/g など）だと lastIndex が進まず無限ループになる。
+        // 以降に continue する経路があるので、判定より前にここで必ず進めておく。
+        // プラグインは第三者が書く前提で、壊れた1つがターミナルごと巻き添えにしないようにする。
+        if (re.lastIndex === start) re.lastIndex++;
+
         if (typeof plugin.accept === 'function') {
             const before = lineText.slice(0, start);
             const after = lineText.slice(end);
@@ -196,8 +203,5 @@ function* matchPlugin(plugin, lineText, ctx) {
         if (!url) continue;
 
         yield { start, end, text, url };
-
-        // 空マッチで無限ループしないための保険
-        if (re.lastIndex === start) re.lastIndex++;
     }
 }

--- a/docs/link-plugin-authoring.md
+++ b/docs/link-plugin-authoring.md
@@ -37,7 +37,7 @@ export default {
 |---|---|---|
 | `id` | ○ | 識別子。設定画面に出る。他と重複しないもの |
 | `pattern` | △ | 検出する正規表現。**`g` フラグを必ず付ける**（無いものは読み込み時に弾かれる） |
-| `url` | ○ | `(text, ctx) => string \| null`。リンク先。`null` を返すとリンクにしない |
+| `url` | △ | `(text, ctx) => string \| null`。リンク先。`null` を返すとリンクにしない。`pattern` 方式では必須（`detect` 方式は hit 側に `url` を入れるため不要） |
 | `accept` | | `({ text, before, after, line, ctx }) => boolean`。誤検出を弾く |
 | `vars` | | `['baseUrl']` のような文字列配列。セッション設定に入力欄が出る |
 | `detect` | | `(line, ctx) => [{ start, end, text, url }]`。`pattern` で表現できないとき用 |


### PR DESCRIPTION
PR #214（リンク化プラグイン）の事後レビュー指摘3件の修正です。

## P1-1: 既存の `#123` リンクが失われる
`terminal.js` から PR 番号検出を外した一方で、`LinkPlugins` は新規・既存とも空のまま、設定画面の新規項目も `Enabled=false` だったため、同梱の `github-pr.js` が一度も有効にならず従来のリンク機能だけが消えていました。

`LinkPluginDefaults`（新規）に既定採用の判定を集約し、**設定が空のときだけ**同梱プラグインを有効として扱います。一度でも保存すれば設定は空でなくなるので、全部オフにした状態がこの既定で復活することはありません。設定画面の初期表示も同じ規則にしたので、見えている状態と実際の適用が食い違いません。

DB のスキーマ変更はありません（v14 の NULL → 空リスト → 既定へフォールバック、で既存 DB のまま動きます）。

## P1-2: 空マッチする正規表現で無限ループ
`matchPlugin` で `accept=false` / `url=null` で `continue` する経路が `lastIndex` を進めず、`/^/g` のようなプラグインでタブがハングしていました。判定より前に `if (re.lastIndex === start) re.lastIndex++;` を置き、すべての経路で必ず進むようにしています。

## P2: ドキュメントと実装の食い違い
detect-only を許すドキュメントに対し、ローダーが `url` 関数を必須にしていました。`detect()` は hit 側に `url` を持つので、**`detect` か `url` のどちらか**があれば読み込むよう緩めました（ドキュメントの表も追随）。

## 確認
- `dotnet build TerminalHub/TerminalHub.csproj` 成功
- 実機確認は未実施（ConPTY を伴うため）。`#123` が既定でリンクになること、既存 DB がそのまま上がることは実機での確認をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)