### PR TITLE
feat: Claude の権限モードに「Auto+Bypass可」を追加し、デフォルトを選択肢から外す

### DIFF
--- a/TerminalHub.Terminal.Tests/ClaudeArgumentsTests.cs
+++ b/TerminalHub.Terminal.Tests/ClaudeArgumentsTests.cs
@@ -43,6 +43,21 @@ public sealed class ClaudeArgumentsTests
     }
 
     [Fact]
+    public void AutoAllowBypassはオート起動とバイパス許可の両方を出す()
+    {
+        // --allow-dangerously-skip-permissions は bypass を切替候補に加えるだけで既定にはしない。
+        // --dangerously-skip-permissions（即バイパス固定）と取り違えないための番人。
+        var options = new Dictionary<string, string>
+        {
+            ["permission-mode"] = "auto-allow-bypass"
+        };
+
+        Assert.Equal(
+            "--permission-mode auto --allow-dangerously-skip-permissions",
+            TerminalConstants.BuildClaudeCodeArgs(options));
+    }
+
+    [Fact]
     public void McpConfigはユーザー指定の引数より前に置かれる()
     {
         // --mcp-config は複数指定でマージされる。ユーザーが自分で書いた指定を後ろに置くことで、

--- a/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionCreateDialog.razor
@@ -250,7 +250,7 @@
 
     // 復元値ホワイトリスト: 設定ファイルが手動編集等で汚染された場合に
     // 不正値で起動引数が壊れるのを防ぐ。SessionOptionsSelector の UI 選択肢と一致させる。
-    private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto", "default" };
+    private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto-allow-bypass", "auto", "default" };
     private static readonly HashSet<string> ValidGeminiApprovalModes = new() { "default", "auto_edit", "yolo" };
     private static readonly HashSet<string> ValidCodexSandboxModes = new() { "", "read-only", "workspace-write", "danger-full-access" };
     private static readonly HashSet<string> ValidCodexApprovalPolicies = new() { "", "untrusted", "on-request", "never" };

--- a/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SessionOptionsSelector.razor
@@ -84,12 +84,23 @@
                         @L["SessionOptions.Claude.PermissionMode.AutoLabel"]
                     </label>
 
-                    <input type="radio" class="btn-check" name="@($"claudePermMode{UniqueId}")" id="@($"claudePermDefault{UniqueId}")"
-                           checked="@(ClaudeOptions.PermissionMode == "default")"
-                           @onchange="@(() => ClaudeOptions.PermissionMode = "default")" autocomplete="off">
-                    <label class="btn btn-outline-primary btn-sm" for="@($"claudePermDefault{UniqueId}")" title="@L["SessionOptions.Claude.PermissionMode.DefaultTitle"]">
-                        @L["SessionOptions.Claude.PermissionMode.DefaultLabel"]
+                    <input type="radio" class="btn-check" name="@($"claudePermMode{UniqueId}")" id="@($"claudePermAutoAllow{UniqueId}")"
+                           checked="@(ClaudeOptions.PermissionMode == "auto-allow-bypass")"
+                           @onchange="@(() => ClaudeOptions.PermissionMode = "auto-allow-bypass")" autocomplete="off">
+                    <label class="btn btn-outline-warning btn-sm" for="@($"claudePermAutoAllow{UniqueId}")" title="@L["SessionOptions.Claude.PermissionMode.AutoAllowBypassTitle"]">
+                        @L["SessionOptions.Claude.PermissionMode.AutoAllowBypassLabel"]
                     </label>
+
+                    @* デフォルトは選択肢から外したが、既にその設定で保存されたセッションを開いたときだけ
+                       選択状態が消えないようボタンを残す（新規には出さない）。 *@
+                    @if (ClaudeOptions.PermissionMode == "default")
+                    {
+                        <input type="radio" class="btn-check" name="@($"claudePermMode{UniqueId}")" id="@($"claudePermDefault{UniqueId}")"
+                               checked="true" autocomplete="off">
+                        <label class="btn btn-outline-primary btn-sm" for="@($"claudePermDefault{UniqueId}")" title="@L["SessionOptions.Claude.PermissionMode.DefaultTitle"]">
+                            @L["SessionOptions.Claude.PermissionMode.DefaultLabel"]
+                        </label>
+                    }
                 </div>
                 @if (!string.IsNullOrWhiteSpace(GetPermissionModeHelp()))
                 {
@@ -735,7 +746,8 @@
 
     public class ClaudeCodeOptions
     {
-        public string PermissionMode { get; set; } = "bypass"; // "bypass" | "auto" | "default"
+        // "bypass" | "auto-allow-bypass" | "auto" | "default"(旧データのみ・UIの選択肢からは撤去)
+        public string PermissionMode { get; set; } = "bypass";
         public bool Continue { get; set; } = true;
         public bool ChromeMode { get; set; } = false;
         public string ExtraArgs { get; set; } = "";
@@ -787,6 +799,7 @@
         return ClaudeOptions.PermissionMode switch
         {
             "bypass" => L["SessionOptions.Claude.PermissionMode.HelpBypass"],
+            "auto-allow-bypass" => L["SessionOptions.Claude.PermissionMode.HelpAutoAllowBypass"],
             "auto" => L["SessionOptions.Claude.PermissionMode.HelpAuto"],
             "default" => L["SessionOptions.Claude.PermissionMode.HelpDefault"],
             _ => ""

--- a/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
+++ b/TerminalHub/Components/Shared/Dialogs/SubSessionDialog.razor
@@ -572,7 +572,7 @@
     // 直近の CLI モード選択は AppSettings.SessionDefaults(ファイル) から読む
     // (値の発生源は SessionCreateDialog に一元化。SubSession 側は読むだけで書き戻さない)。
 
-    private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto", "default" };
+    private static readonly HashSet<string> ValidClaudePermissionModes = new() { "bypass", "auto-allow-bypass", "auto", "default" };
     private static readonly HashSet<string> ValidGeminiApprovalModes = new() { "default", "auto_edit", "yolo" };
     private static readonly HashSet<string> ValidCodexSandboxModes = new() { "", "read-only", "workspace-write", "danger-full-access" };
     private static readonly HashSet<string> ValidCodexApprovalPolicies = new() { "", "untrusted", "on-request", "never" };

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -58,8 +58,10 @@
             {
                 if (permMode == "bypass") args.Add("--dangerously-skip-permissions");
                 // auto-allow-bypass: オートモードで起動しつつ、Shift+Tab の切替候補に bypass を残す。
-                // --allow-dangerously-skip-permissions は「選択肢に加えるだけ」で既定にはしない
-                // （--dangerously-skip-permissions とは別物）。
+                // Pro/Max/Team のターミナルなら Claude Code 側の既定も auto だが、Enterprise・API キー・
+                // -p・Bedrock 系・インストール直後の初回セッションは default 起動なので明示しておく。
+                // --allow-dangerously-skip-permissions は「選択肢に加える」フラグで、
+                // 即バイパス固定の --dangerously-skip-permissions とは別物。
                 else if (permMode == "auto-allow-bypass") args.Add("--permission-mode auto --allow-dangerously-skip-permissions");
                 else if (permMode == "auto") args.Add("--permission-mode auto");
             }

--- a/TerminalHub/Constants/TerminalConstants.cs
+++ b/TerminalHub/Constants/TerminalConstants.cs
@@ -57,6 +57,10 @@
             if (options.TryGetValue("permission-mode", out var permMode))
             {
                 if (permMode == "bypass") args.Add("--dangerously-skip-permissions");
+                // auto-allow-bypass: オートモードで起動しつつ、Shift+Tab の切替候補に bypass を残す。
+                // --allow-dangerously-skip-permissions は「選択肢に加えるだけ」で既定にはしない
+                // （--dangerously-skip-permissions とは別物）。
+                else if (permMode == "auto-allow-bypass") args.Add("--permission-mode auto --allow-dangerously-skip-permissions");
                 else if (permMode == "auto") args.Add("--permission-mode auto");
             }
             else if (options.ContainsKey("bypass-mode") && options["bypass-mode"] == "true")

--- a/TerminalHub/Resources/SharedResource.en.resx
+++ b/TerminalHub/Resources/SharedResource.en.resx
@@ -352,10 +352,13 @@
   <data name="SessionOptions.Claude.PermissionMode.BypassTitle" xml:space="preserve"><value>Auto-approves all operations unconditionally (dangerous)</value></data>
   <data name="SessionOptions.Claude.PermissionMode.AutoLabel" xml:space="preserve"><value>Auto</value></data>
   <data name="SessionOptions.Claude.PermissionMode.AutoTitle" xml:space="preserve"><value>Auto-approves low-risk operations and prompts only for high-risk ones</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoAllowBypassLabel" xml:space="preserve"><value>Auto+Bypass</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoAllowBypassTitle" xml:space="preserve"><value>Starts in auto mode and keeps bypass available via Shift+Tab</value></data>
   <data name="SessionOptions.Claude.PermissionMode.DefaultLabel" xml:space="preserve"><value>Default</value></data>
   <data name="SessionOptions.Claude.PermissionMode.DefaultTitle" xml:space="preserve"><value>Prompts for confirmation on every operation</value></data>
   <data name="SessionOptions.Claude.PermissionMode.HelpBypass" xml:space="preserve"><value>Auto-approves all operations unconditionally (--dangerously-skip-permissions).</value></data>
   <data name="SessionOptions.Claude.PermissionMode.HelpAuto" xml:space="preserve"><value>Auto-approves low-risk operations and prompts only for high-risk ones (--permission-mode auto).</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpAutoAllowBypass" xml:space="preserve"><value>Starts in auto mode while keeping bypass as a switchable option (--permission-mode auto --allow-dangerously-skip-permissions).</value></data>
   <data name="SessionOptions.Claude.PermissionMode.HelpDefault" xml:space="preserve"><value>Prompts for confirmation on every operation.</value></data>
   <data name="SessionOptions.Claude.Continue" xml:space="preserve"><value>Resume previous session (--continue)</value></data>
   <data name="SessionOptions.Claude.Chrome" xml:space="preserve"><value>Browser integration (--chrome)</value></data>

--- a/TerminalHub/Resources/SharedResource.ja.resx
+++ b/TerminalHub/Resources/SharedResource.ja.resx
@@ -352,10 +352,13 @@
   <data name="SessionOptions.Claude.PermissionMode.BypassTitle" xml:space="preserve"><value>全操作を無条件で自動承認します（危険）</value></data>
   <data name="SessionOptions.Claude.PermissionMode.AutoLabel" xml:space="preserve"><value>オートモード</value></data>
   <data name="SessionOptions.Claude.PermissionMode.AutoTitle" xml:space="preserve"><value>低リスク操作を自動承認し、高リスク操作のみ確認を求めます</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoAllowBypassLabel" xml:space="preserve"><value>Auto+Bypass可</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.AutoAllowBypassTitle" xml:space="preserve"><value>オートモードで起動し、Shift+Tab でバイパスに切り替えられるようにします</value></data>
   <data name="SessionOptions.Claude.PermissionMode.DefaultLabel" xml:space="preserve"><value>デフォルト</value></data>
   <data name="SessionOptions.Claude.PermissionMode.DefaultTitle" xml:space="preserve"><value>全ての操作で都度確認を求めます</value></data>
   <data name="SessionOptions.Claude.PermissionMode.HelpBypass" xml:space="preserve"><value>全操作を無条件で自動承認します（--dangerously-skip-permissions）。</value></data>
   <data name="SessionOptions.Claude.PermissionMode.HelpAuto" xml:space="preserve"><value>低リスク操作を自動承認し、高リスク操作のみ確認を求めます（--permission-mode auto）。</value></data>
+  <data name="SessionOptions.Claude.PermissionMode.HelpAutoAllowBypass" xml:space="preserve"><value>オートモードで起動しつつ、バイパスを切替候補に残します（--permission-mode auto --allow-dangerously-skip-permissions）。</value></data>
   <data name="SessionOptions.Claude.PermissionMode.HelpDefault" xml:space="preserve"><value>全ての操作で都度確認を求めます。</value></data>
   <data name="SessionOptions.Claude.Continue" xml:space="preserve"><value>直前のセッションに接続 (--continue)</value></data>
   <data name="SessionOptions.Claude.Chrome" xml:space="preserve"><value>ブラウザ連携 (--chrome)</value></data>


### PR DESCRIPTION
## 背景

「オートモードで起動しつつ、必要なときだけ Shift+Tab でバイパスに上げる」起動方法が選べなかった。
現状の権限モードは bypass / auto / default の排他3択で、auto を選ぶとバイパスが切替候補に出ない。

`claude --help` で裏取りしたとおり、2つのフラグは別物：

- `--dangerously-skip-permissions` … 最初からバイパス固定
- `--allow-dangerously-skip-permissions` … 「Enable bypassing all permission checks **as an option, without it being enabled by default**」＝切替候補に加えるだけ

## 変更

権限モードを以下の3択に再構成した（デフォルトは撤去）。

| ボタン | 引数 |
|---|---|
| バイパス（赤） | `--dangerously-skip-permissions` |
| オートモード（緑） | `--permission-mode auto` |
| **Auto+Bypass可（橙）** | `--permission-mode auto --allow-dangerously-skip-permissions` |

### `--permission-mode auto` を明示している理由

公式ドキュメント（Choose a permission mode / Which mode a session starts in）によると、Pro・Max・Team プランのターミナルでは組み込みの開始モードが auto（Claude Code v2.1.228 以降、ネイティブ Windows は v2.1.233 以降）。ただし次のケースは今も `default` 起動のため、配布物として環境に依存させないよう明示を残した。

- Enterprise プラン / Claude Console API キー
- `claude -p` / Agent SDK
- Bedrock・Vertex・Foundry 経由
- feature-flag 取得が無効
- インストール／アップグレード直後の初回セッション

### 「デフォルト」の扱い

選択肢からは外したが、既に `permission-mode=default` で保存済みのセッションを設定ダイアログで開いたときだけボタンを表示する（選択状態が空になるのを防ぐため）。生成される引数は従来どおり無し。新規セッションには出ない。

## テスト

- `ClaudeArgumentsTests` に `AutoAllowBypassはオート起動とバイパス許可の両方を出す` を追加（2つのフラグの取り違えを防ぐ番人）
- `dotnet test --filter "FullyQualifiedName~ClaudeArgumentsTests"` 9件パス

## 未確認

ConPTY 経由の実起動確認は未実施（ツール経由の起動は ConPty が壊れるため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZkrJq4xjYGJgMH17qQ48b