### PR TITLE
feat: セッション一覧にコンテキスト量バッジを追加

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -20,6 +20,7 @@
 @inject IOutputAnalyzerFactory AnalyzerFactory
 @inject IGitService GitService
 @inject ISessionModelService SessionModelService
+@inject ISessionContextService SessionContextService
 @inject ITerminalService TerminalService
 @inject IOutputAnalyzerService OutputAnalyzerService
 @inject IInputHistoryService InputHistoryService
@@ -100,6 +101,9 @@
                      ShowGitInfo=@showGitInfo
                      GitChangesOnBadgeClick=@gitChangesOnBadgeClick
                      ShowModel=@showModel
+                     ShowContextSize=@showContextSize
+                     ContextCacheAware=@contextCacheAware
+                     ContextMinSizeK=@contextMinSizeK
                      OnShowInfoToast="(string msg) => toast?.ShowInfo(msg)"
                      OnShowErrorToast="(string msg) => toast?.ShowError(msg)"
                      OnShowSuccessToast="(string msg) => toast?.ShowSuccess(msg)"
@@ -217,6 +221,11 @@
     private bool showGitInfo = false; // Git情報を表示
     private bool gitChangesOnBadgeClick = false; // Gitバッジクリックで変更ファイル一覧を表示
     private bool showModel = false; // 実使用モデルのバッジを表示
+    private bool showContextSize = false; // コンテキスト量のバッジを表示
+    private bool contextCacheAware = true; // キャッシュの残り時間を色で示す
+    private int contextMinSizeK = 50; // バッジを出す下限（K トークン。0 で下限なし）
+    // 残り時間の表示は時間の経過だけで変わるので、イベントではなく定期的に描き直す
+    private System.Threading.Timer? contextUsageTimer;
     private bool hideInputPanel = false; // 入力パネルを非表示
     private bool perSessionInputText = true; // 入力テキストの下書きをセッションごとに保持（既定ON）
     private bool isMobileSidebarOpen = false; // モバイルサイドバーの開閉状態
@@ -588,6 +597,9 @@
                 showGitInfo = appSettings.Sessions.ShowGitInfo;
                 gitChangesOnBadgeClick = appSettings.Sessions.GitChangesOnBadgeClick;
                 showModel = appSettings.Sessions.ShowModel;
+                showContextSize = appSettings.Sessions.ShowContextSize;
+                contextCacheAware = appSettings.Sessions.ContextCacheAware;
+                contextMinSizeK = appSettings.Sessions.ContextMinSizeK;
                 hideInputPanel = appSettings.Sessions.HideInputPanel;
                 perSessionInputText = appSettings.Sessions.PerSessionInputText;
                 // 表示系4項目はデバイス別 (LocalStorage 優先、無ければ app-settings をシード)。
@@ -792,6 +804,10 @@
                         {
                             await RefreshAllModelsAsync(notify: false);
                         }
+
+                        // コンテキスト量も同様。あわせて定期更新を張る
+                        await RefreshAllContextUsagesAsync(notify: false);
+                        UpdateContextUsageTimer();
 
                         // Git情報取得完了後にUIを更新
                         await InvokeAsync(StateHasChanged);
@@ -1071,22 +1087,32 @@
         StateHasChanged();
     }
 
-    private async Task HandleSessionDisplaySettingsChanged((bool showTerminalType, bool showGitInfo, bool gitChangesOnBadgeClick, bool showModel, bool hideInputPanel, bool perSessionInputText) settings)
+    private async Task HandleSessionDisplaySettingsChanged(SessionDisplaySettingsChange settings)
     {
-        showTerminalType = settings.showTerminalType;
-        showGitInfo = settings.showGitInfo;
-        gitChangesOnBadgeClick = settings.gitChangesOnBadgeClick;
-        hideInputPanel = settings.hideInputPanel;
-        perSessionInputText = settings.perSessionInputText;
+        showTerminalType = settings.ShowTerminalType;
+        showGitInfo = settings.ShowGitInfo;
+        gitChangesOnBadgeClick = settings.GitChangesOnBadgeClick;
+        hideInputPanel = settings.HideInputPanel;
+        perSessionInputText = settings.PerSessionInputText;
+        contextCacheAware = settings.ContextCacheAware;
+        contextMinSizeK = settings.ContextMinSizeK;
 
-        var modelTurnedOn = settings.showModel && !showModel;
-        showModel = settings.showModel;
+        var modelTurnedOn = settings.ShowModel && !showModel;
+        showModel = settings.ShowModel;
+
+        var contextTurnedOn = settings.ShowContextSize && !showContextSize;
+        showContextSize = settings.ShowContextSize;
+        UpdateContextUsageTimer();
         StateHasChanged();
 
         // ONにした直後にバッジが空のままだと壊れて見えるので、その場で読みに行く
         if (modelTurnedOn)
         {
             await RefreshAllModelsAsync();
+        }
+        if (contextTurnedOn)
+        {
+            await RefreshAllContextUsagesAsync();
         }
     }
 
@@ -1117,6 +1143,52 @@
         }
         // 起動時の裏処理からは呼び出し側がまとめて再描画するので、その場合は通知しない
         if (notify) StateHasChanged();
+    }
+
+    /// <summary>
+    /// 全セッションのコンテキスト量を読み直す（バッジ表示ONのときのみ意味を持つ）。
+    /// </summary>
+    private async Task RefreshAllContextUsagesAsync(bool notify = true)
+    {
+        if (!showContextSize) return;
+
+        var targets = sessions.ToList();
+        var usages = await SessionContextService.GetContextUsagesAsync(targets);
+        foreach (var session in targets)
+        {
+            session.ContextUsage = usages.GetValueOrDefault(session.SessionId);
+        }
+        if (notify) StateHasChanged();
+    }
+
+    /// <summary>
+    /// バッジ表示の ON/OFF に合わせて定期更新を張り直す。
+    /// OFF のときはタイマーごと止める（読むファイルも再描画も無駄になるため）。
+    /// </summary>
+    private void UpdateContextUsageTimer()
+    {
+        if (!showContextSize)
+        {
+            contextUsageTimer?.Dispose();
+            contextUsageTimer = null;
+            return;
+        }
+
+        if (contextUsageTimer != null) return;
+
+        // 60秒間隔。残り時間の表示は分単位なので、この粗さで足りる
+        contextUsageTimer = new System.Threading.Timer(async _ =>
+        {
+            try
+            {
+                await InvokeAsync(async () => await RefreshAllContextUsagesAsync());
+            }
+            catch (Exception ex)
+            {
+                // Circuit 切断後に発火することがある。ここで落とすとタイマーごと死ぬので握る
+                Logger.LogDebug(ex, "コンテキスト量の定期更新に失敗");
+            }
+        }, null, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(60));
     }
 
     private void HandleClaudeModeSwitchKeyChanged(string key)
@@ -3533,6 +3605,19 @@
             }
         }
 
+        // コンテキスト量も発話直後が読みどき（この時点で usage が記録済み）。
+        // 定期更新（60秒）を待たずに、増えた分をその場で反映する
+        if (showContextSize)
+        {
+            var usages = await SessionContextService.GetContextUsagesAsync(new[] { sessionInfo }, forceRefresh: true);
+            var usage = usages.GetValueOrDefault(sessionInfo.SessionId);
+            if (usage != null && usage != sessionInfo.ContextUsage)
+            {
+                sessionInfo.ContextUsage = usage;
+                StateHasChanged();
+            }
+        }
+
         if (sessionInfo.IsGitRepository)
         {
             // Gitステータスを更新
@@ -3678,6 +3763,10 @@
 
     public async ValueTask DisposeAsync()
     {
+        // コンテキスト量の定期更新を止める
+        contextUsageTimer?.Dispose();
+        contextUsageTimer = null;
+
         // 保留中のエミュレータ再同期をキャンセル
         _emulatorResyncCts?.Cancel();
         _emulatorResyncCts?.Dispose();

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -226,6 +226,8 @@
     private int contextMinSizeK = 50; // バッジを出す下限（K トークン。0 で下限なし）
     // 残り時間の表示は時間の経過だけで変わるので、イベントではなく定期的に描き直す
     private System.Threading.Timer? contextUsageTimer;
+    // Circuit 破棄済みの印。破棄後に遅れて走る裏処理がタイマーを張り直すのを防ぐ
+    private bool _disposed;
     private bool hideInputPanel = false; // 入力パネルを非表示
     private bool perSessionInputText = true; // 入力テキストの下書きをセッションごとに保持（既定ON）
     private bool isMobileSidebarOpen = false; // モバイルサイドバーの開閉状態
@@ -599,7 +601,7 @@
                 showModel = appSettings.Sessions.ShowModel;
                 showContextSize = appSettings.Sessions.ShowContextSize;
                 contextCacheAware = appSettings.Sessions.ContextCacheAware;
-                contextMinSizeK = appSettings.Sessions.ContextMinSizeK;
+                contextMinSizeK = ClampContextMinSizeK(appSettings.Sessions.ContextMinSizeK);
                 hideInputPanel = appSettings.Sessions.HideInputPanel;
                 perSessionInputText = appSettings.Sessions.PerSessionInputText;
                 // 表示系4項目はデバイス別 (LocalStorage 優先、無ければ app-settings をシード)。
@@ -778,6 +780,11 @@
                     sessionsToPopulateGitInfo.Add(session.SessionId);
                 }
             }
