### PR TITLE
fix: MCP 配送の Enter 待ちを 0.2 秒から 0.4 秒へ延ばす

### DIFF
--- a/TerminalHub/Services/SessionDeliveryService.cs
+++ b/TerminalHub/Services/SessionDeliveryService.cs
@@ -68,9 +68,16 @@ public sealed class SessionDeliveryService : ISessionDeliveryService, IHostedSer
 
     /// <summary>
     /// 本文送信から Enter までの待ち。Codex 等の TUI CLI は本文取り込み前に \r が来ると
-    /// 送信確定されず入力欄で止まるため、UI の SendInput と同じく 0.2 秒挟む。
+    /// 送信確定されず入力欄で止まるため、間を挟む。
+    ///
+    /// UI の SendInput と同じ 0.2 秒だったが、その値でも取りこぼしが出る（本文は入力欄に
+    /// 入っているのに未提出のまま止まり、人間が手で Enter を押すまで進まない。Claude Code /
+    /// Codex どちらでも観測）。この経路は自動メッセージの配送で人間が待っていないので、
+    /// 待ちを倍にしても誰も気づかない。UI 側は人が待つので伸ばさず、ここだけ 0.4 秒にする。
+    /// 根治ではない（TUI 側の取りこぼしなので確率を下げるだけ）。頻発するなら
+    /// UserPromptSubmit hook を ACK にした Enter 再送ウォッチドッグへ進む。
     /// </summary>
-    private static readonly TimeSpan SubmitDelay = TimeSpan.FromMilliseconds(200);
+    private static readonly TimeSpan SubmitDelay = TimeSpan.FromMilliseconds(400);
 
     /// <summary>
     /// システムが札へ書き込むときの記名。接続キー検証からしか設定されない値なので


### PR DESCRIPTION
## 背景

MCP の `send_to_session` で送った本文が、相手の入力欄に入ったまま**未提出で止まる**ことがあります。人間が気づいて手で Enter を押すまで進みません。

2026-08-03 に調査済みで、サーバー側は健全であることを確認しています（書き込み即完了・ThreadPool 待機 0・ConPTY 読み全数・配送キュー無関与）。犯人は TUI 側の Enter 取りこぼしです。当時は Claude Code のみで観測していましたが、**2026-08-21 に Codex CLI でも観測**したため、TUI 全般の問題と分かりました。

## 変更

`SessionDeliveryService.SubmitDelay` を 200ms → 400ms。

**MCP 配送経路だけ**です。UI からの送信（`Root.razor` の `HandleTextInputSend`）は人が待っているので伸ばしません。配送経路は自動メッセージなので、待ちが倍になっても誰も気づきません。

## これは根治ではありません

TUI 側の取りこぼしなので、確率を下げるだけです。頻発するようなら、設計済みの **Enter 再送ウォッチドッグ**へ進みます。

- ACK は `UserPromptSubmit` hook（Claude Code / Codex とも hook 駆動なので使える）
- 書き込み後に「提出待ち」を記録 → hook で解除 → 一定時間で解除されなければ **Enter だけ1回再送**（本文は再送しない＝二重連結を避ける）
- 武装は送信時に idle のセッションだけ（処理中への送信は ACK が遅れるのが正常なので誤再送を防ぐ）

## 確認

- `dotnet build` 成功（0 エラー / 0 警告）
- 効果は確率的なので、しばらく無人ラリーを回して発生頻度を見るしかありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)