### PR TITLE
fix: サブセッションの並び順が再起動で作成日時順に戻る問題を修正

### DIFF
--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -702,9 +702,9 @@
                             createdSession.PinPriority = sessionInfo.PinPriority;
 
                             // サブセッション管理画面で決めた並び順も復元する。
-                            // ここで漏らすと in-memory が既定の 0 に戻るだけでなく、
-                            // 直後の SaveSessionInfoAsync で DB にも 0 が書き戻され、
-                            // 「再起動したら並び順が作成日時順に戻る」になる。
+                            // ここで漏らすと in-memory が既定の 0 に戻り、
+                            // その後の Git 状態更新や hook を契機としたストレージ保存で
+                            // DB にも 0 が書き戻される（保存済みの並び順ごと失われる）。
                             createdSession.SortOrder = sessionInfo.SortOrder;
 
                             // セッション専用コマンドを復元。

--- a/TerminalHub/Components/Pages/Root.razor
+++ b/TerminalHub/Components/Pages/Root.razor
@@ -701,6 +701,12 @@
                             createdSession.IsPinned = sessionInfo.IsPinned;
                             createdSession.PinPriority = sessionInfo.PinPriority;
 
+                            // サブセッション管理画面で決めた並び順も復元する。
+                            // ここで漏らすと in-memory が既定の 0 に戻るだけでなく、
+                            // 直後の SaveSessionInfoAsync で DB にも 0 が書き戻され、
+                            // 「再起動したら並び順が作成日時順に戻る」になる。
+                            createdSession.SortOrder = sessionInfo.SortOrder;
+
                             // セッション専用コマンドを復元。
                             // CreateSessionAsync は空の SessionCommands で新規 SessionInfo を作るため、
                             // ここでコピーし忘れると、アプリ再起動後に in-memory が空になり、


### PR DESCRIPTION
## 症状

サブセッション管理画面で並べ替えた順序が、TerminalHub を再起動すると作成日時順に戻る。

## 原因

保存タイミングの問題ではなく、**起動時の復元漏れ**。

`Root.razor` の復元ループは `CreateSessionAsync` で新しい `SessionInfo` を作り直し、
必要なフィールドを1つずつコピーする方式だが、`SortOrder` がそのコピー列から漏れていた。

そのため in-memory の値が既定の 0 に戻り、**その後の Git 状態更新や hook を契機とした
ストレージ保存で DB にも 0 が伝播する**（＝保存済みの並び順ごと失われる）。

コメントで注意喚起されている `SessionCommands` / `LinkPlugins` / `Card` とまったく同じ穴。

なお並べ替え時の保存（`UpdateSortOrdersAsync`）自体は正しく動作している。

## 修正

復元時に `SortOrder` をコピーする1行を追加（再発防止のため理由をコメントに残した）。

## 注意

既存 DB の並び順は上記の書き戻しで既に消えている可能性が高いため、
この修正を適用したあと**もう一度並べ替え直す**必要がある。

## 確認

- `dotnet build` 成功（0 警告 / 0 エラー）
- `dotnet test` 283 件合格
- Codex レビュー実施。指摘は P3 のコメント文言のみで、修正コード自体は妥当と確認済み
  （代入位置は保存処理より前、アーカイブ経路と他ブラウザ再接続経路は漏れなし、
  他に同種の復元漏れプロパティは見つからず、採番とトランザクション運用も問題なし）
- 実起動での動作確認はユーザー側にお願いします（ConPTY のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZkrJq4xjYGJgMH17qQ48b