+            // コンテキスト量の初期読みと定期更新は Git 情報の取得とは独立に始める。
+            // 同じ裏処理に相乗りさせると、Git 情報が既に揃っている再接続では
+            // ブロックごと実行されず、バッジが出ないままになる。
+            StartContextUsageTracking();
+
             if (sessionsToPopulateGitInfo.Count > 0)
             {
                 _ = Task.Run(async () =>
@@ -804,10 +811,6 @@
                         {
                             await RefreshAllModelsAsync(notify: false);
                         }
-
-                        // コンテキスト量も同様。あわせて定期更新を張る
-                        await RefreshAllContextUsagesAsync(notify: false);
-                        UpdateContextUsageTimer();
 
                         // Git情報取得完了後にUIを更新
                         await InvokeAsync(StateHasChanged);
@@ -1095,7 +1098,7 @@
         hideInputPanel = settings.HideInputPanel;
         perSessionInputText = settings.PerSessionInputText;
         contextCacheAware = settings.ContextCacheAware;
-        contextMinSizeK = settings.ContextMinSizeK;
+        contextMinSizeK = ClampContextMinSizeK(settings.ContextMinSizeK);
 
         var modelTurnedOn = settings.ShowModel && !showModel;
         showModel = settings.ShowModel;
@@ -1165,9 +1168,42 @@
     /// バッジ表示の ON/OFF に合わせて定期更新を張り直す。
     /// OFF のときはタイマーごと止める（読むファイルも再描画も無駄になるため）。
     /// </summary>
+    /// <summary>
+    /// バッジの表示下限を実用範囲に丸める。app-settings.json を直接編集された場合も
+    /// ここを通るので、設定ダイアログを経由しない値でも一覧が壊れない。
+    /// </summary>
+    private static int ClampContextMinSizeK(int value) => Math.Clamp(value, 0, 1000);
+
+    /// <summary>
+    /// 起動時の初期読みと定期更新の開始。Git 情報の取得とは独立に呼ぶ。
+    /// </summary>
+    private void StartContextUsageTracking()
+    {
+        if (!showContextSize) return;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await InvokeAsync(async () =>
+                {
+                    await RefreshAllContextUsagesAsync(notify: false);
+                    UpdateContextUsageTimer();
+                    StateHasChanged();
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "コンテキスト量の初期読みに失敗");
+            }
+        });
+    }
+
     private void UpdateContextUsageTimer()
     {
-        if (!showContextSize)
+        // 破棄後に遅れて届いた裏処理でタイマーを作り直さない
+        // （作ると破棄済み Circuit を掴んだまま生き続ける）
+        if (_disposed || !showContextSize)
         {
             contextUsageTimer?.Dispose();
             contextUsageTimer = null;
@@ -3763,7 +3799,9 @@
 
     public async ValueTask DisposeAsync()
     {
-        // コンテキスト量の定期更新を止める
+        // コンテキスト量の定期更新を止める（先に印を付けてから止める。
+        // 逆順だと、止めた直後に遅れてきた裏処理が張り直してしまう）
+        _disposed = true;
         contextUsageTimer?.Dispose();
         contextUsageTimer = null;
 

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -512,6 +512,39 @@
                                             <span class="text-muted small">（@L["Settings.Sessions.Display.ShowModelSub"]）</span>
                                         </label>
                                     </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" @bind="showContextSize" id="showContextSize">
+                                        <label class="form-check-label" for="showContextSize">
+                                            <i class="bi bi-thermometer-half me-1"></i>@L["Settings.Sessions.Display.ShowContextSize"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.Display.ShowContextSizeSub"]）</span>
+                                        </label>
+                                    </div>
+                                    @* コンテキスト量バッジのサブオプション（本体がOFFなら無効化） *@
+                                    <div class="form-check ms-4">
+                                        <input class="form-check-input" type="checkbox" @bind="contextCacheAware" id="contextCacheAware" disabled="@(!showContextSize)">
+                                        <label class="form-check-label" for="contextCacheAware">
+                                            @L["Settings.Sessions.Display.ContextCacheAware"]
+                                            <span class="text-muted small">（@L["Settings.Sessions.Display.ContextCacheAwareSub"]）</span>
+                                        </label>
+                                    </div>
+                                    <div class="d-flex align-items-center ms-4 mt-1">
+                                        <label class="form-label mb-0 me-2" for="contextMinSizeK">
+                                            @L["Settings.Sessions.Display.ContextMinSize"]
+                                        </label>
+                                        <div class="input-group input-group-sm" style="width: 8rem;">
+                                            <input type="number" class="form-control" id="contextMinSizeK" min="0" max="1000"
+                                                   @bind="contextMinSizeK" disabled="@(!showContextSize)">
+                                            <span class="input-group-text">K</span>
+                                        </div>
+                                        <span class="text-muted small ms-2">（@L["Settings.Sessions.Display.ContextMinSizeSub"]）</span>
+                                    </div>
+                                    @if (showContextSize)
+                                    {
+                                        <p class="text-muted small ms-4 mt-1 mb-0">
+                                            <i class="bi bi-exclamation-circle me-1"></i>
+                                            @L["Settings.Sessions.Display.ContextNote"]
+                                        </p>
+                                    }
                                     @* 反映の遅れは仕様なので、問い合わせになる前に理由を書いておく *@
                                     @if (showModel)
                                     {
@@ -1397,6 +1430,9 @@
     private bool showGitInfo = false;
     private bool gitChangesOnBadgeClick = false;
     private bool showModel = false;
+    private bool showContextSize = false;
+    private bool contextCacheAware = true;
+    private int contextMinSizeK = 50;
     private bool hideInputPanel = false;
     private bool perSessionInputText = true;
     private bool terminalLinkCopyMode = false;
@@ -1440,7 +1476,7 @@
     [Parameter] public EventCallback<string> OnSessionSortModeChanged { get; set; }
     [Parameter] public string SessionSortMode { get; set; } = "lastAccessed";
     [Parameter] public EventCallback<string> OnClaudeModeSwitchKeyChanged { get; set; }
-    [Parameter] public EventCallback<(bool showTerminalType, bool showGitInfo, bool gitChangesOnBadgeClick, bool showModel, bool hideInputPanel, bool perSessionInputText)> OnSessionDisplaySettingsChanged { get; set; }
+    [Parameter] public EventCallback<SessionDisplaySettingsChange> OnSessionDisplaySettingsChanged { get; set; }
     [Parameter] public EventCallback<double> OnSessionListScaleChanged { get; set; }
     [Parameter] public EventCallback<int> OnTerminalFontSizeChanged { get; set; }
     [Parameter] public EventCallback<int> OnTerminalHeightPercentChanged { get; set; }
@@ -1559,6 +1595,10 @@
             showGitInfo = settings.Sessions.ShowGitInfo;
             gitChangesOnBadgeClick = settings.Sessions.GitChangesOnBadgeClick;
             showModel = settings.Sessions.ShowModel;
+            showContextSize = settings.Sessions.ShowContextSize;
+            contextCacheAware = settings.Sessions.ContextCacheAware;
+            // 桁を打ち間違えても一覧が壊れないよう、受け取る値をここで丸める
+            contextMinSizeK = Math.Clamp(settings.Sessions.ContextMinSizeK, 0, 1000);
             hideInputPanel = settings.Sessions.HideInputPanel;
             perSessionInputText = settings.Sessions.PerSessionInputText;
 
@@ -1822,6 +1862,9 @@
                     ShowGitInfo = showGitInfo,
                     GitChangesOnBadgeClick = gitChangesOnBadgeClick,
                     ShowModel = showModel,
+                    ShowContextSize = showContextSize,
+                    ContextCacheAware = contextCacheAware,
+                    ContextMinSizeK = Math.Clamp(contextMinSizeK, 0, 1000),
                     HideInputPanel = hideInputPanel,
                     PerSessionInputText = perSessionInputText
                 },
@@ -1930,7 +1973,10 @@
             await OnSessionSortModeChanged.InvokeAsync(sessionSortMode);
 
             // セッション表示設定の変更を通知
-            await OnSessionDisplaySettingsChanged.InvokeAsync((showTerminalType, showGitInfo, gitChangesOnBadgeClick, showModel, hideInputPanel, perSessionInputText));
+            await OnSessionDisplaySettingsChanged.InvokeAsync(new SessionDisplaySettingsChange(
+                showTerminalType, showGitInfo, gitChangesOnBadgeClick, showModel,
+                showContextSize, contextCacheAware, contextMinSizeK,
+                hideInputPanel, perSessionInputText));
 
             // モード切替キーの変更を通知
             await OnClaudeModeSwitchKeyChanged.InvokeAsync(claudeModeSwitchKey);

--- a/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SettingsDialog.razor
@@ -1975,7 +1975,7 @@
             // セッション表示設定の変更を通知
             await OnSessionDisplaySettingsChanged.InvokeAsync(new SessionDisplaySettingsChange(
                 showTerminalType, showGitInfo, gitChangesOnBadgeClick, showModel,
-                showContextSize, contextCacheAware, contextMinSizeK,
+                showContextSize, contextCacheAware, Math.Clamp(contextMinSizeK, 0, 1000),
                 hideInputPanel, perSessionInputText));
 
             // モード切替キーの変更を通知

--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -127,6 +127,12 @@
                                     @session.CurrentModel
                                 </span>
                             }
+                            @* コンテキスト量。色はプロンプトキャッシュの温度で、切れかけ(黄/赤)のときだけ目を引く。
+                               灰色は「温度の情報が無い」= 考慮OFF か、すでに冷えている *@
+                            @if (ShowContextSize && GetContextBadge(session) is { } ctx)
+                            {
+                                <span class="badge @ctx.CssClass ms-1" title="@ctx.Title">@ctx.Text</span>
+                            }
                             @if (ShowGitInfo && session.IsGitRepository && !string.IsNullOrEmpty(session.GitBranch))
                             {
                                 @* クリック領域は赤丸＋Gitアイコンのみに限定（ブランチ名クリックでは履歴を開かない）。
@@ -256,6 +262,12 @@
     /// <summary>Git バッジのクリックで変更ファイル一覧を表示する（設定のサブオプション）</summary>
     [Parameter] public bool GitChangesOnBadgeClick { get; set; }
     [Parameter] public bool ShowModel { get; set; }
+    /// <summary>コンテキスト量バッジを表示する（設定）</summary>
+    [Parameter] public bool ShowContextSize { get; set; }
+    /// <summary>コンテキスト量バッジでキャッシュの残り時間を色で示す（サブオプション）</summary>
+    [Parameter] public bool ContextCacheAware { get; set; } = true;
+    /// <summary>コンテキスト量バッジを出す下限（K トークン）。0 以下で下限なし</summary>
+    [Parameter] public int ContextMinSizeK { get; set; } = 50;
     [Parameter] public EventCallback<string> OnShowInfoToast { get; set; }
     [Parameter] public EventCallback<string> OnShowErrorToast { get; set; }
     [Parameter] public EventCallback<string> OnShowSuccessToast { get; set; }
@@ -268,6 +280,66 @@
     private List<GitChangedFile>? gitChangesFiles;
     // 多重クリックによる並行取得を防ぐ
     private bool isGitChangesLoading;
+
+    /// <summary>プロンプトキャッシュの寿命。最後の API 要求から 1 時間（サブスクの既定）</summary>
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(60);
+    /// <summary>この残り時間を切ったら黄</summary>
+    private static readonly TimeSpan CacheWarnAt = TimeSpan.FromMinutes(15);
+    /// <summary>この残り時間を切ったら赤</summary>
+    private static readonly TimeSpan CacheDangerAt = TimeSpan.FromMinutes(10);
+
+    private record ContextBadge(string Text, string CssClass, string Title);
+
+    /// <summary>
+    /// コンテキスト量バッジの表示内容。下限未満・取得できない場合は null（＝出さない）。
+    ///
+    /// 色が付くのは「切れかけの15分間」だけで、通り過ぎれば灰色に落ちる。
+    /// つまり色 = 今なら間に合う、灰色 = もう手遅れ、と一意に読める。
+    /// </summary>
+    private ContextBadge? GetContextBadge(SessionInfo session)
+    {
+        var usage = session.ContextUsage;
+        if (usage == null) return null;
+
+        var sizeK = usage.Tokens / 1000;
+        if (ContextMinSizeK > 0 && sizeK < ContextMinSizeK) return null;
+
+        var text = $"{sizeK}K";
+        var sizeTitle = string.Format(L["SessionList.Badge.ContextTitleFormat"], usage.Tokens.ToString("N0"));
+
+        // 考慮OFF: 温度の情報を持たないので常に灰色（数字だけの計器）
+        if (!ContextCacheAware)
+        {
+            return new ContextBadge(text, "text-bg-secondary", sizeTitle);
+        }
+
+        // 処理中は API 応答待ちで記録が伸びず、実際より冷たく見える。温かい側に倒す
+        var isProcessing = session.ProcessingStartTime.HasValue;
+        var remaining = isProcessing
+            ? CacheTtl
+            : CacheTtl - (DateTime.UtcNow - usage.LastActivityUtc);
+
+        if (remaining <= TimeSpan.Zero)
+        {
+            return new ContextBadge(text, "text-bg-secondary",
+                $"{sizeTitle} / {L["SessionList.Badge.ContextCacheCold"]}");
+        }
+
+        var left = Math.Max(1, (int)Math.Ceiling(remaining.TotalMinutes));
+
+        if (remaining > CacheWarnAt)
+        {
+            var warm = string.Format(L["SessionList.Badge.ContextCacheWarmFormat"], left);
+            return new ContextBadge(text, "text-bg-primary", $"{sizeTitle} / {warm}");
+        }
+
+        var css = remaining <= CacheDangerAt ? "text-bg-danger" : "text-bg-warning";
+        var expiring = string.Format(L["SessionList.Badge.ContextCacheExpiringFormat"], left);
+        return new ContextBadge(
+            string.Format(L["SessionList.Badge.ContextRemainingFormat"], sizeK, left),
+            css,
+            $"{sizeTitle} / {expiring}");
+    }
 
     private string GetGitBadgeTitle(SessionInfo session)
     {

--- a/TerminalHub/Models/AppSettings.cs
+++ b/TerminalHub/Models/AppSettings.cs
@@ -153,6 +153,21 @@ public class SessionDisplaySettings
     public bool GitChangesOnBadgeClick { get; set; }
     /// <summary>実使用モデルのバッジを表示する（ClaudeCode / CodexCLI のみ）。既定 false。</summary>
     public bool ShowModel { get; set; }
+
+    /// <summary>コンテキスト量（トークン数）のバッジを表示する（ClaudeCode のみ）。既定 false。</summary>
+    public bool ShowContextSize { get; set; }
+
+    /// <summary>
+    /// コンテキスト量バッジでプロンプトキャッシュの残り時間を色で示す（ShowContextSize 有効時のみ意味を持つ）。
+    /// 既定 true。false にすると常に灰色＝数字だけの計器になる。
+    /// </summary>
+    public bool ContextCacheAware { get; set; } = true;
+
+    /// <summary>
+    /// コンテキスト量バッジを出す下限（1000 トークン単位）。既定 50（＝50K 未満は表示しない）。
+    /// 0 以下で下限なし（常に表示）。細いセッションは冷えても損しないので、既定では隠す。
+    /// </summary>
+    public int ContextMinSizeK { get; set; } = 50;
     public bool HideInputPanel { get; set; }
     /// <summary>
     /// 入力テキスト欄の下書きをセッションごとに保持するか。既定 true（＝セッション固定）。
@@ -162,6 +177,22 @@ public class SessionDisplaySettings
     /// </summary>
     public bool PerSessionInputText { get; set; } = true;
 }
+
+/// <summary>
+/// セッション表示設定のうち、設定ダイアログから Root へ通知する分だけを束ねたもの。
+/// 項目が増えるたびにタプルの要素が伸びて読めなくなるため record にした
+/// （名前で受け渡せるので、増えても呼び出し側の並び順に依存しない）。
+/// </summary>
+public record SessionDisplaySettingsChange(
+    bool ShowTerminalType,
+    bool ShowGitInfo,
+    bool GitChangesOnBadgeClick,
+    bool ShowModel,
+    bool ShowContextSize,
+    bool ContextCacheAware,
+    int ContextMinSizeK,
+    bool HideInputPanel,
+    bool PerSessionInputText);
 
 /// <summary>
 /// 開発ツール設定

--- a/TerminalHub/Models/ClaudeHookPayload.cs
+++ b/TerminalHub/Models/ClaudeHookPayload.cs
@@ -35,4 +35,12 @@ public class ClaudeHookPayload
     /// <summary>PreToolUse 等で実行対象のツール名が入る（matcher で AskUserQuestion に絞って登録）。</summary>
     [JsonPropertyName("tool_name")]
     public string? ToolName { get; set; }
+
+    /// <summary>
+    /// このセッションのトランスクリプト（.jsonl）の絶対パス。公式ドキュメント記載の共通フィールド。
+    /// コンテキスト量バッジが「どの記録を読むか」を厳密に決めるために使う
+    /// （フォルダからの推測だと、同じフォルダの複数セッションを取り違える）。
+    /// </summary>
+    [JsonPropertyName("transcript_path")]
+    public string? TranscriptPath { get; set; }
 }

--- a/TerminalHub/Models/HookNotification.cs
+++ b/TerminalHub/Models/HookNotification.cs
@@ -51,6 +51,9 @@ public class HookNotification
     /// <summary>ツール名（PreToolUse 等の tool_name。AskUserQuestion 判別用）</summary>
     public string? ToolName { get; set; }
 
+    /// <summary>トランスクリプト(.jsonl)の絶対パス（Claude Code のみ。コンテキスト量バッジ用）</summary>
+    public string? TranscriptPath { get; set; }
+
     /// <summary>タイムスタンプ</summary>
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
 

--- a/TerminalHub/Models/SessionInfo.cs
+++ b/TerminalHub/Models/SessionInfo.cs
@@ -202,6 +202,22 @@ namespace TerminalHub.Models
         /// </summary>
         [System.Text.Json.Serialization.JsonIgnore]
         public string? CurrentModel { get; set; }
+
+        /// <summary>
+        /// コンテキスト量バッジの表示値（トークン数と最終記録時刻）。取得できないときは null。
+        /// トランスクリプト由来なので保存しない（起動のたびに読み直す）。
+        /// </summary>
+        [System.Text.Json.Serialization.JsonIgnore]
+        public SessionContextUsage? ContextUsage { get; set; }
+
+        /// <summary>
+        /// Claude Code の hook が知らせてきたトランスクリプトのパス。
+        /// 同じフォルダに複数セッションがぶら下がる場合、フォルダからの推測では
+        /// どちらの記録か決められないため、hook が飛んだセッションはこれを正とする。
+        /// hook が最低1回飛ぶまでは null（その間はフォルダからの推測で代用する）。
+        /// </summary>
+        [System.Text.Json.Serialization.JsonIgnore]
+        public string? TranscriptPath { get; set; }
         
         // ParentSessionIdは保存して復元時に親子関係を維持
         public Guid? ParentSessionId { get; set; } // Worktreeの場合の親セッション

--- a/TerminalHub/Program.cs
+++ b/TerminalHub/Program.cs
@@ -124,7 +124,9 @@ builder.Services.AddScoped<INotificationService, NotificationService>();
 
 // GitServiceを登録
 builder.Services.AddSingleton<IGitService, GitService>();
+builder.Services.AddSingleton<IClaudeTranscriptLocator, ClaudeTranscriptLocator>();
 builder.Services.AddSingleton<ISessionModelService, SessionModelService>();
+builder.Services.AddSingleton<ISessionContextService, SessionContextService>();
 
 // OutputAnalyzerFactoryを登録
 builder.Services.AddSingleton<IOutputAnalyzerFactory, OutputAnalyzerFactory>();
@@ -388,6 +390,7 @@ app.MapPost("/api/hook/claude/{sessionId:guid}",
         AgentType = payload.AgentType,
         Message = payload.Message,
         ToolName = payload.ToolName,
+        TranscriptPath = payload.TranscriptPath,
         Timestamp = DateTime.UtcNow
     };
     await hookService.HandleHookNotificationAsync(notification);

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -715,8 +715,8 @@
   <data name="Settings.Sessions.Display.ContextCacheAwareSub" xml:space="preserve"><value>yellow at 15 min left, red at 10 min</value></data>
   <data name="Settings.Sessions.Display.ContextMinSize" xml:space="preserve"><value>Minimum size to show</value></data>
   <data name="Settings.Sessions.Display.ContextMinSizeSub" xml:space="preserve"><value>0 for no minimum (always show)</value></data>
-  <data name="Settings.Sessions.Display.ContextNote" xml:space="preserve"><value>The size is read from the transcript, so it does not change until that session speaks again. Remaining cache time is calculated from the last utterance.</value></data>
-  <data name="SessionList.Badge.ContextTitleFormat" xml:space="preserve"><value>Context: {0} tokens</value></data>
+  <data name="Settings.Sessions.Display.ContextNote" xml:space="preserve"><value>The size is read from the transcript, so it does not change until that session speaks again. It is the measured size of the last request sent, so it differs from the CLI's /context (an estimate for the next request). Remaining cache time is calculated from the last utterance.</value></data>
+  <data name="SessionList.Badge.ContextTitleFormat" xml:space="preserve"><value>Context: {0} tokens (as of the last request sent)</value></data>
   <data name="SessionList.Badge.ContextCacheWarmFormat" xml:space="preserve"><value>Cache is warm (about {0} min left)</value></data>
   <data name="SessionList.Badge.ContextCacheExpiringFormat" xml:space="preserve"><value>About {0} min until the cache expires. Once it does, the next read costs roughly 20x.</value></data>
   <data name="SessionList.Badge.ContextCacheCold" xml:space="preserve"><value>Cache expired. The next turn will re-read the whole context.</value></data>

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -709,4 +709,16 @@
   <data name="SubSession.Manage.Restore" xml:space="preserve"><value>Restore</value></data>
   <data name="SubSession.Manage.RestoreTitle" xml:space="preserve"><value>Restore to the list</value></data>
   <data name="SubSession.Manage.DragHandle" xml:space="preserve"><value>Drag to reorder</value></data>
+  <data name="Settings.Sessions.Display.ShowContextSize" xml:space="preserve"><value>Show context size</value></data>
+  <data name="Settings.Sessions.Display.ShowContextSizeSub" xml:space="preserve"><value>Claude Code only</value></data>
+  <data name="Settings.Sessions.Display.ContextCacheAware" xml:space="preserve"><value>Show remaining cache time as color</value></data>
+  <data name="Settings.Sessions.Display.ContextCacheAwareSub" xml:space="preserve"><value>yellow at 15 min left, red at 10 min</value></data>
+  <data name="Settings.Sessions.Display.ContextMinSize" xml:space="preserve"><value>Minimum size to show</value></data>
+  <data name="Settings.Sessions.Display.ContextMinSizeSub" xml:space="preserve"><value>0 for no minimum (always show)</value></data>
+  <data name="Settings.Sessions.Display.ContextNote" xml:space="preserve"><value>The size is read from the transcript, so it does not change until that session speaks again. Remaining cache time is calculated from the last utterance.</value></data>
+  <data name="SessionList.Badge.ContextTitleFormat" xml:space="preserve"><value>Context: {0} tokens</value></data>
+  <data name="SessionList.Badge.ContextCacheWarmFormat" xml:space="preserve"><value>Cache is warm (about {0} min left)</value></data>
+  <data name="SessionList.Badge.ContextCacheExpiringFormat" xml:space="preserve"><value>About {0} min until the cache expires. Once it does, the next read costs roughly 20x.</value></data>
+  <data name="SessionList.Badge.ContextCacheCold" xml:space="preserve"><value>Cache expired. The next turn will re-read the whole context.</value></data>
+  <data name="SessionList.Badge.ContextRemainingFormat" xml:space="preserve"><value>{0}K &#183; {1}m</value></data>
 </root>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -715,8 +715,8 @@
   <data name="Settings.Sessions.Display.ContextCacheAwareSub" xml:space="preserve"><value>残り15分で黄、10分で赤</value></data>
   <data name="Settings.Sessions.Display.ContextMinSize" xml:space="preserve"><value>表示する下限</value></data>
   <data name="Settings.Sessions.Display.ContextMinSizeSub" xml:space="preserve"><value>0 で下限なし（常に表示）</value></data>
-  <data name="Settings.Sessions.Display.ContextNote" xml:space="preserve"><value>記録から読むため、そのセッションが次に発話するまで数字は変わりません。キャッシュの残り時間は最後の発話からの経過で計算します。</value></data>
-  <data name="SessionList.Badge.ContextTitleFormat" xml:space="preserve"><value>コンテキスト {0} トークン</value></data>
+  <data name="Settings.Sessions.Display.ContextNote" xml:space="preserve"><value>記録から読むため、そのセッションが次に発話するまで数字は変わりません。最後に送信したリクエストの実測値なので、CLI の /context（次に送るとしたらの見積もり）とは差が出ます。キャッシュの残り時間は最後の発話からの経過で計算します。</value></data>
+  <data name="SessionList.Badge.ContextTitleFormat" xml:space="preserve"><value>コンテキスト {0} トークン（最後に送信した時点）</value></data>
   <data name="SessionList.Badge.ContextCacheWarmFormat" xml:space="preserve"><value>キャッシュ有効（残り約{0}分）</value></data>
   <data name="SessionList.Badge.ContextCacheExpiringFormat" xml:space="preserve"><value>キャッシュが切れるまで約{0}分。切れると次回の読み込みが約20倍のコストになります。</value></data>
   <data name="SessionList.Badge.ContextCacheCold" xml:space="preserve"><value>キャッシュ切れ。次回は再読み込みになります。</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -709,4 +709,16 @@
   <data name="SubSession.Manage.Restore" xml:space="preserve"><value>戻す</value></data>
   <data name="SubSession.Manage.RestoreTitle" xml:space="preserve"><value>一覧へ戻す</value></data>
   <data name="SubSession.Manage.DragHandle" xml:space="preserve"><value>ドラッグで並べ替え</value></data>
+  <data name="Settings.Sessions.Display.ShowContextSize" xml:space="preserve"><value>コンテキスト量を表示</value></data>
+  <data name="Settings.Sessions.Display.ShowContextSizeSub" xml:space="preserve"><value>Claude Code のみ</value></data>
+  <data name="Settings.Sessions.Display.ContextCacheAware" xml:space="preserve"><value>キャッシュの残り時間を色で示す</value></data>
+  <data name="Settings.Sessions.Display.ContextCacheAwareSub" xml:space="preserve"><value>残り15分で黄、10分で赤</value></data>
+  <data name="Settings.Sessions.Display.ContextMinSize" xml:space="preserve"><value>表示する下限</value></data>
+  <data name="Settings.Sessions.Display.ContextMinSizeSub" xml:space="preserve"><value>0 で下限なし（常に表示）</value></data>
+  <data name="Settings.Sessions.Display.ContextNote" xml:space="preserve"><value>記録から読むため、そのセッションが次に発話するまで数字は変わりません。キャッシュの残り時間は最後の発話からの経過で計算します。</value></data>
+  <data name="SessionList.Badge.ContextTitleFormat" xml:space="preserve"><value>コンテキスト {0} トークン</value></data>
+  <data name="SessionList.Badge.ContextCacheWarmFormat" xml:space="preserve"><value>キャッシュ有効（残り約{0}分）</value></data>
+  <data name="SessionList.Badge.ContextCacheExpiringFormat" xml:space="preserve"><value>キャッシュが切れるまで約{0}分。切れると次回の読み込みが約20倍のコストになります。</value></data>
+  <data name="SessionList.Badge.ContextCacheCold" xml:space="preserve"><value>キャッシュ切れ。次回は再読み込みになります。</value></data>
+  <data name="SessionList.Badge.ContextRemainingFormat" xml:space="preserve"><value>{0}K・{1}分</value></data>
 </root>

--- a/TerminalHub/Services/ClaudeTranscriptLocator.cs
+++ b/TerminalHub/Services/ClaudeTranscriptLocator.cs
@@ -1,0 +1,141 @@
+using System.Collections.Concurrent;
+using System.Text;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// 作業フォルダから Claude Code のトランスクリプト（~/.claude/projects/&lt;cwd を潰した名前&gt;/*.jsonl）を引く。
+    ///
+    /// SessionModelService と SessionContextService が同じ引き方をするため共通化した。
+    /// hook の transcript_path を受け取る案もあるが、それだと hook が最低1回飛ぶまで
+    /// 紐付けが得られない。フォルダ名から機械的に決まる以上、こちらの方が起動直後から使える。
+    /// </summary>
+    public interface IClaudeTranscriptLocator
+    {
+        /// <summary>新しい順にトランスクリプトのパスを返す（存在しなければ空）</summary>
+        IReadOnlyList<string> EnumerateNewestFirst(string folderPath, int take);
+    }
+
+    public class ClaudeTranscriptLocator : IClaudeTranscriptLocator
+    {
+        /// <summary>プロジェクト一覧（直接検索が外れたときの保険）を作り直す間隔</summary>
+        private static readonly TimeSpan IndexTtl = TimeSpan.FromMinutes(2);
+
+        // 複数スレッドから同時に読まれるので、作りかけを見せないよう完成品を丸ごと差し替える。
+        // 同時に作り直しが走っても結果は同じなので、作成自体は直列化しない。
+        private volatile ProjectIndex? _index;
+
+        private sealed record ProjectIndex(Dictionary<string, string> Map, DateTime BuiltAt);
+
+        public IReadOnlyList<string> EnumerateNewestFirst(string folderPath, int take)
+        {
+            var dir = FindProjectDir(folderPath);
+            if (dir == null) return Array.Empty<string>();
+
+            try
+            {
+                return Directory.EnumerateFiles(dir, "*.jsonl")
+                    .Select(p => new FileInfo(p))
+                    .OrderByDescending(f => f.LastWriteTime)
+                    .Take(take)
+                    .Select(f => f.FullName)
+                    .ToList();
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        /// <summary>
+        /// フォルダ名は cwd から機械的に決まるので、まず組み立てて直接叩く（全列挙は不要）。
+        /// Windows のパス比較は大文字小文字を区別しないため、記録側と綴りが違っても直接ヒットする。
+        /// 外れたときだけ、保険として一覧から突き合わせる。
+        /// </summary>
+        private string? FindProjectDir(string folderPath)
+        {
+            var root = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude", "projects");
+            if (!Directory.Exists(root)) return null;
+
+            var key = ToProjectKey(folderPath);
+            if (key == null) return null;
+
+            var direct = Path.Combine(root, key);
+            if (Directory.Exists(direct)) return direct;
+
+            return GetIndex(root).GetValueOrDefault(key);
+        }
+
+        private Dictionary<string, string> GetIndex(string root)
+        {
+            var current = _index;
+            if (current != null && DateTime.UtcNow - current.BuiltAt < IndexTtl) return current.Map;
+
+            var index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var dir in Directory.EnumerateDirectories(root))
+            {
+                var k = ToProjectKey(Path.GetFileName(dir));
+                if (k != null) index[k] = dir;
+            }
+            _index = new ProjectIndex(index, DateTime.UtcNow);
+            return index;
+        }
+
+        /// <summary>パス -> projects のフォルダ名。末尾の空白や区切りは落としてから記号を潰す</summary>
+        private static string? ToProjectKey(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return null;
+            var p = path.Trim().TrimEnd('\\', '/', ' ');
+            var sb = new StringBuilder(p.Length);
+            foreach (var c in p)
+                sb.Append(char.IsAsciiLetterOrDigit(c) ? c : '-');
+            return sb.ToString().TrimEnd('-');
+        }
+    }
+
+    /// <summary>
+    /// jsonl（1行=1JSON）を必要な分だけ読むための共通処理。
+    /// 巨大なファイルを丸ごと読むと極端に遅くなるので、末尾/先頭だけを掴む。
+    /// </summary>
+    public static class TranscriptTail
+    {
+        /// <summary>
+        /// 末尾のみを読む。書き込み中のファイルを掴むため ReadWrite 共有で開く。
+        /// </summary>
+        public static IReadOnlyList<string> ReadTailLines(string path, int tailBytes)
+        {
+            try
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                var start = Math.Max(0, fs.Length - tailBytes);
+                fs.Seek(start, SeekOrigin.Begin);
+                var buf = new byte[fs.Length - start];
+                var read = fs.Read(buf, 0, buf.Length);
+                var lines = Encoding.UTF8.GetString(buf, 0, read).Split('\n');
+                // 途中から読んだ場合、先頭行は千切れているので捨てる
+                return start > 0 && lines.Length > 1 ? lines[1..] : lines;
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        /// <summary>先頭行だけを読む</summary>
+        public static string? ReadHead(string path, int bytes = 8192)
+        {
+            try
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                var buf = new byte[Math.Min(bytes, fs.Length)];
+                var read = fs.Read(buf, 0, buf.Length);
+                return Encoding.UTF8.GetString(buf, 0, read).Split('\n').FirstOrDefault();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/TerminalHub/Services/HookNotificationService.cs
+++ b/TerminalHub/Services/HookNotificationService.cs
@@ -100,6 +100,14 @@ public class HookNotificationService : IHookNotificationService
             return;
         }
 
+        // Claude Code はどの hook でもトランスクリプトのパスを添えてくる。
+        // コンテキスト量バッジが読む先を厳密に決められるので、来たら覚えておく
+        // （フォルダからの推測は、同じフォルダに複数セッションがいると取り違える）。
+        if (!string.IsNullOrEmpty(notification.TranscriptPath))
+        {
+            session.TranscriptPath = notification.TranscriptPath;
+        }
+
         var permissionRequestRequiresUserInput = eventType != HookEventType.PermissionRequest ||
             CodexProcessOptionsSnapshot.ResolvePermissionRequestRequiresUserInput(
                 session.RunningCodexOptions, session.Options);

--- a/TerminalHub/Services/SessionContextService.cs
+++ b/TerminalHub/Services/SessionContextService.cs
@@ -1,0 +1,175 @@
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using TerminalHub.Models;
+
+namespace TerminalHub.Services
+{
+    /// <summary>
+    /// セッションのコンテキスト量（トークン数）と、最後に記録が伸びた時刻。
+    /// 時刻はプロンプトキャッシュの温度判定に使う（最後の API 要求から 1 時間で TTL 切れ）。
+    /// </summary>
+    /// <param name="Tokens">直近の assistant 発話時点のコンテキスト量</param>
+    /// <param name="LastActivityUtc">トランスクリプトの最終更新時刻（UTC）</param>
+    public record SessionContextUsage(int Tokens, DateTime LastActivityUtc);
+
+    public interface ISessionContextService
+    {
+        /// <summary>
+        /// 複数セッション分をまとめて取得する（対象外・取得不能は結果に含めない）。
+        /// forceRefresh=true で緩衝を無視して読み直す（発話直後など、変わったと分かっているとき）。
+        /// </summary>
+        Task<IReadOnlyDictionary<Guid, SessionContextUsage>> GetContextUsagesAsync(
+            IReadOnlyList<SessionInfo> sessions, bool forceRefresh = false);
+    }
+
+    /// <summary>
+    /// Claude Code のトランスクリプト（.jsonl）末尾から、直近の assistant 発話の usage を読む。
+    ///
+    /// コンテキスト量 = input_tokens + cache_creation_input_tokens + cache_read_input_tokens。
+    /// この3つがその発話で「読ませた全量」で、これがキャッシュに載る量でもある。
+    /// output_tokens は次のターンの入力になるが、次の発話の usage に含まれて出てくるので足さない。
+    ///
+    /// Claude Code 限定。usage も .jsonl も Claude Code の形式で、他の CLI には無い。
+    /// </summary>
+    public class SessionContextService : ISessionContextService
+    {
+        private readonly ILogger<SessionContextService> _logger;
+        private readonly IClaudeTranscriptLocator _transcriptLocator;
+
+        // 取得はファイル読みなので、短時間に何度も呼ばれても読み直さないための緩衝。
+        // 一覧の再描画は入力のたびに走るが、実ファイルを触るのは 30 秒に 1 回で足りる。
+        private readonly ConcurrentDictionary<Guid, (SessionContextUsage? Usage, DateTime ReadAt)> _cache = new();
+
+        private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(30);
+
+        /// <summary>末尾から読むバイト数。1発話分の usage が入っていれば足りる</summary>
+        private const int TailBytes = 128 * 1024;
+
+        private static readonly Regex UsageRegex = new(
+            "\"usage\":\\{(?<body>[^}]*)\\}", RegexOptions.Compiled);
+
+        public SessionContextService(ILogger<SessionContextService> logger, IClaudeTranscriptLocator transcriptLocator)
+        {
+            _logger = logger;
+            _transcriptLocator = transcriptLocator;
+        }
+
+        public async Task<IReadOnlyDictionary<Guid, SessionContextUsage>> GetContextUsagesAsync(
+            IReadOnlyList<SessionInfo> sessions, bool forceRefresh = false)
+        {
+            var result = new Dictionary<Guid, SessionContextUsage>();
+            var targets = sessions.Where(IsSupported).ToList();
+            if (targets.Count == 0) return result;
+
+            var pending = new List<SessionInfo>();
+            foreach (var s in targets)
+            {
+                if (!forceRefresh && TryGetCached(s.SessionId, out var cached))
+                {
+                    if (cached != null) result[s.SessionId] = cached;
+                }
+                else
+                {
+                    pending.Add(s);
+                }
+            }
+            if (pending.Count == 0) return result;
+
+            try
+            {
+                await Task.Run(() =>
+                {
+                    var now = DateTime.UtcNow;
+                    foreach (var s in pending)
+                    {
+                        var usage = Read(s);
+                        _cache[s.SessionId] = (usage, now);
+                        if (usage != null) result[s.SessionId] = usage;
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[SessionContextService] コンテキスト量の取得に失敗");
+            }
+            return result;
+        }
+
+        private static bool IsSupported(SessionInfo session) =>
+            session.TerminalType == TerminalType.ClaudeCode
+            && (!string.IsNullOrEmpty(session.TranscriptPath) || !string.IsNullOrEmpty(session.FolderPath));
+
+        private bool TryGetCached(Guid sessionId, out SessionContextUsage? usage)
+        {
+            if (_cache.TryGetValue(sessionId, out var e) && DateTime.UtcNow - e.ReadAt < CacheTtl)
+            {
+                usage = e.Usage;
+                return true;
+            }
+            usage = null;
+            return false;
+        }
+
+        private SessionContextUsage? Read(SessionInfo session)
+        {
+            var path = ResolveTranscript(session);
+            if (path == null) return null;
+
+            try
+            {
+                var lastWrite = File.GetLastWriteTimeUtc(path);
+
+                // 末尾から遡り、最初に見つかった「本編の assistant 発話」の usage を採る。
+                // サブエージェント（isSidechain:true）の発話は別コンテキストなので飛ばす
+                // ——拾ってしまうと、Task 実行中だけ数字が small に化ける。
+                foreach (var line in TranscriptTail.ReadTailLines(path, TailBytes).Reverse())
+                {
+                    if (!line.Contains("\"type\":\"assistant\"", StringComparison.Ordinal)) continue;
+                    if (line.Contains("\"isSidechain\":true", StringComparison.Ordinal)) continue;
+
+                    var m = UsageRegex.Match(line);
+                    if (!m.Success) continue;
+
+                    var body = m.Groups["body"].Value;
+                    var tokens = ReadInt(body, "input_tokens")
+                        + ReadInt(body, "cache_creation_input_tokens")
+                        + ReadInt(body, "cache_read_input_tokens");
+                    if (tokens <= 0) continue;
+
+                    return new SessionContextUsage(tokens, lastWrite);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "[SessionContextService] 読み取りに失敗: {Path}", path);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// hook が知らせてきたパスがあればそれを使う（同じフォルダに複数セッションがいても取り違えない）。
+        /// まだ hook が飛んでいないセッションは、フォルダから最新の記録を推測する。
+        /// </summary>
+        private string? ResolveTranscript(SessionInfo session)
+        {
+            if (!string.IsNullOrEmpty(session.TranscriptPath) && File.Exists(session.TranscriptPath))
+                return session.TranscriptPath;
+
+            // 最新の1件だけ見る。モデル名と違って古い記録の値は無意味（前のセッションの残り）なので遡らない
+            return _transcriptLocator.EnumerateNewestFirst(session.FolderPath, 1).FirstOrDefault();
+        }
+
+        /// <summary>usage 本体（"a":1,"b":2 …）から数値を1つ取り出す。無ければ 0</summary>
+        private static int ReadInt(string body, string key)
+        {
+            var needle = $"\"{key}\":";
+            var i = body.IndexOf(needle, StringComparison.Ordinal);
+            if (i < 0) return 0;
+
+            i += needle.Length;
+            var end = i;
+            while (end < body.Length && char.IsAsciiDigit(body[end])) end++;
+            return end > i && int.TryParse(body.AsSpan(i, end - i), out var v) ? v : 0;
+        }
+    }
+}

--- a/TerminalHub/Services/SessionContextService.cs
+++ b/TerminalHub/Services/SessionContextService.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Text.RegularExpressions;
 using TerminalHub.Models;
 
 namespace TerminalHub.Services
@@ -45,8 +44,6 @@ namespace TerminalHub.Services
         /// <summary>末尾から読むバイト数。1発話分の usage が入っていれば足りる</summary>
         private const int TailBytes = 128 * 1024;
 
-        private static readonly Regex UsageRegex = new(
-            "\"usage\":\\{(?<body>[^}]*)\\}", RegexOptions.Compiled);
 
         public SessionContextService(ILogger<SessionContextService> logger, IClaudeTranscriptLocator transcriptLocator)
         {
@@ -127,13 +124,12 @@ namespace TerminalHub.Services
                     if (!line.Contains("\"type\":\"assistant\"", StringComparison.Ordinal)) continue;
                     if (line.Contains("\"isSidechain\":true", StringComparison.Ordinal)) continue;
 
-                    var m = UsageRegex.Match(line);
-                    if (!m.Success) continue;
+                    var usage = ExtractUsage(line);
+                    if (usage == null) continue;
 
-                    var body = m.Groups["body"].Value;
-                    var tokens = ReadInt(body, "input_tokens")
-                        + ReadInt(body, "cache_creation_input_tokens")
-                        + ReadInt(body, "cache_read_input_tokens");
+                    var tokens = ReadInt(usage, "input_tokens")
+                        + ReadInt(usage, "cache_creation_input_tokens")
+                        + ReadInt(usage, "cache_read_input_tokens");
                     if (tokens <= 0) continue;
 
                     return new SessionContextUsage(tokens, lastWrite);
@@ -159,17 +155,58 @@ namespace TerminalHub.Services
             return _transcriptLocator.EnumerateNewestFirst(session.FolderPath, 1).FirstOrDefault();
         }
 
-        /// <summary>usage 本体（"a":1,"b":2 …）から数値を1つ取り出す。無ければ 0</summary>
-        private static int ReadInt(string body, string key)
+        /// <summary>
+        /// 1行から usage オブジェクトを丸ごと切り出す。
+        ///
+        /// usage には server_tool_use / cache_creation / iterations といった入れ子が入るため、
+        /// 「最初の閉じ括弧まで」で切ると必要なフィールドを取りこぼすことがある
+        /// （しかも 0 が返るだけで静かに壊れる）。括弧の対応を数えて全体を取る。
+        /// </summary>
+        private static string? ExtractUsage(string line)
+        {
+            var i = line.IndexOf("\"usage\":", StringComparison.Ordinal);
+            if (i < 0) return null;
+
+            var open = line.IndexOf('{', i);
+            if (open < 0) return null;
+
+            var depth = 0;
+            for (var k = open; k < line.Length; k++)
+            {
+                if (line[k] == '{') depth++;
+                else if (line[k] == '}' && --depth == 0) return line[open..(k + 1)];
+            }
+            return null; // 行が途中で切れている（末尾読みの境界）
+        }
+
+        /// <summary>
+        /// usage から数値フィールドを1つ取り出す。無ければ 0。
+        ///
+        /// iterations の中に同名のキーが入っているため、入れ子の中は見ない
+        /// （直下のものだけを採る）。文字列値は現れない前提だが、括弧の深さで判定するので
+        /// 順序が変わっても取り違えない。
+        /// </summary>
+        private static int ReadInt(string usage, string key)
         {
             var needle = $"\"{key}\":";
-            var i = body.IndexOf(needle, StringComparison.Ordinal);
-            if (i < 0) return 0;
+            var depth = 0;
 
-            i += needle.Length;
-            var end = i;
-            while (end < body.Length && char.IsAsciiDigit(body[end])) end++;
-            return end > i && int.TryParse(body.AsSpan(i, end - i), out var v) ? v : 0;
+            for (var i = 0; i < usage.Length; i++)
+            {
+                var c = usage[i];
+                if (c == '{' || c == '[') { depth++; continue; }
+                if (c == '}' || c == ']') { depth--; continue; }
+
+                // usage オブジェクトの直下（開き括弧のぶんで depth==1）だけを見る
+                if (depth != 1 || c != '"') continue;
+                if (string.CompareOrdinal(usage, i, needle, 0, needle.Length) != 0) continue;
+
+                var v = i + needle.Length;
+                var end = v;
+                while (end < usage.Length && char.IsAsciiDigit(usage[end])) end++;
+                return end > v && int.TryParse(usage.AsSpan(v, end - v), out var parsed) ? parsed : 0;
+            }
+            return 0;
         }
     }
 }

--- a/TerminalHub/Services/SessionModelService.cs
+++ b/TerminalHub/Services/SessionModelService.cs
@@ -14,6 +14,7 @@ namespace TerminalHub.Services
     public class SessionModelService : ISessionModelService
     {
         private readonly ILogger<SessionModelService> _logger;
+        private readonly IClaudeTranscriptLocator _transcriptLocator;
 
         // 直近の取得結果。短時間に何度も呼ばれても実ファイルを読み直さないための緩衝。
         // ロックは張らない（取得は読み取り専用で、同時に走っても結果は同じ。
@@ -21,8 +22,6 @@ namespace TerminalHub.Services
         private readonly ConcurrentDictionary<Guid, (string? Model, DateTime ReadAt)> _cache = new();
 
         private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(15);
-        /// <summary>Claude のプロジェクト一覧（直接検索が外れたときの保険）を作り直す間隔</summary>
-        private static readonly TimeSpan IndexTtl = TimeSpan.FromMinutes(2);
         /// <summary>Codex の走査上限。全件でも数百程度だが、増え続ける前提で頭を抑える</summary>
         private const int CodexScanLimit = 500;
         /// <summary>末尾から読むバイト数。巨大な jsonl 全体を読むと極端に遅くなる</summary>
@@ -33,9 +32,10 @@ namespace TerminalHub.Services
         private static readonly Regex ModelRegex = new("\"model\":\"([^\"]+)\"", RegexOptions.Compiled);
         private static readonly Regex CwdRegex = new("\"cwd\":\"([^\"]+)\"", RegexOptions.Compiled);
 
-        public SessionModelService(ILogger<SessionModelService> logger)
+        public SessionModelService(ILogger<SessionModelService> logger, IClaudeTranscriptLocator transcriptLocator)
         {
             _logger = logger;
+            _transcriptLocator = transcriptLocator;
         }
 
         public async Task<string?> GetCurrentModelAsync(SessionInfo session, bool forceRefresh = false)
@@ -127,19 +127,10 @@ namespace TerminalHub.Services
 
         private string? ReadClaudeModel(string folderPath)
         {
-            var dir = FindClaudeProjectDir(folderPath);
-            if (dir == null) return null;
-
             // 更新日時での足切りはしない。長く放置したセッションでもモデルは変わらず有効なため。
             // 再起動直後は新しい記録がまだ空で、最新ファイルだけ見るとバッジが消えてしまうので、
             // 見つかるまで新しい順に数件遡る（/model の指定は既定として引き継がれるため直前の値が妥当）
-            var files = Directory.EnumerateFiles(dir, "*.jsonl")
-                .Select(p => new FileInfo(p))
-                .OrderByDescending(f => f.LastWriteTime)
-                .Take(ClaudeFileLookback)
-                .Select(f => f.FullName);
-
-            foreach (var jsonl in files)
+            foreach (var jsonl in _transcriptLocator.EnumerateNewestFirst(folderPath, ClaudeFileLookback))
             {
                 // 末尾から遡り、最後に assistant が喋ったときのモデルを拾う
                 foreach (var line in ReadTailLines(jsonl).Reverse())
@@ -150,58 +141,6 @@ namespace TerminalHub.Services
                 }
             }
             return null;
-        }
-
-        /// <summary>
-        /// フォルダ名は cwd から機械的に決まるので、まず組み立てて直接叩く（全列挙は不要）。
-        /// Windows のパス比較は大文字小文字を区別しないため、記録側と綴りが違っても直接ヒットする。
-        /// 外れたときだけ、保険として一覧から突き合わせる。
-        /// </summary>
-        private string? FindClaudeProjectDir(string folderPath)
-        {
-            var root = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude", "projects");
-            if (!Directory.Exists(root)) return null;
-
-            var key = ToProjectKey(folderPath);
-            if (key == null) return null;
-
-            var direct = Path.Combine(root, key);
-            if (Directory.Exists(direct)) return direct;
-
-            return GetClaudeProjectIndex(root).GetValueOrDefault(key);
-        }
-
-        // 複数スレッドから同時に読まれるので、作りかけを見せないよう完成品を丸ごと差し替える。
-        // 同時に作り直しが走っても結果は同じなので、作成自体は直列化しない。
-        private volatile ClaudeProjectIndex? _claudeIndex;
-
-        private sealed record ClaudeProjectIndex(Dictionary<string, string> Map, DateTime BuiltAt);
-
-        private Dictionary<string, string> GetClaudeProjectIndex(string root)
-        {
-            var current = _claudeIndex;
-            if (current != null && DateTime.UtcNow - current.BuiltAt < IndexTtl) return current.Map;
-
-            var index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var dir in Directory.EnumerateDirectories(root))
-            {
-                var k = ToProjectKey(Path.GetFileName(dir));
-                if (k != null) index[k] = dir;
-            }
-            _claudeIndex = new ClaudeProjectIndex(index, DateTime.UtcNow);
-            return index;
-        }
-
-        /// <summary>パス -> projects のフォルダ名。末尾の空白や区切りは落としてから記号を潰す</summary>
-        private static string? ToProjectKey(string? path)
-        {
-            if (string.IsNullOrWhiteSpace(path)) return null;
-            var p = path.Trim().TrimEnd('\\', '/', ' ');
-            var sb = new StringBuilder(p.Length);
-            foreach (var c in p)
-                sb.Append(char.IsAsciiLetterOrDigit(c) ? c : '-');
-            return sb.ToString().TrimEnd('-');
         }
 
         // --- Codex -----------------------------------------------------------
@@ -318,43 +257,9 @@ namespace TerminalHub.Services
 
         private static readonly Regex DateSuffixRegex = new(@"-\d{8}$", RegexOptions.Compiled);
 
-        /// <summary>
-        /// 末尾のみを読む。1行=1JSON なので、全体をパースせず行単位で拾えば足りる。
-        /// 書き込み中のファイルを掴むため ReadWrite 共有で開く。
-        /// </summary>
-        private static IReadOnlyList<string> ReadTailLines(string path)
-        {
-            try
-            {
-                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                var start = Math.Max(0, fs.Length - TailBytes);
-                fs.Seek(start, SeekOrigin.Begin);
-                var buf = new byte[fs.Length - start];
-                var read = fs.Read(buf, 0, buf.Length);
-                var lines = Encoding.UTF8.GetString(buf, 0, read).Split('\n');
-                // 途中から読んだ場合、先頭行は千切れているので捨てる
-                return start > 0 && lines.Length > 1 ? lines[1..] : lines;
-            }
-            catch
-            {
-                return Array.Empty<string>();
-            }
-        }
+        private static IReadOnlyList<string> ReadTailLines(string path) =>
+            TranscriptTail.ReadTailLines(path, TailBytes);
 
-        /// <summary>先頭行（session_meta）だけを読む</summary>
-        private static string? ReadHead(string path, int bytes = 8192)
-        {
-            try
-            {
-                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                var buf = new byte[Math.Min(bytes, fs.Length)];
-                var read = fs.Read(buf, 0, buf.Length);
-                return Encoding.UTF8.GetString(buf, 0, read).Split('\n').FirstOrDefault();
-            }
-            catch
-            {
-                return null;
-            }
-        }
+        private static string? ReadHead(string path) => TranscriptTail.ReadHead(path);
     }
 }


### PR DESCRIPTION
## 概要

セッション一覧に、Claude Code のコンテキスト量（トークン数）をバッジで表示する。
あわせてプロンプトキャッシュの温度を色で示し、「まだ温かいうちに畳める」タイミングだけを知らせる。

`ping` による延命や Enter 再送のような能動的な動きは持たない。**副作用のない計器**に留めている。

## なぜ

プロンプトキャッシュの TTL は最後の発話から1時間で、切れると次回の読み込みが約20倍のコストになる
（読み 0.1x → 書き 2.0x）。一方で **冷えてから圧縮するのは何もしないより高い**ので、
「冷えた × 大きい」で警告するのは一番払ってはいけない瞬間を狙うことになる。

そこで警告を **切れる前（残り15分／10分）** に置いた。色が付くのはその15分間だけで、
通り過ぎれば灰色に落ちるため、色 = 今なら間に合う / 灰色 = もう手遅れ、と一意に読める。
放置レーンが黄赤で滞留することはない。

## 変更内容

### 1. `refactor:` トランスクリプトの引き方を共通サービスへ切り出し

`SessionModelService` が持っていた「作業フォルダ → `~/.claude/projects` の記録」の解決と
jsonl の末尾読みを `ClaudeTranscriptLocator` / `TranscriptTail` へ移動。挙動変更なし。

### 2. `feat:` バッジ本体

**読み取り** (`SessionContextService`)
- コンテキスト量 = `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`
  （その発話で読ませた全量 ＝ キャッシュに載る量。`output_tokens` は次の発話の usage に
  含まれて出てくるので足さない）
- サブエージェント（`isSidechain:true`）の usage は拾わない。別コンテキストなので、
  拾うと Task 実行中だけ数字が小さく化ける
- 読む記録は hook の `transcript_path` を正とし、無ければフォルダから最新1件を推測する
  （同じフォルダに複数セッションがぶら下がると推測では取り違えるため）
- 末尾 128KB のみ seek して読む。緩衝 30 秒

**表示** (`SessionList`)

| 状態 | 色 | 表示 |
|---|---|---|
| 残り15分超 | 青 | `161K` |
| 残り15分切り | 黄 | `161K・12分` |
| 残り10分切り | 赤 | `161K・7分` |
| Cold / 考慮OFF | 灰 | `161K` |

- ツールチップは常時。黄赤のときはコストの理由も添える
- 処理中（`ProcessingStartTime` あり）は API 応答待ちで記録が伸びず実際より冷たく見えるため、温かい側に倒す

**設定**（セッション表示設定）
- `ShowContextSize`（既定 false） / `ContextCacheAware`（既定 true） / `ContextMinSizeK`（既定 50）
- `OnSessionDisplaySettingsChanged` が6要素タプルで限界だったので `SessionDisplaySettingsChange` record へ

**更新契機**: 起動時の裏処理 → 60秒ごと（表示OFFならタイマーごと停止）→ 発話直後（緩衝を無視して読み直し）

## 対象と制約

- **Claude Code のみ**。usage も .jsonl も Claude Code の形式で、他の CLI には無い
- TTL 1時間は**サブスク前提**。overage 時は 5分になるが検知できないため、その状態では警告が間に合わない
- hook が最低1回飛ぶまでは記録の紐付けがフォルダ推測になる（同一フォルダに複数セッションだと取り違える）

## 確認

- ビルド成功 / 既存テスト 282 件すべて通過
- 実データで解析ロジックを検算（実セッションの jsonl から 161,921 トークンを取得）
- スキーマ変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)