### PR TITLE
fix: 処理中フラグが残ったセッションが永久に「残り60分」と表示される問題を修正

### DIFF
--- a/TerminalHub/Components/Shared/SessionList.razor
+++ b/TerminalHub/Components/Shared/SessionList.razor
@@ -313,11 +313,11 @@
             return new ContextBadge(text, "text-bg-secondary", sizeTitle);
         }
 
-        // 処理中は API 応答待ちで記録が伸びず、実際より冷たく見える。温かい側に倒す
-        var isProcessing = session.ProcessingStartTime.HasValue;
-        var remaining = isProcessing
-            ? CacheTtl
-            : CacheTtl - (DateTime.UtcNow - usage.LastActivityUtc);
+        // 処理中は API 応答待ちで記録が伸びず、実際より冷たく見える。
+        // 処理開始＝本物のリクエストを投げた時刻なので、それを活動時刻とみなして温かい側に倒す。
+        // 満タン固定にはしない（処理中フラグが残ったセッションが永久に「残り60分」になるため。
+        // Stop hook は撃ち漏らすことがあり、フラグは放っておくと立ちっぱなしになる）
+        var remaining = CacheTtl - (DateTime.UtcNow - GetCacheBasisUtc(session, usage));
 
         if (remaining <= TimeSpan.Zero)
         {
@@ -339,6 +339,18 @@
             string.Format(L["SessionList.Badge.ContextRemainingFormat"], sizeK, left),
             css,
             $"{sizeTitle} / {expiring}");
+    }
+
+    /// <summary>
+    /// キャッシュ残り時間の起点。処理中なら処理開始時刻（＝直近に API を叩いた時刻）と
+    /// 記録上の最終活動時刻の新しい方を採る。
+    /// ProcessingStartTime はローカル時刻（DateTime.Now）で入るので UTC に揃える。
+    /// </summary>
+    private static DateTime GetCacheBasisUtc(SessionInfo session, SessionContextUsage usage)
+    {
+        if (session.ProcessingStartTime is not { } started) return usage.LastActivityUtc;
+        var startedUtc = started.ToUniversalTime();
+        return startedUtc > usage.LastActivityUtc ? startedUtc : usage.LastActivityUtc;
     }
 
     private string GetGitBadgeTitle(SessionInfo session)


### PR DESCRIPTION
## 問題
コンテキスト量バッジのキャッシュ残り時間が、処理中のセッションで**常に「残り60分」**になる。

`SessionList.razor` で処理中は無条件に TTL 満タンを返していた。API 応答待ちの間は usage が伸びず実際より冷たく見えるための措置だが、Stop hook の撃ち漏らし（既知）で処理中フラグが立ちっぱなしになると、そのセッションは何時間経っても満タンのままになる。

実例: Chatwork のセッションは最終 API 通信が 10:16 で、2 時間後の 12:16 時点でもバッジは「残り60分」だった（実際はキャッシュ失効済み）。

## 修正
満タン固定をやめ、**処理開始時刻（＝直近に API を叩いた時刻）**を活動時刻とみなす。温かい側に倒す本来の意図は保ったまま、時間経過で正しく減る。`ProcessingStartTime` はローカル時刻で入るため UTC に揃える。

## 検証
ビルド済みアセンブリに対してリフレクションで実測（起点は Chatwork セッションの実データ 2026-08-27T01:16:31Z）:

| ケース | 起点 | 残り | 判定 |
|---|---|---|---|
| 処理中フラグ立ちっぱなし（10:16 開始・現在 12:16） | 01:16Z | -59分 | 冷えた（修正前は「残り60分」） |
| 処理中フラグなし | 01:16Z | -59分 | 冷えた |
| 今まさに処理中（12:10 開始） | 03:10Z | 54分 | 温かい |
| 処理直後（10:20 時点） | 01:16Z | 57分 | 温かい |